### PR TITLE
Add missing view source files (extensions_tab, source_browse_tab)

### DIFF
--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -1,0 +1,51 @@
+/**
+ * VitaSuwayomi - Extensions Tab
+ * Manage Suwayomi extensions (install, update, uninstall)
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include "app/suwayomi_client.hpp"
+
+namespace vitasuwayomi {
+
+class ExtensionsTab : public brls::Box {
+public:
+    ExtensionsTab();
+
+    void onFocusGained() override;
+
+private:
+    enum class ViewMode {
+        INSTALLED,
+        AVAILABLE,
+        UPDATES
+    };
+
+    void loadExtensions();
+    void showInstalled();
+    void showAvailable();
+    void showUpdates();
+    void updateButtonStyles();
+    void populateList(const std::vector<Extension>& extensions);
+    brls::Box* createExtensionItem(const Extension& ext);
+    void installExtension(const Extension& ext);
+    void updateExtension(const Extension& ext);
+    void uninstallExtension(const Extension& ext);
+    void showError(const std::string& message);
+
+    brls::Label* m_titleLabel = nullptr;
+    brls::Button* m_installedBtn = nullptr;
+    brls::Button* m_availableBtn = nullptr;
+    brls::Button* m_updatesBtn = nullptr;
+    brls::Box* m_listBox = nullptr;
+
+    ViewMode m_currentView = ViewMode::INSTALLED;
+    std::vector<Extension> m_extensions;
+    std::vector<Extension> m_installed;
+    std::vector<Extension> m_available;
+    std::vector<Extension> m_updates;
+};
+
+} // namespace vitasuwayomi

--- a/include/view/source_browse_tab.hpp
+++ b/include/view/source_browse_tab.hpp
@@ -1,0 +1,53 @@
+/**
+ * VitaSuwayomi - Source Browse Tab
+ * Browse manga from a specific source (popular, latest, search)
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include "app/suwayomi_client.hpp"
+#include "view/recycling_grid.hpp"
+
+namespace vitasuwayomi {
+
+class SourceBrowseTab : public brls::Box {
+public:
+    SourceBrowseTab(const Source& source);
+
+    void onFocusGained() override;
+
+private:
+    enum class BrowseMode {
+        POPULAR,
+        LATEST,
+        SEARCH
+    };
+
+    void loadPopular();
+    void loadLatest();
+    void loadSearch(const std::string& query);
+    void loadNextPage();
+    void loadManga();
+    void updateGrid();
+    void updateModeButtons();
+    void updateLoadMoreButton();
+    void showSearchDialog();
+    void onMangaSelected(const Manga& manga);
+
+    Source m_source;
+    BrowseMode m_browseMode = BrowseMode::POPULAR;
+    std::string m_searchQuery;
+    int m_currentPage = 1;
+    bool m_hasNextPage = false;
+    std::vector<Manga> m_mangaList;
+
+    brls::Label* m_titleLabel = nullptr;
+    brls::Button* m_popularBtn = nullptr;
+    brls::Button* m_latestBtn = nullptr;
+    brls::Button* m_searchBtn = nullptr;
+    brls::Button* m_loadMoreBtn = nullptr;
+    RecyclingGrid* m_contentGrid = nullptr;
+};
+
+} // namespace vitasuwayomi

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1,0 +1,292 @@
+/**
+ * VitaSuwayomi - Extensions Tab
+ * Manage Suwayomi extensions (install, update, uninstall)
+ */
+
+#include "view/extensions_tab.hpp"
+#include "app/suwayomi_client.hpp"
+#include "utils/image_loader.hpp"
+
+#include <borealis.hpp>
+
+namespace vitasuwayomi {
+
+ExtensionsTab::ExtensionsTab() {
+    // Load from XML
+    this->inflateFromXMLRes("xml/tabs/extensions.xml");
+
+    // Get references to UI elements
+    m_titleLabel = dynamic_cast<brls::Label*>(this->getView("extensions/title"));
+    m_installedBtn = dynamic_cast<brls::Button*>(this->getView("extensions/installed_btn"));
+    m_availableBtn = dynamic_cast<brls::Button*>(this->getView("extensions/available_btn"));
+    m_updatesBtn = dynamic_cast<brls::Button*>(this->getView("extensions/updates_btn"));
+    m_listBox = dynamic_cast<brls::Box*>(this->getView("extensions/list"));
+
+    // Set up button handlers
+    if (m_installedBtn) {
+        m_installedBtn->registerClickAction([this](brls::View*) {
+            showInstalled();
+            return true;
+        });
+    }
+
+    if (m_availableBtn) {
+        m_availableBtn->registerClickAction([this](brls::View*) {
+            showAvailable();
+            return true;
+        });
+    }
+
+    if (m_updatesBtn) {
+        m_updatesBtn->registerClickAction([this](brls::View*) {
+            showUpdates();
+            return true;
+        });
+    }
+
+    // Load extensions list
+    loadExtensions();
+}
+
+void ExtensionsTab::onFocusGained() {
+    brls::Box::onFocusGained();
+}
+
+void ExtensionsTab::loadExtensions() {
+    brls::Logger::debug("Loading extensions list...");
+
+    brls::async([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Extension> extensions;
+
+        if (client.fetchExtensionList(extensions)) {
+            m_extensions = extensions;
+
+            // Categorize extensions
+            m_installed.clear();
+            m_available.clear();
+            m_updates.clear();
+
+            for (const auto& ext : m_extensions) {
+                if (ext.installed) {
+                    m_installed.push_back(ext);
+                    if (ext.hasUpdate) {
+                        m_updates.push_back(ext);
+                    }
+                } else {
+                    m_available.push_back(ext);
+                }
+            }
+
+            brls::sync([this]() {
+                showInstalled();
+            });
+        } else {
+            brls::sync([this]() {
+                showError("Failed to load extensions");
+            });
+        }
+    });
+}
+
+void ExtensionsTab::showInstalled() {
+    m_currentView = ViewMode::INSTALLED;
+    updateButtonStyles();
+    populateList(m_installed);
+}
+
+void ExtensionsTab::showAvailable() {
+    m_currentView = ViewMode::AVAILABLE;
+    updateButtonStyles();
+    populateList(m_available);
+}
+
+void ExtensionsTab::showUpdates() {
+    m_currentView = ViewMode::UPDATES;
+    updateButtonStyles();
+    populateList(m_updates);
+}
+
+void ExtensionsTab::updateButtonStyles() {
+    // Update button styles based on current view
+    if (m_installedBtn) {
+        m_installedBtn->setStyle(m_currentView == ViewMode::INSTALLED ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+    if (m_availableBtn) {
+        m_availableBtn->setStyle(m_currentView == ViewMode::AVAILABLE ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+    if (m_updatesBtn) {
+        m_updatesBtn->setStyle(m_currentView == ViewMode::UPDATES ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+}
+
+void ExtensionsTab::populateList(const std::vector<Extension>& extensions) {
+    if (!m_listBox) return;
+
+    m_listBox->clearViews();
+
+    if (extensions.empty()) {
+        auto* emptyLabel = new brls::Label();
+        emptyLabel->setText("No extensions found");
+        emptyLabel->setFontSize(16);
+        emptyLabel->setMargins(20, 20, 20, 20);
+        m_listBox->addView(emptyLabel);
+        return;
+    }
+
+    for (const auto& ext : extensions) {
+        auto* item = createExtensionItem(ext);
+        if (item) {
+            m_listBox->addView(item);
+        }
+    }
+}
+
+brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
+    auto* container = new brls::Box();
+    container->setAxis(brls::Axis::ROW);
+    container->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    container->setAlignItems(brls::AlignItems::CENTER);
+    container->setPadding(10, 15, 10, 15);
+    container->setMarginBottom(5);
+    container->setFocusable(true);
+
+    // Left side: icon and info
+    auto* leftBox = new brls::Box();
+    leftBox->setAxis(brls::Axis::ROW);
+    leftBox->setAlignItems(brls::AlignItems::CENTER);
+    leftBox->setGrow(1.0f);
+
+    // Extension icon
+    auto* icon = new brls::Image();
+    icon->setSize(brls::Size(40, 40));
+    icon->setMarginRight(15);
+    if (!ext.iconUrl.empty()) {
+        vitaabs::ImageLoader::loadAsync(ext.iconUrl, [icon](const std::string& path) {
+            brls::sync([icon, path]() {
+                icon->setImageFromFile(path);
+            });
+        });
+    }
+    leftBox->addView(icon);
+
+    // Extension info
+    auto* infoBox = new brls::Box();
+    infoBox->setAxis(brls::Axis::COLUMN);
+
+    auto* nameLabel = new brls::Label();
+    nameLabel->setText(ext.name);
+    nameLabel->setFontSize(14);
+    infoBox->addView(nameLabel);
+
+    auto* detailLabel = new brls::Label();
+    detailLabel->setText(ext.lang + " • v" + ext.versionName);
+    detailLabel->setFontSize(11);
+    detailLabel->setTextColor(nvgRGB(160, 160, 160));
+    infoBox->addView(detailLabel);
+
+    leftBox->addView(infoBox);
+    container->addView(leftBox);
+
+    // Right side: action button
+    auto* actionBtn = new brls::Button();
+    actionBtn->setStyle(brls::ButtonStyle::BORDERED);
+
+    if (ext.installed) {
+        if (ext.hasUpdate) {
+            actionBtn->addView(new brls::Label("Update"));
+            actionBtn->registerClickAction([this, ext](brls::View*) {
+                updateExtension(ext);
+                return true;
+            });
+        } else {
+            actionBtn->addView(new brls::Label("Uninstall"));
+            actionBtn->registerClickAction([this, ext](brls::View*) {
+                uninstallExtension(ext);
+                return true;
+            });
+        }
+    } else {
+        actionBtn->addView(new brls::Label("Install"));
+        actionBtn->registerClickAction([this, ext](brls::View*) {
+            installExtension(ext);
+            return true;
+        });
+    }
+
+    container->addView(actionBtn);
+
+    return container;
+}
+
+void ExtensionsTab::installExtension(const Extension& ext) {
+    brls::Logger::info("Installing extension: {}", ext.name);
+
+    brls::async([this, ext]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        bool success = client.installExtension(ext.pkgName);
+
+        brls::sync([this, success, ext]() {
+            if (success) {
+                brls::Application::notify("Installed: " + ext.name);
+                loadExtensions();
+            } else {
+                brls::Application::notify("Failed to install: " + ext.name);
+            }
+        });
+    });
+}
+
+void ExtensionsTab::updateExtension(const Extension& ext) {
+    brls::Logger::info("Updating extension: {}", ext.name);
+
+    brls::async([this, ext]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        bool success = client.updateExtension(ext.pkgName);
+
+        brls::sync([this, success, ext]() {
+            if (success) {
+                brls::Application::notify("Updated: " + ext.name);
+                loadExtensions();
+            } else {
+                brls::Application::notify("Failed to update: " + ext.name);
+            }
+        });
+    });
+}
+
+void ExtensionsTab::uninstallExtension(const Extension& ext) {
+    brls::Logger::info("Uninstalling extension: {}", ext.name);
+
+    brls::async([this, ext]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        bool success = client.uninstallExtension(ext.pkgName);
+
+        brls::sync([this, success, ext]() {
+            if (success) {
+                brls::Application::notify("Uninstalled: " + ext.name);
+                loadExtensions();
+            } else {
+                brls::Application::notify("Failed to uninstall: " + ext.name);
+            }
+        });
+    });
+}
+
+void ExtensionsTab::showError(const std::string& message) {
+    if (!m_listBox) return;
+
+    m_listBox->clearViews();
+
+    auto* errorLabel = new brls::Label();
+    errorLabel->setText(message);
+    errorLabel->setFontSize(16);
+    errorLabel->setTextColor(nvgRGB(255, 100, 100));
+    errorLabel->setMargins(20, 20, 20, 20);
+    m_listBox->addView(errorLabel);
+}
+
+} // namespace vitasuwayomi

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -1,0 +1,215 @@
+/**
+ * VitaSuwayomi - Source Browse Tab
+ * Browse manga from a specific source
+ */
+
+#include "view/source_browse_tab.hpp"
+#include "app/suwayomi_client.hpp"
+#include "view/media_item_cell.hpp"
+#include "utils/image_loader.hpp"
+
+#include <borealis.hpp>
+
+namespace vitasuwayomi {
+
+SourceBrowseTab::SourceBrowseTab(const Source& source)
+    : m_source(source)
+    , m_currentPage(1)
+    , m_hasNextPage(false)
+    , m_browseMode(BrowseMode::POPULAR) {
+
+    this->setAxis(brls::Axis::COLUMN);
+    this->setPadding(20, 30, 20, 30);
+
+    // Title
+    m_titleLabel = new brls::Label();
+    m_titleLabel->setText(source.name);
+    m_titleLabel->setFontSize(24);
+    m_titleLabel->setMarginBottom(15);
+    this->addView(m_titleLabel);
+
+    // Mode buttons
+    auto* modeBox = new brls::Box();
+    modeBox->setAxis(brls::Axis::ROW);
+    modeBox->setMarginBottom(15);
+
+    m_popularBtn = new brls::Button();
+    m_popularBtn->setStyle(brls::ButtonStyle::PRIMARY);
+    m_popularBtn->addView(new brls::Label("Popular"));
+    m_popularBtn->setMarginRight(10);
+    m_popularBtn->registerClickAction([this](brls::View*) {
+        loadPopular();
+        return true;
+    });
+    modeBox->addView(m_popularBtn);
+
+    if (source.supportsLatest) {
+        m_latestBtn = new brls::Button();
+        m_latestBtn->setStyle(brls::ButtonStyle::BORDERED);
+        m_latestBtn->addView(new brls::Label("Latest"));
+        m_latestBtn->setMarginRight(10);
+        m_latestBtn->registerClickAction([this](brls::View*) {
+            loadLatest();
+            return true;
+        });
+        modeBox->addView(m_latestBtn);
+    }
+
+    m_searchBtn = new brls::Button();
+    m_searchBtn->setStyle(brls::ButtonStyle::BORDERED);
+    m_searchBtn->addView(new brls::Label("Search"));
+    m_searchBtn->registerClickAction([this](brls::View*) {
+        showSearchDialog();
+        return true;
+    });
+    modeBox->addView(m_searchBtn);
+
+    this->addView(modeBox);
+
+    // Content grid
+    m_contentGrid = new RecyclingGrid();
+    m_contentGrid->setGrow(1.0f);
+    this->addView(m_contentGrid);
+
+    // Load more button (hidden initially)
+    m_loadMoreBtn = new brls::Button();
+    m_loadMoreBtn->setStyle(brls::ButtonStyle::BORDERED);
+    m_loadMoreBtn->addView(new brls::Label("Load More"));
+    m_loadMoreBtn->setMarginTop(15);
+    m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
+    m_loadMoreBtn->registerClickAction([this](brls::View*) {
+        loadNextPage();
+        return true;
+    });
+    this->addView(m_loadMoreBtn);
+
+    // Initial load
+    loadPopular();
+}
+
+void SourceBrowseTab::onFocusGained() {
+    brls::Box::onFocusGained();
+}
+
+void SourceBrowseTab::loadPopular() {
+    m_browseMode = BrowseMode::POPULAR;
+    m_currentPage = 1;
+    m_mangaList.clear();
+    updateModeButtons();
+    loadManga();
+}
+
+void SourceBrowseTab::loadLatest() {
+    m_browseMode = BrowseMode::LATEST;
+    m_currentPage = 1;
+    m_mangaList.clear();
+    updateModeButtons();
+    loadManga();
+}
+
+void SourceBrowseTab::loadSearch(const std::string& query) {
+    m_browseMode = BrowseMode::SEARCH;
+    m_searchQuery = query;
+    m_currentPage = 1;
+    m_mangaList.clear();
+    updateModeButtons();
+    loadManga();
+}
+
+void SourceBrowseTab::loadNextPage() {
+    if (!m_hasNextPage) return;
+    m_currentPage++;
+    loadManga();
+}
+
+void SourceBrowseTab::loadManga() {
+    brls::Logger::debug("Loading manga from source {} (page {})", m_source.name, m_currentPage);
+
+    brls::async([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Manga> newManga;
+        bool hasNext = false;
+        bool success = false;
+
+        switch (m_browseMode) {
+            case BrowseMode::POPULAR:
+                success = client.fetchPopularManga(m_source.id, m_currentPage, newManga, hasNext);
+                break;
+            case BrowseMode::LATEST:
+                success = client.fetchLatestManga(m_source.id, m_currentPage, newManga, hasNext);
+                break;
+            case BrowseMode::SEARCH:
+                success = client.searchManga(m_source.id, m_searchQuery, m_currentPage, newManga, hasNext);
+                break;
+        }
+
+        brls::sync([this, success, newManga, hasNext]() {
+            if (success) {
+                // Append new manga to list
+                for (const auto& manga : newManga) {
+                    m_mangaList.push_back(manga);
+                }
+                m_hasNextPage = hasNext;
+                updateGrid();
+                updateLoadMoreButton();
+            } else {
+                brls::Application::notify("Failed to load manga");
+            }
+        });
+    });
+}
+
+void SourceBrowseTab::updateGrid() {
+    if (!m_contentGrid) return;
+
+    m_contentGrid->clearViews();
+
+    for (const auto& manga : m_mangaList) {
+        auto* cell = new MangaItemCell();
+        cell->setManga(manga);
+        cell->registerClickAction([this, manga](brls::View*) {
+            onMangaSelected(manga);
+            return true;
+        });
+        m_contentGrid->addView(cell);
+    }
+}
+
+void SourceBrowseTab::updateModeButtons() {
+    if (m_popularBtn) {
+        m_popularBtn->setStyle(m_browseMode == BrowseMode::POPULAR ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+    if (m_latestBtn) {
+        m_latestBtn->setStyle(m_browseMode == BrowseMode::LATEST ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+    if (m_searchBtn) {
+        m_searchBtn->setStyle(m_browseMode == BrowseMode::SEARCH ?
+            brls::ButtonStyle::PRIMARY : brls::ButtonStyle::BORDERED);
+    }
+}
+
+void SourceBrowseTab::updateLoadMoreButton() {
+    if (m_loadMoreBtn) {
+        m_loadMoreBtn->setVisibility(m_hasNextPage ?
+            brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+}
+
+void SourceBrowseTab::showSearchDialog() {
+    brls::Swkbd::openForText([this](std::string query) {
+        if (!query.empty()) {
+            loadSearch(query);
+        }
+    }, "Search manga...", "", 100, "", 0, "Search", "");
+}
+
+void SourceBrowseTab::onMangaSelected(const Manga& manga) {
+    brls::Logger::info("Selected manga: {} (id: {})", manga.title, manga.id);
+
+    // Push manga detail view
+    // TODO: Implement navigation to MangaDetailView
+}
+
+} // namespace vitasuwayomi


### PR DESCRIPTION
Add missing view source files (extensions_tab, source_browse_tab)

Created the source files that were referenced in CMakeLists.txt:
- src/view/extensions_tab.cpp - Extension management UI
- include/view/extensions_tab.hpp - Extension tab header
- src/view/source_browse_tab.cpp - Source browsing UI
- include/view/source_browse_tab.hpp - Source browse header

These files implement:
- Extension listing (installed, available, updates)
- Extension install/update/uninstall actions
- Source browsing (popular, latest, search)
- Manga grid display from sources

---
_Generated by [Claude Code](https://claude.ai/code)_