### PR TITLE
Remove all Audiobookshelf-specific code and rewrite for Suwayomi

### DIFF
--- a/include/view/manga_detail_view.hpp
+++ b/include/view/manga_detail_view.hpp
@@ -1,0 +1,10 @@
+/**
+ * VitaSuwayomi - Manga Detail View
+ * Forward to media_detail_view.hpp for backward compatibility
+ */
+
+#pragma once
+
+#include "view/media_detail_view.hpp"
+
+// MangaDetailView is defined in media_detail_view.hpp

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -1,0 +1,10 @@
+/**
+ * VitaSuwayomi - Manga Item Cell
+ * Forward to media_item_cell.hpp for backward compatibility
+ */
+
+#pragma once
+
+#include "view/media_item_cell.hpp"
+
+// MangaItemCell is defined in media_item_cell.hpp

--- a/include/view/settings_tab.hpp
+++ b/include/view/settings_tab.hpp
@@ -1,6 +1,6 @@
 /**
  * VitaSuwayomi - Settings Tab
- * Application settings and server info
+ * Application settings for manga reader
  */
 
 #pragma once
@@ -14,31 +14,20 @@ public:
     SettingsTab();
 
 private:
-    void createServerSection();
+    void createAccountSection();
     void createUISection();
     void createReaderSection();
-    void createLibrarySection();
     void createDownloadsSection();
-    void createExtensionsSection();
-    void createTrackingSection();
     void createAboutSection();
-    void createDebugSection();
 
     void onDisconnect();
     void onThemeChanged(int index);
-    void onReadingModeChanged(int index);
-    void onPageScaleModeChanged(int index);
-    void onTriggerLibraryUpdate();
-    void onManageCategories();
-    void onManageExtensions();
 
     brls::ScrollingFrame* m_scrollView = nullptr;
     brls::Box* m_contentBox = nullptr;
 
-    // Server section
-    brls::Label* m_serverUrlLabel = nullptr;
-    brls::Label* m_serverVersionLabel = nullptr;
-    brls::DetailCell* m_disconnectCell = nullptr;
+    // Account/Server section
+    brls::Label* m_serverLabel = nullptr;
 
     // UI section
     brls::SelectorCell* m_themeSelector = nullptr;
@@ -47,37 +36,12 @@ private:
     brls::BooleanCell* m_debugLogToggle = nullptr;
 
     // Reader section
-    brls::SelectorCell* m_readingModeSelector = nullptr;  // LTR, RTL, Vertical, Webtoon
-    brls::SelectorCell* m_pageScaleSelector = nullptr;    // Fit, Width, Height, Original
-    brls::BooleanCell* m_keepScreenOnToggle = nullptr;
-    brls::BooleanCell* m_showPageNumberToggle = nullptr;
-    brls::BooleanCell* m_tapToNavigateToggle = nullptr;
-    brls::SelectorCell* m_backgroundColorSelector = nullptr;  // Black, White, Gray
-
-    // Library section
-    brls::DetailCell* m_updateLibraryCell = nullptr;
-    brls::DetailCell* m_manageCategoriesCell = nullptr;
-    brls::BooleanCell* m_updateOnStartToggle = nullptr;
-    brls::BooleanCell* m_updateOnlyWifiToggle = nullptr;
-    brls::SelectorCell* m_defaultCategorySelector = nullptr;
+    brls::SelectorCell* m_readingModeSelector = nullptr;
+    brls::SelectorCell* m_pageScaleModeSelector = nullptr;
+    brls::SelectorCell* m_readerBgSelector = nullptr;
 
     // Downloads section
-    brls::BooleanCell* m_downloadToServerToggle = nullptr;  // Download to server vs local
-    brls::BooleanCell* m_autoDownloadToggle = nullptr;
-    brls::BooleanCell* m_wifiOnlyDownloadToggle = nullptr;
-    brls::SelectorCell* m_concurrentDownloadsSelector = nullptr;
-    brls::BooleanCell* m_deleteAfterReadToggle = nullptr;
     brls::DetailCell* m_clearDownloadsCell = nullptr;
-    brls::Label* m_downloadStatsLabel = nullptr;
-
-    // Extensions section
-    brls::DetailCell* m_manageExtensionsCell = nullptr;
-    brls::Label* m_installedExtensionsLabel = nullptr;
-
-    // Tracking section
-    brls::DetailCell* m_myAnimeListCell = nullptr;
-    brls::DetailCell* m_aniListCell = nullptr;
-    brls::DetailCell* m_mangaUpdatesCell = nullptr;
 };
 
 } // namespace vitasuwayomi

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -1,12 +1,11 @@
 /**
  * VitaSuwayomi - Login Activity implementation
- * Handles user authentication for Audiobookshelf server
+ * Handles connection to Suwayomi server
  */
 
 #include "activity/login_activity.hpp"
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
-#include "view/progress_dialog.hpp"
 #include "utils/async.hpp"
 
 #include <memory>
@@ -30,7 +29,7 @@ void LoginActivity::onContentAvailable() {
     }
 
     if (statusLabel) {
-        statusLabel->setText("Enter your Audiobookshelf server URL and credentials");
+        statusLabel->setText("Enter your Suwayomi server URL");
     }
 
     if (pinCodeLabel) {
@@ -44,43 +43,43 @@ void LoginActivity::onContentAvailable() {
             brls::Application::getImeManager()->openForText([this](std::string text) {
                 m_serverUrl = text;
                 serverLabel->setText(std::string("Server: ") + text);
-            }, "Enter Server URL", "http://your-server:13378", 256, m_serverUrl);
+            }, "Enter Server URL", "http://your-server:4567", 256, m_serverUrl);
             return true;
         });
         serverLabel->addGestureRecognizer(new brls::TapGestureRecognizer(serverLabel));
     }
 
-    // Username input
+    // Username input (optional for Suwayomi basic auth)
     if (usernameLabel) {
-        usernameLabel->setText(std::string("Username: ") + (m_username.empty() ? "Not set" : m_username));
+        usernameLabel->setText("Username: (optional)");
         usernameLabel->registerClickAction([this](brls::View* view) {
             brls::Application::getImeManager()->openForText([this](std::string text) {
                 m_username = text;
-                usernameLabel->setText(std::string("Username: ") + text);
-            }, "Enter Username", "", 128, m_username);
+                usernameLabel->setText(std::string("Username: ") + (text.empty() ? "(optional)" : text));
+            }, "Enter Username (optional)", "", 128, m_username);
             return true;
         });
         usernameLabel->addGestureRecognizer(new brls::TapGestureRecognizer(usernameLabel));
     }
 
-    // Password input
+    // Password input (optional for Suwayomi basic auth)
     if (passwordLabel) {
-        passwordLabel->setText(std::string("Password: ") + (m_password.empty() ? "Not set" : "********"));
+        passwordLabel->setText("Password: (optional)");
         passwordLabel->registerClickAction([this](brls::View* view) {
             brls::Application::getImeManager()->openForPassword([this](std::string text) {
                 m_password = text;
-                passwordLabel->setText("Password: ********");
-            }, "Enter Password", "", 128, "");
+                passwordLabel->setText(std::string("Password: ") + (text.empty() ? "(optional)" : "********"));
+            }, "Enter Password (optional)", "", 128, "");
             return true;
         });
         passwordLabel->addGestureRecognizer(new brls::TapGestureRecognizer(passwordLabel));
     }
 
-    // Login button
+    // Connect button
     if (loginButton) {
-        loginButton->setText("Login");
+        loginButton->setText("Connect");
         loginButton->registerClickAction([this](brls::View* view) {
-            onLoginPressed();
+            onConnectPressed();
             return true;
         });
     }
@@ -112,13 +111,13 @@ void LoginActivity::onTestConnectionPressed() {
 
     if (statusLabel) statusLabel->setText("Testing connection...");
 
-    AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
+    SuwayomiClient& client = SuwayomiClient::getInstance();
 
     // Try to connect and fetch server info
     if (client.connectToServer(m_serverUrl)) {
         ServerInfo info;
         if (client.fetchServerInfo(info)) {
-            std::string msg = "Connected to " + info.serverName + " v" + info.version;
+            std::string msg = "Connected! Server v" + info.version;
             if (statusLabel) statusLabel->setText(msg);
         } else {
             if (statusLabel) statusLabel->setText("Server is reachable!");
@@ -128,39 +127,35 @@ void LoginActivity::onTestConnectionPressed() {
     }
 }
 
-void LoginActivity::onLoginPressed() {
+void LoginActivity::onConnectPressed() {
     if (m_serverUrl.empty()) {
         if (statusLabel) statusLabel->setText("Please enter server URL");
         return;
     }
 
-    if (m_username.empty() || m_password.empty()) {
-        if (statusLabel) statusLabel->setText("Please enter username and password");
-        return;
+    if (statusLabel) statusLabel->setText("Connecting...");
+
+    SuwayomiClient& client = SuwayomiClient::getInstance();
+
+    // Set authentication if provided
+    if (!m_username.empty() && !m_password.empty()) {
+        client.setAuthCredentials(m_username, m_password);
     }
 
-    if (statusLabel) statusLabel->setText("Logging in...");
-
-    // Perform login
-    AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-
-    // Set server URL first, then attempt login
-    client.setServerUrl(m_serverUrl);
-
-    if (client.login(m_username, m_password)) {
-        // Save credentials
-        Application::getInstance().setUsername(m_username);
+    // Try to connect
+    if (client.connectToServer(m_serverUrl)) {
+        // Save server URL
         Application::getInstance().setServerUrl(m_serverUrl);
-        Application::getInstance().setAuthToken(client.getAuthToken());
+        Application::getInstance().setConnected(true);
         Application::getInstance().saveSettings();
 
-        if (statusLabel) statusLabel->setText("Login successful!");
+        if (statusLabel) statusLabel->setText("Connected!");
 
         brls::sync([this]() {
             Application::getInstance().pushMainActivity();
         });
     } else {
-        if (statusLabel) statusLabel->setText("Login failed - check credentials");
+        if (statusLabel) statusLabel->setText("Connection failed - check URL and server");
     }
 }
 

--- a/src/activity/main_activity.cpp
+++ b/src/activity/main_activity.cpp
@@ -1,11 +1,13 @@
 /**
  * VitaSuwayomi - Main Activity implementation
+ * Main tab-based navigation for the manga reader app
  */
 
 #include "activity/main_activity.hpp"
-#include "view/home_tab.hpp"
 #include "view/library_section_tab.hpp"
-#include "view/search_tab.hpp"
+#include "view/extensions_tab.hpp"
+#include "view/source_browse_tab.hpp"
+#include "view/downloads_tab.hpp"
 #include "view/settings_tab.hpp"
 #include "app/downloads_manager.hpp"
 #include "app/application.hpp"
@@ -16,15 +18,8 @@
 
 namespace vitasuwayomi {
 
-// Cached library sections
-static std::vector<Library> s_cachedSections;
-
-// Helper to calculate text width (approximate based on character count)
-static int calculateTextWidth(const std::string& text) {
-    const int charWidth = 12;
-    const int padding = 50;
-    return static_cast<int>(text.length()) * charWidth + padding;
-}
+// Cached categories for library tabs
+static std::vector<Category> s_cachedCategories;
 
 MainActivity::MainActivity() {
     brls::Logger::debug("MainActivity created");
@@ -38,150 +33,56 @@ void MainActivity::onContentAvailable() {
     brls::Logger::debug("MainActivity content available");
 
     if (tabFrame) {
-        AppSettings& settings = Application::getInstance().getSettings();
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
+        SuwayomiClient& client = SuwayomiClient::getInstance();
 
-        // Try to fetch libraries - if this fails, we're offline
-        std::vector<Library> sections;
-        bool isOnline = client.fetchLibraries(sections);
-
-        if (!isOnline || sections.empty()) {
-            // Offline mode - show library tabs with downloaded content and Settings
-            brls::Logger::info("MainActivity: Offline mode - showing downloaded content");
-
-            // Set sidebar width for offline mode
-            brls::View* sidebar = tabFrame->getView("brls/tab_frame/sidebar");
-            if (sidebar) {
-                sidebar->setWidth(220);
-            }
-
-            // Check if we have any downloads
-            auto downloads = DownloadsManager::getInstance().getDownloads();
-
-            if (downloads.empty()) {
-                // No downloads - show offline notice
-                tabFrame->addTab("Offline", []() {
-                    auto* box = new brls::Box();
-                    box->setAxis(brls::Axis::COLUMN);
-                    box->setPadding(40);
-                    box->setJustifyContent(brls::JustifyContent::CENTER);
-                    box->setAlignItems(brls::AlignItems::CENTER);
-                    box->setGrow(1.0f);
-
-                    auto* title = new brls::Label();
-                    title->setText("No Server Connection");
-                    title->setFontSize(24);
-                    title->setMarginBottom(20);
-                    box->addView(title);
-
-                    auto* msg = new brls::Label();
-                    msg->setText("Connect to WiFi and configure your\nAudiobookshelf server in Settings.\n\nNo downloaded content available.");
-                    msg->setHorizontalAlign(brls::HorizontalAlign::CENTER);
-                    msg->setFontSize(16);
-                    box->addView(msg);
-
-                    return box;
-                });
-            } else {
-                // Have downloads - create library tabs for downloaded content
-                // Check what types of content we have downloaded
-                bool hasBooks = false;
-                bool hasPodcasts = false;
-                for (const auto& dl : downloads) {
-                    if (dl.mediaType == "book" || dl.mediaType.empty()) hasBooks = true;
-                    if (dl.mediaType == "podcast" || dl.mediaType == "episode") hasPodcasts = true;
-                }
-
-                if (hasBooks) {
-                    tabFrame->addTab("Audiobooks", []() {
-                        auto* tab = new LibrarySectionTab("offline-books", "Audiobooks (Offline)", "book");
-                        return tab;
-                    });
-                }
-
-                if (hasPodcasts) {
-                    tabFrame->addTab("Podcasts", []() {
-                        auto* tab = new LibrarySectionTab("offline-podcasts", "Podcasts (Offline)", "podcast");
-                        return tab;
-                    });
-                }
-            }
-
-            tabFrame->addTab("Settings", []() { return new SettingsTab(); });
-
-            // Focus first content tab
-            tabFrame->focusTab(0);
-            return;
-        }
-
-        // Online mode - normal flow
-        s_cachedSections = sections;
-
-        // Sync progress from server for all downloaded items
-        brls::Logger::info("MainActivity: Online - syncing progress from server for downloaded items");
-        DownloadsManager::getInstance().syncProgressFromServer();
-
-        // Calculate dynamic sidebar width based on content
-        int sidebarWidth = 200;  // Minimum width
-
-        std::vector<std::string> standardTabs = {"Home", "Search", "Downloads", "Settings"};
-        for (const auto& tab : standardTabs) {
-            sidebarWidth = std::max(sidebarWidth, calculateTextWidth(tab));
-        }
-
-        // Check library names for width
-        for (const auto& section : sections) {
-            sidebarWidth = std::max(sidebarWidth, calculateTextWidth(section.name));
-        }
-
-        // Apply sidebar width (with reasonable bounds)
-        sidebarWidth = std::min(sidebarWidth, 350);
+        // Set sidebar width
         brls::View* sidebar = tabFrame->getView("brls/tab_frame/sidebar");
         if (sidebar) {
-            sidebar->setWidth(sidebarWidth);
+            sidebar->setWidth(200);
         }
 
-        // Add Home tab first (Continue Listening + Recently Added Episodes)
-        tabFrame->addTab("Home", []() { return new HomeTab(); });
-        brls::Logger::debug("MainActivity: Added Home tab");
+        // Check connection status
+        bool isOnline = client.isConnected();
 
-        // Add library tabs directly (no Home/Library intermediate screens)
-        // Sort by type: Audiobooks first, then Podcasts
-        std::vector<Library> bookLibs, podcastLibs;
-        for (const auto& lib : sections) {
-            if (lib.mediaType == "book") {
-                bookLibs.push_back(lib);
-            } else if (lib.mediaType == "podcast") {
-                podcastLibs.push_back(lib);
-            }
-        }
+        // Add Library tab (shows manga from library)
+        tabFrame->addTab("Library", []() {
+            return new LibrarySectionTab(0, "Library");
+        });
 
-        // Add Audiobooks libraries
-        for (const auto& lib : bookLibs) {
-            std::string id = lib.id;
-            std::string name = lib.name;
-            tabFrame->addTab(name, [id, name]() {
-                return new LibrarySectionTab(id, name, "book");
+        // Add Browse tab (browse manga sources)
+        tabFrame->addTab("Browse", []() {
+            return new SourceBrowseTab();
+        });
+
+        // Add Extensions tab (manage extensions)
+        tabFrame->addTab("Extensions", []() {
+            return new ExtensionsTab();
+        });
+
+        // Add Downloads tab (manage downloads)
+        tabFrame->addTab("Downloads", []() {
+            return new DownloadsTab();
+        });
+
+        // Add Settings tab
+        tabFrame->addTab("Settings", []() {
+            return new SettingsTab();
+        });
+
+        // If online, try to load categories for additional library tabs
+        if (isOnline) {
+            asyncTask<bool>([&client]() {
+                std::vector<Category> categories;
+                return client.fetchCategories(categories);
+            }, [this](bool success) {
+                if (success && !s_cachedCategories.empty()) {
+                    // Could add category-specific tabs here if needed
+                    brls::Logger::info("MainActivity: Loaded {} categories", s_cachedCategories.size());
+                }
             });
-            brls::Logger::debug("MainActivity: Added audiobook library tab: {}", name);
         }
 
-        // Add Podcast libraries
-        for (const auto& lib : podcastLibs) {
-            std::string id = lib.id;
-            std::string name = lib.name;
-            tabFrame->addTab(name, [id, name]() {
-                return new LibrarySectionTab(id, name, "podcast");
-            });
-            brls::Logger::debug("MainActivity: Added podcast library tab: {}", name);
-        }
-
-        // Utility tabs (no separators)
-        tabFrame->addTab("Search", []() { return new SearchTab(); });
-        tabFrame->addTab("Settings", []() { return new SettingsTab(); });
-
-        // Focus first tab
-        tabFrame->focusTab(0);
+        brls::Logger::info("MainActivity: Tabs created, isOnline={}", isOnline);
     }
 }
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1,22 +1,20 @@
 /**
  * VitaSuwayomi - Library Section Tab implementation
+ * Shows manga library content organized by categories
  */
 
 #include "view/library_section_tab.hpp"
-#include "view/podcast_search_tab.hpp"
+#include "view/manga_item_cell.hpp"
+#include "view/manga_detail_view.hpp"
+#include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "app/downloads_manager.hpp"
-#include "view/media_item_cell.hpp"
-#include "view/media_detail_view.hpp"
-#include "app/application.hpp"
 #include "utils/async.hpp"
-#include <map>
-#include <tuple>
 
 namespace vitasuwayomi {
 
-LibrarySectionTab::LibrarySectionTab(const std::string& sectionKey, const std::string& title, const std::string& sectionType)
-    : m_sectionKey(sectionKey), m_title(title), m_sectionType(sectionType) {
+LibrarySectionTab::LibrarySectionTab(int categoryId, const std::string& categoryName)
+    : m_categoryId(categoryId), m_categoryName(categoryName) {
 
     // Create alive flag for async callback safety
     m_alive = std::make_shared<bool>(true);
@@ -29,43 +27,42 @@ LibrarySectionTab::LibrarySectionTab(const std::string& sectionKey, const std::s
 
     // Title
     m_titleLabel = new brls::Label();
-    m_titleLabel->setText(title);
+    m_titleLabel->setText(categoryName);
     m_titleLabel->setFontSize(28);
     m_titleLabel->setMarginBottom(15);
     this->addView(m_titleLabel);
 
-    const auto& settings = Application::getInstance().getSettings();
-
-    // View mode selector (All / Collections / Categories)
+    // View mode selector buttons
     m_viewModeBox = new brls::Box();
     m_viewModeBox->setAxis(brls::Axis::ROW);
     m_viewModeBox->setJustifyContent(brls::JustifyContent::FLEX_START);
     m_viewModeBox->setAlignItems(brls::AlignItems::CENTER);
     m_viewModeBox->setMarginBottom(15);
 
-    // All Items button
+    // All Manga button
     m_allBtn = new brls::Button();
     m_allBtn->setText("All");
     m_allBtn->setMarginRight(10);
     m_allBtn->registerClickAction([this](brls::View* view) {
-        showAllItems();
+        showAllManga();
         return true;
     });
     m_viewModeBox->addView(m_allBtn);
 
-    // Collections button (only show if collections are enabled)
-    if (settings.showCollections) {
-        m_collectionsBtn = new brls::Button();
-        m_collectionsBtn->setText("Collections");
-        m_collectionsBtn->setMarginRight(10);
-        m_collectionsBtn->registerClickAction([this](brls::View* view) {
-            showCollections();
-            return true;
-        });
-        m_viewModeBox->addView(m_collectionsBtn);
-    }
+    // Categories button
+    m_categoriesBtn = new brls::Button();
+    m_categoriesBtn->setText("Categories");
+    m_categoriesBtn->setMarginRight(10);
+    m_categoriesBtn->registerClickAction([this](brls::View* view) {
+        // Load categories if not loaded
+        if (!m_categoriesLoaded) {
+            loadCategories();
+        }
+        return true;
+    });
+    m_viewModeBox->addView(m_categoriesBtn);
 
-    // Downloaded button - always show
+    // Downloaded button
     m_downloadedBtn = new brls::Button();
     m_downloadedBtn->setText("Downloaded");
     m_downloadedBtn->setMarginRight(10);
@@ -75,61 +72,55 @@ LibrarySectionTab::LibrarySectionTab(const std::string& sectionKey, const std::s
     });
     m_viewModeBox->addView(m_downloadedBtn);
 
-    // Note: Categories/Genres button removed - Audiobookshelf doesn't have a genre browsing API
+    // Unread button
+    m_unreadBtn = new brls::Button();
+    m_unreadBtn->setText("Unread");
+    m_unreadBtn->setMarginRight(10);
+    m_unreadBtn->registerClickAction([this](brls::View* view) {
+        showUnread();
+        return true;
+    });
+    m_viewModeBox->addView(m_unreadBtn);
 
-    // Back button (hidden by default, shown in filtered view)
+    // Update Library button
+    m_updateBtn = new brls::Button();
+    m_updateBtn->setText("Update");
+    m_updateBtn->setMarginRight(10);
+    m_updateBtn->registerClickAction([this](brls::View* view) {
+        triggerLibraryUpdate();
+        return true;
+    });
+    m_viewModeBox->addView(m_updateBtn);
+
+    // Back button (hidden by default)
     m_backBtn = new brls::Button();
     m_backBtn->setText("< Back");
     m_backBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->registerClickAction([this](brls::View* view) {
-        showAllItems();
+        showAllManga();
         return true;
     });
     m_viewModeBox->addView(m_backBtn);
-
-    // Find Podcasts button (only for podcast libraries)
-    if (sectionType == "podcast") {
-        m_findPodcastsBtn = new brls::Button();
-        m_findPodcastsBtn->setText("+ Find Podcasts");
-        m_findPodcastsBtn->setMarginLeft(20);
-        m_findPodcastsBtn->registerClickAction([this](brls::View* view) {
-            openPodcastSearch();
-            return true;
-        });
-        m_viewModeBox->addView(m_findPodcastsBtn);
-
-        // Check New Episodes button
-        m_checkEpisodesBtn = new brls::Button();
-        m_checkEpisodesBtn->setText("Check Episodes");
-        m_checkEpisodesBtn->setMarginLeft(10);
-        m_checkEpisodesBtn->registerClickAction([this](brls::View* view) {
-            checkAllNewEpisodes();
-            return true;
-        });
-        m_viewModeBox->addView(m_checkEpisodesBtn);
-    }
 
     this->addView(m_viewModeBox);
 
     // Content grid
     m_contentGrid = new RecyclingGrid();
     m_contentGrid->setGrow(1.0f);
-    m_contentGrid->setOnItemSelected([this](const MediaItem& item) {
-        onItemSelected(item);
+    m_contentGrid->setOnMangaSelected([this](const Manga& manga) {
+        onMangaSelected(manga);
     });
     this->addView(m_contentGrid);
 
-    // Load content immediately
-    brls::Logger::debug("LibraryTab: Created for section {} ({}) type={}", m_sectionKey, m_title, m_sectionType);
+    brls::Logger::debug("LibrarySectionTab: Created for category {} ({})", m_categoryId, m_categoryName);
     loadContent();
 }
 
 LibrarySectionTab::~LibrarySectionTab() {
-    // Mark as no longer alive to prevent async callbacks from updating destroyed UI
     if (m_alive) {
         *m_alive = false;
     }
-    brls::Logger::debug("LibrarySectionTab: Destroyed for section {}", m_sectionKey);
+    brls::Logger::debug("LibrarySectionTab: Destroyed for category {}", m_categoryId);
 }
 
 void LibrarySectionTab::onFocusGained() {
@@ -140,502 +131,147 @@ void LibrarySectionTab::onFocusGained() {
     }
 }
 
+void LibrarySectionTab::refresh() {
+    m_loaded = false;
+    loadContent();
+}
+
 void LibrarySectionTab::loadContent() {
-    brls::Logger::debug("LibrarySectionTab::loadContent - section: {} (async)", m_sectionKey);
+    brls::Logger::debug("LibrarySectionTab::loadContent - category: {}", m_categoryId);
 
-    const auto& settings = Application::getInstance().getSettings();
-    std::string key = m_sectionKey;
-    std::weak_ptr<bool> aliveWeak = m_alive;  // Capture weak_ptr for async safety
+    std::weak_ptr<bool> aliveWeak = m_alive;
+    int categoryId = m_categoryId;
 
-    // Always load downloaded items first (for filtering and offline mode)
-    loadDownloadedItems();
+    asyncRun([this, categoryId, aliveWeak]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Manga> manga;
 
-    // If showOnlyDownloaded is enabled, just show downloaded items and hide navigation
-    if (settings.showOnlyDownloaded) {
-        brls::Logger::info("LibraryTab: Show only downloaded mode enabled");
-        m_viewMode = LibraryViewMode::DOWNLOADED;
-        m_loaded = true;
-        // Hide all navigation buttons in downloaded-only mode
-        hideNavigationButtons();
-        return;
-    }
+        bool success = false;
+        if (categoryId == 0) {
+            // Fetch all library manga
+            success = client.fetchLibraryManga(manga);
+        } else {
+            // Fetch manga for specific category
+            success = client.fetchCategoryManga(categoryId, manga);
+        }
 
-    asyncRun([this, key, aliveWeak]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> items;
+        if (success) {
+            brls::Logger::info("LibrarySectionTab: Got {} manga for category {}", manga.size(), categoryId);
 
-        if (client.fetchLibraryItems(key, items)) {
-            brls::Logger::info("LibraryTab: Got {} items for section {}", items.size(), key);
-
-            brls::sync([this, items, aliveWeak]() {
-                // Check if object is still alive before updating UI
+            brls::sync([this, manga, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) {
-                    brls::Logger::debug("LibraryTab: Tab destroyed, skipping UI update");
+                    brls::Logger::debug("LibrarySectionTab: Tab destroyed, skipping UI update");
                     return;
                 }
 
-                m_items = items;
-                // Only update grid if we're in ALL_ITEMS mode
-                if (m_viewMode == LibraryViewMode::ALL_ITEMS) {
-                    m_contentGrid->setDataSource(m_items);
+                m_mangaList = manga;
+
+                if (m_viewMode == LibraryViewMode::ALL_MANGA) {
+                    m_contentGrid->setMangaDataSource(m_mangaList);
                 }
+
                 m_loaded = true;
             });
         } else {
-            brls::Logger::error("LibraryTab: Failed to load content for section {} - showing downloaded items", key);
+            brls::Logger::error("LibrarySectionTab: Failed to load manga for category {}", categoryId);
+
             brls::sync([this, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
 
-                // Offline - show downloaded items instead and hide navigation
-                // Only add "(Offline)" if not already in title (e.g. offline-mode tabs)
-                if (m_title.find("(Offline)") == std::string::npos) {
-                    m_titleLabel->setText(m_title + " (Offline)");
-                }
-                m_viewMode = LibraryViewMode::DOWNLOADED;
-                m_contentGrid->setDataSource(m_downloadedItems);
-                hideNavigationButtons();
+                // Show offline mode with downloaded items
+                m_titleLabel->setText(m_categoryName + " (Offline)");
+                showDownloaded();
                 m_loaded = true;
             });
         }
     });
 
-    // Preload collections for quick switching
-    if (settings.showCollections) {
-        loadCollections();
-    }
-    // Note: Genre preloading removed - Audiobookshelf doesn't have a genre browsing API
+    // Preload categories
+    loadCategories();
 }
 
-void LibrarySectionTab::loadCollections() {
-    std::string key = m_sectionKey;
+void LibrarySectionTab::loadCategories() {
+    if (m_categoriesLoaded) return;
+
     std::weak_ptr<bool> aliveWeak = m_alive;
 
-    asyncRun([this, key, aliveWeak]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<Collection> collections;
+    asyncRun([this, aliveWeak]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Category> categories;
 
-        if (client.fetchLibraryCollections(key, collections)) {
-            brls::Logger::info("LibrarySectionTab: Got {} collections for section {}", collections.size(), key);
+        if (client.fetchCategories(categories)) {
+            brls::Logger::info("LibrarySectionTab: Got {} categories", categories.size());
 
-            // Convert Collection to MediaItem for display
-            std::vector<MediaItem> collectionItems;
-            for (const auto& col : collections) {
-                MediaItem item;
-                item.id = col.id;
-                item.title = col.name;
-                item.description = col.description;
-                item.coverPath = col.coverPath;
-                item.type = "collection";
-                item.mediaType = MediaType::UNKNOWN;
-                collectionItems.push_back(item);
-            }
-
-            brls::sync([this, collectionItems, aliveWeak]() {
+            brls::sync([this, categories, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
 
-                m_collections = collectionItems;
-                m_collectionsLoaded = true;
+                m_categories = categories;
+                m_categoriesLoaded = true;
 
-                // Hide collections button if none available
-                if (m_collections.empty() && m_collectionsBtn) {
-                    m_collectionsBtn->setVisibility(brls::Visibility::GONE);
+                // Hide categories button if no categories
+                if (m_categories.empty() && m_categoriesBtn) {
+                    m_categoriesBtn->setVisibility(brls::Visibility::GONE);
                 }
             });
         } else {
-            brls::Logger::debug("LibrarySectionTab: No collections for section {}", key);
+            brls::Logger::debug("LibrarySectionTab: No categories or failed to fetch");
+
             brls::sync([this, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
 
-                m_collectionsLoaded = true;
-                if (m_collectionsBtn) {
-                    m_collectionsBtn->setVisibility(brls::Visibility::GONE);
+                m_categoriesLoaded = true;
+                if (m_categoriesBtn) {
+                    m_categoriesBtn->setVisibility(brls::Visibility::GONE);
                 }
             });
         }
     });
 }
 
-void LibrarySectionTab::loadGenres() {
-    // Audiobookshelf doesn't have a dedicated genre browsing API like Plex
-    // Genre filtering would require fetching all items and extracting unique genres
-    // For now, we disable the genres feature
-    brls::Logger::debug("LibrarySectionTab: Genre browsing not supported in Audiobookshelf");
-
-    m_genresLoaded = true;
-    m_genres.clear();
-
-    if (m_categoriesBtn) {
-        m_categoriesBtn->setVisibility(brls::Visibility::GONE);
-    }
+void LibrarySectionTab::showAllManga() {
+    m_viewMode = LibraryViewMode::ALL_MANGA;
+    m_titleLabel->setText(m_categoryName);
+    m_contentGrid->setMangaDataSource(m_mangaList);
+    updateViewModeButtons();
 }
 
-void LibrarySectionTab::loadDownloadedItems() {
-    brls::Logger::debug("LibrarySectionTab::loadDownloadedItems - section: {}", m_sectionKey);
+void LibrarySectionTab::showByCategory(int categoryId) {
+    m_viewMode = LibraryViewMode::BY_CATEGORY;
+
+    // Find category name
+    std::string categoryName = "Category";
+    for (const auto& cat : m_categories) {
+        if (cat.id == categoryId) {
+            categoryName = cat.name;
+            break;
+        }
+    }
+
+    m_titleLabel->setText(m_categoryName + " - " + categoryName);
+    m_filterTitle = categoryName;
 
     std::weak_ptr<bool> aliveWeak = m_alive;
-    std::string sectionType = m_sectionType;
 
-    // Load downloaded items synchronously (they're already local)
-    DownloadsManager& mgr = DownloadsManager::getInstance();
-    mgr.init();
+    asyncRun([this, categoryId, aliveWeak]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Manga> manga;
 
-    auto downloads = mgr.getDownloads();
-    std::vector<MediaItem> downloadedItems;
+        if (client.fetchCategoryManga(categoryId, manga)) {
+            brls::Logger::info("LibrarySectionTab: Got {} manga for category {}", manga.size(), categoryId);
 
-    // For podcasts, group episodes by podcast
-    // Map: podcastId -> vector of {episodeId, episodeTitle, coverPath}
-    std::map<std::string, std::vector<std::tuple<std::string, std::string, std::string, std::string>>> podcastEpisodes;
-    // Also track podcast name for each podcastId
-    std::map<std::string, std::string> podcastNames;
-
-    for (const auto& dl : downloads) {
-        // Filter by media type to match this library's type
-        bool matchesType = false;
-        if (sectionType == "book" && (dl.mediaType == "book" || dl.mediaType.empty())) {
-            matchesType = true;
-        } else if (sectionType == "podcast" && (dl.mediaType == "podcast" || dl.mediaType == "episode")) {
-            matchesType = true;
-        }
-
-        if (matchesType && dl.state == DownloadState::COMPLETED) {
-            brls::Logger::debug("LibrarySectionTab: Downloaded item '{}' - localCoverPath='{}'",
-                               dl.title, dl.localCoverPath);
-
-            // For podcast episodes, group by podcast
-            if (sectionType == "podcast" && !dl.episodeId.empty()) {
-                // This is a podcast episode - group by podcastId
-                std::string podcastId = dl.itemId;
-                // Use parentTitle first, fall back to authorName, then "Unknown Podcast"
-                std::string podcastName = !dl.parentTitle.empty() ? dl.parentTitle :
-                                          (!dl.authorName.empty() ? dl.authorName : "Unknown Podcast");
-                podcastNames[podcastId] = podcastName;
-                // Store: episodeId, episodeTitle, coverPath, podcastName
-                podcastEpisodes[podcastId].push_back(std::make_tuple(dl.episodeId, dl.title, dl.localCoverPath, podcastName));
-            } else {
-                // Audiobook or standalone item
-                MediaItem item;
-                item.id = dl.itemId;
-                item.title = dl.title;
-                item.authorName = dl.authorName;
-                item.description = dl.description;
-                item.duration = dl.duration;
-                item.currentTime = dl.currentTime;
-                item.coverPath = dl.localCoverPath;
-                item.type = dl.mediaType;
-                item.mediaType = MediaType::BOOK;
-
-                // Mark as downloaded for UI purposes
-                item.isDownloaded = true;
-
-                downloadedItems.push_back(item);
-            }
-        }
-    }
-
-    // Convert podcast episodes to MediaItems
-    for (const auto& [podcastId, episodes] : podcastEpisodes) {
-        if (episodes.size() == 1) {
-            // Single episode - show as individual episode that plays directly
-            const auto& ep = episodes[0];
-            MediaItem item;
-            item.id = podcastId;  // Keep podcast ID for playback
-            item.podcastId = podcastId;
-            item.episodeId = std::get<0>(ep);  // Episode ID
-            item.title = std::get<1>(ep);  // Episode title
-            item.coverPath = std::get<2>(ep);  // Cover path
-            item.authorName = std::get<3>(ep);  // Podcast name as author
-            item.type = "episode";
-            item.mediaType = MediaType::PODCAST_EPISODE;
-            item.isDownloaded = true;
-
-            downloadedItems.push_back(item);
-        } else {
-            // Multiple episodes - show as grouped podcast
-            MediaItem item;
-            item.id = podcastId;
-            item.title = podcastNames[podcastId];  // Podcast name
-            item.coverPath = std::get<2>(episodes[0]);  // Cover path from first episode
-            int episodeCount = episodes.size();
-            item.authorName = std::to_string(episodeCount) + " episodes downloaded";
-            item.type = "podcast";
-            item.mediaType = MediaType::PODCAST;
-            item.isDownloaded = true;
-
-            downloadedItems.push_back(item);
-        }
-    }
-
-    brls::Logger::info("LibrarySectionTab: Found {} downloaded items for type {}", downloadedItems.size(), sectionType);
-
-    m_downloadedItems = downloadedItems;
-    m_downloadedLoaded = true;
-
-    // If in DOWNLOADED view mode, update the grid
-    if (m_viewMode == LibraryViewMode::DOWNLOADED) {
-        m_titleLabel->setText(m_title + " - Downloaded");
-        m_contentGrid->setDataSource(m_downloadedItems);
-        updateViewModeButtons();
-    }
-
-    // Hide Downloaded button if no downloads
-    if (m_downloadedBtn) {
-        if (m_downloadedItems.empty()) {
-            m_downloadedBtn->setVisibility(brls::Visibility::GONE);
-        } else {
-            m_downloadedBtn->setVisibility(brls::Visibility::VISIBLE);
-        }
-    }
-}
-
-void LibrarySectionTab::showDownloaded() {
-    if (!m_downloadedLoaded) {
-        loadDownloadedItems();
-    }
-
-    m_viewMode = LibraryViewMode::DOWNLOADED;
-    m_titleLabel->setText(m_title + " - Downloaded");
-    m_contentGrid->setDataSource(m_downloadedItems);
-    updateViewModeButtons();
-}
-
-void LibrarySectionTab::filterByDownloaded() {
-    // Filter the current items list to show only downloaded items
-    if (m_items.empty()) return;
-
-    DownloadsManager& mgr = DownloadsManager::getInstance();
-    std::vector<MediaItem> filtered;
-
-    for (const auto& item : m_items) {
-        if (mgr.isDownloaded(item.id)) {
-            filtered.push_back(item);
-        }
-    }
-
-    m_contentGrid->setDataSource(filtered);
-}
-
-void LibrarySectionTab::showAllItems() {
-    m_viewMode = LibraryViewMode::ALL_ITEMS;
-    m_titleLabel->setText(m_title);
-    m_contentGrid->setDataSource(m_items);
-    updateViewModeButtons();
-}
-
-void LibrarySectionTab::showCollections() {
-    if (!m_collectionsLoaded) {
-        brls::Application::notify("Loading collections...");
-        return;
-    }
-
-    if (m_collections.empty()) {
-        brls::Application::notify("No collections available");
-        return;
-    }
-
-    m_viewMode = LibraryViewMode::COLLECTIONS;
-    m_titleLabel->setText(m_title + " - Collections");
-
-    // Show collections in the grid
-    m_contentGrid->setDataSource(m_collections);
-    updateViewModeButtons();
-}
-
-void LibrarySectionTab::showCategories() {
-    if (!m_genresLoaded) {
-        brls::Application::notify("Loading categories...");
-        return;
-    }
-
-    if (m_genres.empty()) {
-        brls::Application::notify("No categories available");
-        return;
-    }
-
-    m_viewMode = LibraryViewMode::CATEGORIES;
-    m_titleLabel->setText(m_title + " - Categories");
-
-    // Convert genres to MediaItem format for the grid
-    std::vector<MediaItem> genreItems;
-    for (const auto& genre : m_genres) {
-        MediaItem item;
-        item.title = genre.title;
-        item.id = genre.id;  // Use genre key for filtering
-        item.type = "genre";
-        item.mediaType = MediaType::UNKNOWN;
-        genreItems.push_back(item);
-    }
-
-    m_contentGrid->setDataSource(genreItems);
-    updateViewModeButtons();
-}
-
-void LibrarySectionTab::updateViewModeButtons() {
-    // Show/hide back button
-    bool inFilteredView = (m_viewMode == LibraryViewMode::FILTERED);
-    m_backBtn->setVisibility(inFilteredView ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-
-    // Show/hide mode buttons
-    bool showModeButtons = (m_viewMode != LibraryViewMode::FILTERED);
-    if (m_allBtn) {
-        m_allBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-    if (m_collectionsBtn) {
-        m_collectionsBtn->setVisibility(showModeButtons && !m_collections.empty() ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-    if (m_categoriesBtn) {
-        m_categoriesBtn->setVisibility(showModeButtons && !m_genres.empty() ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-    if (m_downloadedBtn) {
-        m_downloadedBtn->setVisibility(showModeButtons && !m_downloadedItems.empty() ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-}
-
-void LibrarySectionTab::hideNavigationButtons() {
-    // Hide all navigation buttons for offline/downloaded-only mode
-    if (m_allBtn) {
-        m_allBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_collectionsBtn) {
-        m_collectionsBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_categoriesBtn) {
-        m_categoriesBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_downloadedBtn) {
-        m_downloadedBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_backBtn) {
-        m_backBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_findPodcastsBtn) {
-        m_findPodcastsBtn->setVisibility(brls::Visibility::GONE);
-    }
-    if (m_checkEpisodesBtn) {
-        m_checkEpisodesBtn->setVisibility(brls::Visibility::GONE);
-    }
-}
-
-void LibrarySectionTab::onItemSelected(const MediaItem& item) {
-    brls::Logger::debug("LibrarySectionTab::onItemSelected - title='{}' id='{}' type='{}' viewMode={}",
-                       item.title, item.id, item.type, static_cast<int>(m_viewMode));
-
-    // Handle selection based on current view mode
-    if (m_viewMode == LibraryViewMode::COLLECTIONS) {
-        // Selected a collection - show its contents
-        brls::Logger::debug("LibrarySectionTab: Opening collection");
-        onCollectionSelected(item);
-        return;
-    }
-
-    if (m_viewMode == LibraryViewMode::CATEGORIES) {
-        // Selected a category/genre - filter by it
-        brls::Logger::debug("LibrarySectionTab: Opening category");
-        GenreItem genre;
-        genre.title = item.title;
-        genre.id = item.id;
-        onGenreSelected(genre);
-        return;
-    }
-
-    // Normal item selection - for Audiobookshelf, most items go to detail view
-    // Podcast episodes can be played directly
-    if (item.mediaType == MediaType::PODCAST_EPISODE) {
-        brls::Logger::debug("LibrarySectionTab: Playing podcast episode");
-        Application::getInstance().pushPlayerActivity(item.podcastId, item.episodeId);
-        return;
-    }
-
-    // Show media detail view for books and other types
-    brls::Logger::info("LibrarySectionTab: Opening detail view for '{}'", item.title);
-    auto* detailView = new MediaDetailView(item);
-    brls::Logger::debug("LibrarySectionTab: MediaDetailView created, pushing activity");
-    brls::Application::pushActivity(new brls::Activity(detailView));
-    brls::Logger::debug("LibrarySectionTab: Activity pushed successfully");
-}
-
-void LibrarySectionTab::onCollectionSelected(const MediaItem& collection) {
-    brls::Logger::debug("LibrarySectionTab: Selected collection: {}", collection.title);
-
-    m_filterTitle = collection.title;
-    std::string collectionId = collection.id;
-    std::string filterTitle = m_filterTitle;
-    std::weak_ptr<bool> aliveWeak = m_alive;
-
-    asyncRun([this, collectionId, filterTitle, aliveWeak]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> items;
-
-        if (client.fetchCollectionBooks(collectionId, items)) {
-            brls::Logger::info("LibrarySectionTab: Got {} items in collection", items.size());
-
-            brls::sync([this, items, filterTitle, aliveWeak]() {
-                auto alive = aliveWeak.lock();
-                if (!alive || !*alive) {
-                    brls::Logger::debug("LibrarySectionTab: Tab no longer alive, skipping collection display");
-                    return;
-                }
-
-                brls::Logger::debug("LibrarySectionTab: Displaying {} collection items", items.size());
-                m_viewMode = LibraryViewMode::FILTERED;
-                brls::Logger::debug("LibrarySectionTab: Setting title");
-                m_titleLabel->setText(m_title + " - " + filterTitle);
-                brls::Logger::debug("LibrarySectionTab: Setting grid data source");
-                m_contentGrid->setDataSource(items);
-                brls::Logger::debug("LibrarySectionTab: Grid updated, updating buttons");
-                updateViewModeButtons();
-                brls::Logger::debug("LibrarySectionTab: Buttons updated");
-
-                // Try to give focus to the grid
-                brls::Logger::debug("LibrarySectionTab: About to request focus on grid");
-                if (m_contentGrid) {
-                    brls::Application::giveFocus(m_contentGrid);
-                }
-                brls::Logger::debug("LibrarySectionTab: Collection display complete");
-            });
-        } else {
-            brls::Logger::error("LibrarySectionTab: Failed to load collection content");
-            brls::sync([aliveWeak]() {
-                auto alive = aliveWeak.lock();
-                if (!alive || !*alive) return;
-                brls::Application::notify("Failed to load collection");
-            });
-        }
-    });
-}
-
-void LibrarySectionTab::onGenreSelected(const GenreItem& genre) {
-    brls::Logger::debug("LibraryTab: Selected genre: {} (key: {})", genre.title, genre.id);
-
-    m_filterTitle = genre.title;
-    std::string key = m_sectionKey;
-    std::string genreKey = genre.id;
-    std::string genreTitle = genre.title;
-    std::string filterTitle = m_filterTitle;
-    std::weak_ptr<bool> aliveWeak = m_alive;
-
-    asyncRun([this, key, genreKey, genreTitle, filterTitle, aliveWeak]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> items;
-
-        // Try with genre key first, fall back to title
-        if (client.fetchByGenreKey(key, genreKey, items) || client.fetchByGenre(key, genreTitle, items)) {
-            brls::Logger::info("LibraryTab: Got {} items for genre", items.size());
-
-            brls::sync([this, items, filterTitle, aliveWeak]() {
+            brls::sync([this, manga, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
 
-                m_viewMode = LibraryViewMode::FILTERED;
-                m_titleLabel->setText(m_title + " - " + filterTitle);
-                m_contentGrid->setDataSource(items);
+                m_contentGrid->setMangaDataSource(manga);
                 updateViewModeButtons();
             });
         } else {
-            brls::Logger::error("LibraryTab: Failed to load genre content");
+            brls::Logger::error("LibrarySectionTab: Failed to fetch category manga");
             brls::sync([aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
@@ -645,46 +281,151 @@ void LibrarySectionTab::onGenreSelected(const GenreItem& genre) {
     });
 }
 
-void LibrarySectionTab::openPodcastSearch() {
-    brls::Logger::debug("LibrarySectionTab: Opening podcast search for library {}", m_sectionKey);
+void LibrarySectionTab::showDownloaded() {
+    m_viewMode = LibraryViewMode::DOWNLOADED;
+    m_titleLabel->setText(m_categoryName + " - Downloaded");
 
-    auto* searchTab = new PodcastSearchTab(m_sectionKey);
-    brls::Application::pushActivity(new brls::Activity(searchTab));
-}
+    // Filter manga that have downloaded chapters
+    std::vector<Manga> downloadedManga;
+    DownloadsManager& mgr = DownloadsManager::getInstance();
 
-void LibrarySectionTab::checkAllNewEpisodes() {
-    brls::Logger::debug("LibrarySectionTab: Checking for new episodes in all podcasts");
+    for (const auto& manga : m_mangaList) {
+        if (mgr.isMangaDownloaded(manga.id)) {
+            Manga copy = manga;
+            copy.isDownloaded = true;
+            downloadedManga.push_back(copy);
+        }
+    }
 
-    brls::Application::notify("Checking for new episodes...");
-
-    std::weak_ptr<bool> aliveWeak = m_alive;
-    std::string libraryKey = m_sectionKey;
-
-    asyncRun([this, libraryKey, aliveWeak]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-
-        int totalNew = 0;
-        for (const auto& item : m_items) {
-            if (item.type == "podcast" || item.mediaType == MediaType::PODCAST) {
-                std::vector<MediaItem> newEps;
-                if (client.checkNewEpisodes(item.id, newEps)) {
-                    if (!newEps.empty()) {
-                        totalNew += newEps.size();
-                        // Auto-download new episodes
-                        client.downloadAllNewEpisodes(item.id);
-                    }
-                }
+    // Also include manga from DownloadsManager that might not be in library
+    auto downloads = mgr.getDownloads();
+    for (const auto& dl : downloads) {
+        bool found = false;
+        for (const auto& m : downloadedManga) {
+            if (m.id == dl.mangaId) {
+                found = true;
+                break;
             }
         }
+        if (!found && dl.completedChapters > 0) {
+            Manga manga;
+            manga.id = dl.mangaId;
+            manga.title = dl.title;
+            manga.author = dl.author;
+            manga.isDownloaded = true;
+            manga.downloadedCount = dl.completedChapters;
+            downloadedManga.push_back(manga);
+        }
+    }
 
-        brls::sync([totalNew, aliveWeak]() {
+    m_contentGrid->setMangaDataSource(downloadedManga);
+    updateViewModeButtons();
+}
+
+void LibrarySectionTab::showUnread() {
+    m_viewMode = LibraryViewMode::UNREAD;
+    m_titleLabel->setText(m_categoryName + " - Unread");
+
+    // Filter manga with unread chapters
+    std::vector<Manga> unreadManga;
+    for (const auto& manga : m_mangaList) {
+        if (manga.unreadCount > 0) {
+            unreadManga.push_back(manga);
+        }
+    }
+
+    // Sort by unread count descending
+    std::sort(unreadManga.begin(), unreadManga.end(),
+              [](const Manga& a, const Manga& b) {
+                  return a.unreadCount > b.unreadCount;
+              });
+
+    m_contentGrid->setMangaDataSource(unreadManga);
+    updateViewModeButtons();
+}
+
+void LibrarySectionTab::showReading() {
+    m_viewMode = LibraryViewMode::READING;
+    m_titleLabel->setText(m_categoryName + " - Reading");
+
+    // Filter manga that are being read (have progress but not completed)
+    std::vector<Manga> readingManga;
+    for (const auto& manga : m_mangaList) {
+        if (manga.lastChapterRead > 0 && manga.unreadCount > 0) {
+            readingManga.push_back(manga);
+        }
+    }
+
+    // Sort by last chapter read descending
+    std::sort(readingManga.begin(), readingManga.end(),
+              [](const Manga& a, const Manga& b) {
+                  return a.lastChapterRead > b.lastChapterRead;
+              });
+
+    m_contentGrid->setMangaDataSource(readingManga);
+    updateViewModeButtons();
+}
+
+void LibrarySectionTab::onMangaSelected(const Manga& manga) {
+    brls::Logger::debug("LibrarySectionTab: Selected manga '{}' id={}", manga.title, manga.id);
+
+    // Push manga detail view
+    auto* detailView = new MangaDetailView(manga);
+    brls::Application::pushActivity(new brls::Activity(detailView));
+}
+
+void LibrarySectionTab::onCategorySelected(const Category& category) {
+    brls::Logger::debug("LibrarySectionTab: Selected category '{}' id={}", category.name, category.id);
+    showByCategory(category.id);
+}
+
+void LibrarySectionTab::updateViewModeButtons() {
+    bool inFilteredView = (m_viewMode != LibraryViewMode::ALL_MANGA);
+    m_backBtn->setVisibility(inFilteredView ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+
+    // Show/hide mode buttons based on view
+    bool showModeButtons = !inFilteredView;
+    if (m_allBtn) {
+        m_allBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+    if (m_categoriesBtn && !m_categories.empty()) {
+        m_categoriesBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+    if (m_downloadedBtn) {
+        m_downloadedBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+    if (m_unreadBtn) {
+        m_unreadBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+    if (m_updateBtn) {
+        m_updateBtn->setVisibility(showModeButtons ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+}
+
+void LibrarySectionTab::triggerLibraryUpdate() {
+    brls::Logger::info("LibrarySectionTab: Triggering library update");
+    brls::Application::notify("Updating library...");
+
+    std::weak_ptr<bool> aliveWeak = m_alive;
+
+    asyncRun([this, aliveWeak]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        bool success = false;
+        if (m_categoryId == 0) {
+            success = client.triggerLibraryUpdate();
+        } else {
+            success = client.triggerLibraryUpdate(m_categoryId);
+        }
+
+        brls::sync([success, aliveWeak]() {
             auto alive = aliveWeak.lock();
             if (!alive || !*alive) return;
 
-            if (totalNew > 0) {
-                brls::Application::notify("Found " + std::to_string(totalNew) + " new episode(s)");
+            if (success) {
+                brls::Application::notify("Library update started");
             } else {
-                brls::Application::notify("No new episodes found");
+                brls::Application::notify("Failed to start library update");
             }
         });
     });

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1,41 +1,27 @@
 /**
- * VitaSuwayomi - Media Detail View implementation
+ * VitaSuwayomi - Manga Detail View implementation
+ * Shows detailed information about a manga including chapters list
  */
 
 #include "view/media_detail_view.hpp"
 #include "app/suwayomi_client.hpp"
-#include "view/media_item_cell.hpp"
-#include "view/progress_dialog.hpp"
 #include "app/application.hpp"
 #include "app/downloads_manager.hpp"
-#include "app/temp_file_manager.hpp"
 #include "utils/image_loader.hpp"
-#include "utils/http_client.hpp"
-#include "utils/audio_utils.hpp"
 #include "utils/async.hpp"
-#include <thread>
-#include <algorithm>
-#include <fstream>
-
-#ifdef __vita__
-#include <psp2/kernel/threadmgr.h>
-#include <psp2/io/fcntl.h>
-#include <psp2/io/stat.h>
-#endif
 
 namespace vitasuwayomi {
 
-MediaDetailView::MediaDetailView(const MediaItem& item)
-    : m_item(item) {
-    brls::Logger::info("MediaDetailView: Creating for '{}' id='{}' type='{}'",
-                       item.title, item.id, item.type);
+MangaDetailView::MangaDetailView(const Manga& manga)
+    : m_manga(manga) {
+    brls::Logger::info("MangaDetailView: Creating for '{}' id={}", manga.title, manga.id);
 
     this->setAxis(brls::Axis::COLUMN);
     this->setJustifyContent(brls::JustifyContent::FLEX_START);
     this->setAlignItems(brls::AlignItems::STRETCH);
     this->setGrow(1.0f);
 
-    // Register back button (B/Circle) to pop this activity
+    // Register back button
     this->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View* view) {
         brls::Application::popActivity();
         return true;
@@ -49,136 +35,76 @@ MediaDetailView::MediaDetailView(const MediaItem& item)
     m_mainContent->setAxis(brls::Axis::COLUMN);
     m_mainContent->setPadding(30);
 
-    // Top row - poster and info
+    // Top row - cover and info
     auto* topRow = new brls::Box();
     topRow->setAxis(brls::Axis::ROW);
     topRow->setJustifyContent(brls::JustifyContent::FLEX_START);
     topRow->setAlignItems(brls::AlignItems::FLEX_START);
     topRow->setMarginBottom(20);
 
-    // Left side - poster (square for book/podcast covers)
+    // Left side - cover image
     auto* leftBox = new brls::Box();
     leftBox->setAxis(brls::Axis::COLUMN);
-    leftBox->setWidth(460);
+    leftBox->setWidth(200);
     leftBox->setMarginRight(20);
 
-    m_posterImage = new brls::Image();
-    m_posterImage->setWidth(200);
-    m_posterImage->setHeight(200);  // Square cover
-    m_posterImage->setScalingType(brls::ImageScalingType::FIT);
-    leftBox->addView(m_posterImage);
+    m_coverImage = new brls::Image();
+    m_coverImage->setWidth(180);
+    m_coverImage->setHeight(260);
+    m_coverImage->setScalingType(brls::ImageScalingType::FIT);
+    leftBox->addView(m_coverImage);
 
-    // Play button - for books and podcast episodes
-    if (m_item.mediaType == MediaType::BOOK || m_item.mediaType == MediaType::PODCAST_EPISODE) {
-        // Horizontal button row for all buttons
-        auto* buttonRow = new brls::Box();
-        buttonRow->setAxis(brls::Axis::ROW);
-        buttonRow->setMarginTop(20);
-        buttonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
+    // Action buttons
+    auto* buttonRow = new brls::Box();
+    buttonRow->setAxis(brls::Axis::ROW);
+    buttonRow->setMarginTop(15);
+    buttonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
 
-        m_playButton = new brls::Button();
-        m_playButton->setText("Play");
-        m_playButton->setWidth(90);
-        m_playButton->setHeight(40);
-        m_playButton->setMarginRight(10);
-        m_playButton->registerClickAction([this](brls::View* view) {
-            onPlay(true);  // Always auto-resume from last position
-            return true;
-        });
-        buttonRow->addView(m_playButton);
+    m_readButton = new brls::Button();
+    m_readButton->setText("Read");
+    m_readButton->setWidth(80);
+    m_readButton->setHeight(40);
+    m_readButton->setMarginRight(10);
+    m_readButton->registerClickAction([this](brls::View* view) {
+        onRead();
+        return true;
+    });
+    buttonRow->addView(m_readButton);
 
-        // Download/Delete button for directly playable content
-        AppSettings& settings = Application::getInstance().getSettings();
-        bool isDownloaded = DownloadsManager::getInstance().isDownloaded(m_item.id);
-
-        if (!settings.saveToDownloads && !isDownloaded) {
-            // Show Download button only if not already downloaded and not auto-saving
-            m_downloadButton = new brls::Button();
-            m_downloadButton->setText("Download");
-            m_downloadButton->setWidth(115);
-            m_downloadButton->setHeight(40);
-            m_downloadButton->setMarginRight(10);
-            m_downloadButton->registerClickAction([this](brls::View* view) {
-                onDownload();
-                return true;
-            });
-            buttonRow->addView(m_downloadButton);
+    m_libraryButton = new brls::Button();
+    m_libraryButton->setText(m_manga.inLibrary ? "Remove" : "Add");
+    m_libraryButton->setWidth(80);
+    m_libraryButton->setHeight(40);
+    m_libraryButton->setMarginRight(10);
+    m_libraryButton->registerClickAction([this](brls::View* view) {
+        if (m_manga.inLibrary) {
+            onRemoveFromLibrary();
+        } else {
+            onAddToLibrary();
         }
+        return true;
+    });
+    buttonRow->addView(m_libraryButton);
 
-        if (isDownloaded) {
-            // Show Delete button for downloaded items
-            m_deleteButton = new brls::Button();
-            m_deleteButton->setText("Delete");
-            m_deleteButton->setWidth(100);
-            m_deleteButton->setHeight(40);
-            m_deleteButton->registerClickAction([this](brls::View* view) {
-                onDeleteDownload();
-                return true;
-            });
-            buttonRow->addView(m_deleteButton);
-        }
+    leftBox->addView(buttonRow);
 
-        leftBox->addView(buttonRow);
-    }
+    // Download button row
+    auto* dlButtonRow = new brls::Box();
+    dlButtonRow->setAxis(brls::Axis::ROW);
+    dlButtonRow->setMarginTop(10);
+    dlButtonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
 
-    // For podcasts, show download options
-    if (m_item.mediaType == MediaType::PODCAST) {
-        // Horizontal button row for all podcast buttons
-        auto* podcastButtonRow = new brls::Box();
-        podcastButtonRow->setAxis(brls::Axis::ROW);
-        podcastButtonRow->setMarginTop(20);
-        podcastButtonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
+    m_downloadButton = new brls::Button();
+    m_downloadButton->setText("Download");
+    m_downloadButton->setWidth(100);
+    m_downloadButton->setHeight(40);
+    m_downloadButton->registerClickAction([this](brls::View* view) {
+        showDownloadOptions();
+        return true;
+    });
+    dlButtonRow->addView(m_downloadButton);
 
-        m_playButton = new brls::Button();
-        m_playButton->setText("Play");
-        m_playButton->setWidth(90);
-        m_playButton->setHeight(40);
-        m_playButton->setMarginRight(10);
-        m_playButton->registerClickAction([this](brls::View* view) {
-            onPlay(false);
-            return true;
-        });
-        podcastButtonRow->addView(m_playButton);
-
-        // Find New Episodes button - check RSS for new episodes
-        m_findEpisodesButton = new brls::Button();
-        m_findEpisodesButton->setText("Find New");
-        m_findEpisodesButton->setWidth(110);
-        m_findEpisodesButton->setHeight(40);
-        m_findEpisodesButton->setMarginRight(10);
-        m_findEpisodesButton->registerClickAction([this](brls::View* view) {
-            findNewEpisodes();
-            return true;
-        });
-        podcastButtonRow->addView(m_findEpisodesButton);
-
-        // Download button for podcasts - always show (will be hidden if all episodes are downloaded in loadChildren)
-        m_downloadButton = new brls::Button();
-        m_downloadButton->setText("Download");
-        m_downloadButton->setWidth(130);
-        m_downloadButton->setHeight(40);
-        m_downloadButton->setMarginRight(10);
-        m_downloadButton->registerClickAction([this](brls::View* view) {
-            showDownloadOptions();
-            return true;
-        });
-        podcastButtonRow->addView(m_downloadButton);
-
-        // Delete button for downloaded episodes - initially hidden, shown if any episodes downloaded
-        m_deleteButton = new brls::Button();
-        m_deleteButton->setText("Remove");
-        m_deleteButton->setWidth(130);
-        m_deleteButton->setHeight(40);
-        m_deleteButton->setVisibility(brls::Visibility::GONE);  // Hidden until we check downloads
-        m_deleteButton->registerClickAction([this](brls::View* view) {
-            deleteAllDownloadedEpisodes();
-            return true;
-        });
-        podcastButtonRow->addView(m_deleteButton);
-
-        leftBox->addView(podcastButtonRow);
-    }
-
+    leftBox->addView(dlButtonRow);
     topRow->addView(leftBox);
 
     // Right side - details
@@ -188,100 +114,130 @@ MediaDetailView::MediaDetailView(const MediaItem& item)
 
     // Title
     m_titleLabel = new brls::Label();
-    m_titleLabel->setText(m_item.title);
+    m_titleLabel->setText(m_manga.title);
     m_titleLabel->setFontSize(26);
     m_titleLabel->setMarginBottom(10);
     rightBox->addView(m_titleLabel);
 
-    // Author/Series info
-    if (!m_item.authorName.empty()) {
-        auto* authorLabel = new brls::Label();
-        authorLabel->setText("By: " + m_item.authorName);
-        authorLabel->setFontSize(18);
-        authorLabel->setMarginBottom(10);
-        rightBox->addView(authorLabel);
+    // Author
+    if (!m_manga.author.empty()) {
+        m_authorLabel = new brls::Label();
+        m_authorLabel->setText("Author: " + m_manga.author);
+        m_authorLabel->setFontSize(18);
+        m_authorLabel->setMarginBottom(5);
+        rightBox->addView(m_authorLabel);
     }
 
-    // Metadata row
-    auto* metaBox = new brls::Box();
-    metaBox->setAxis(brls::Axis::ROW);
-    metaBox->setMarginBottom(15);
-
-    if (!m_item.publishedYear.empty()) {
-        m_yearLabel = new brls::Label();
-        m_yearLabel->setText(m_item.publishedYear);
-        m_yearLabel->setFontSize(16);
-        m_yearLabel->setMarginRight(15);
-        metaBox->addView(m_yearLabel);
+    // Artist
+    if (!m_manga.artist.empty() && m_manga.artist != m_manga.author) {
+        m_artistLabel = new brls::Label();
+        m_artistLabel->setText("Artist: " + m_manga.artist);
+        m_artistLabel->setFontSize(18);
+        m_artistLabel->setMarginBottom(5);
+        rightBox->addView(m_artistLabel);
     }
 
-    if (m_item.duration > 0) {
-        m_durationLabel = new brls::Label();
-        int hours = (int)(m_item.duration / 3600.0f);
-        int mins = (int)((m_item.duration - hours * 3600) / 60.0f);
-        if (hours > 0) {
-            m_durationLabel->setText(std::to_string(hours) + "h " + std::to_string(mins) + "m");
-        } else {
-            m_durationLabel->setText(std::to_string(mins) + " min");
+    // Status
+    m_statusLabel = new brls::Label();
+    m_statusLabel->setText("Status: " + m_manga.getStatusString());
+    m_statusLabel->setFontSize(16);
+    m_statusLabel->setMarginBottom(5);
+    rightBox->addView(m_statusLabel);
+
+    // Source
+    if (!m_manga.sourceName.empty()) {
+        m_sourceLabel = new brls::Label();
+        m_sourceLabel->setText("Source: " + m_manga.sourceName);
+        m_sourceLabel->setFontSize(16);
+        m_sourceLabel->setMarginBottom(10);
+        rightBox->addView(m_sourceLabel);
+    }
+
+    // Chapter count and unread
+    m_chapterCountLabel = new brls::Label();
+    std::string chapterInfo = std::to_string(m_manga.chapterCount) + " chapters";
+    if (m_manga.unreadCount > 0) {
+        chapterInfo += " (" + std::to_string(m_manga.unreadCount) + " unread)";
+    }
+    m_chapterCountLabel->setText(chapterInfo);
+    m_chapterCountLabel->setFontSize(16);
+    m_chapterCountLabel->setMarginBottom(10);
+    rightBox->addView(m_chapterCountLabel);
+
+    // Genre tags
+    if (!m_manga.genre.empty()) {
+        m_genreBox = new brls::Box();
+        m_genreBox->setAxis(brls::Axis::ROW);
+        m_genreBox->setMarginBottom(10);
+
+        for (size_t i = 0; i < m_manga.genre.size() && i < 5; i++) {
+            auto* genreLabel = new brls::Label();
+            genreLabel->setText(m_manga.genre[i]);
+            genreLabel->setFontSize(14);
+            genreLabel->setMarginRight(10);
+            m_genreBox->addView(genreLabel);
         }
-        m_durationLabel->setFontSize(16);
-        metaBox->addView(m_durationLabel);
+        rightBox->addView(m_genreBox);
     }
 
-    rightBox->addView(metaBox);
-
-    // Summary/Description
-    if (!m_item.description.empty()) {
-        m_summaryLabel = new brls::Label();
-        m_summaryLabel->setText(m_item.description);
-        m_summaryLabel->setFontSize(16);
-        m_summaryLabel->setMarginBottom(20);
-        rightBox->addView(m_summaryLabel);
+    // Description
+    if (!m_manga.description.empty()) {
+        m_descriptionLabel = new brls::Label();
+        // Truncate long descriptions
+        std::string desc = m_manga.description;
+        if (desc.length() > 500) {
+            desc = desc.substr(0, 497) + "...";
+        }
+        m_descriptionLabel->setText(desc);
+        m_descriptionLabel->setFontSize(14);
+        m_descriptionLabel->setMarginTop(10);
+        rightBox->addView(m_descriptionLabel);
     }
 
     topRow->addView(rightBox);
     m_mainContent->addView(topRow);
 
-    // Episodes container for podcasts
-    if (m_item.mediaType == MediaType::PODCAST) {
-        auto* episodesLabel = new brls::Label();
-        episodesLabel->setText("Episodes");
-        episodesLabel->setFontSize(20);
-        episodesLabel->setMarginBottom(10);
-        m_mainContent->addView(episodesLabel);
+    // Chapters section header
+    auto* chaptersHeaderRow = new brls::Box();
+    chaptersHeaderRow->setAxis(brls::Axis::ROW);
+    chaptersHeaderRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    chaptersHeaderRow->setAlignItems(brls::AlignItems::CENTER);
+    chaptersHeaderRow->setMarginBottom(10);
 
-        auto* episodesScroll = new brls::HScrollingFrame();
-        episodesScroll->setHeight(180);
-        episodesScroll->setMarginBottom(20);
+    m_chaptersLabel = new brls::Label();
+    m_chaptersLabel->setText("Chapters");
+    m_chaptersLabel->setFontSize(20);
+    chaptersHeaderRow->addView(m_chaptersLabel);
 
-        m_childrenBox = new brls::Box();
-        m_childrenBox->setAxis(brls::Axis::ROW);
-        m_childrenBox->setJustifyContent(brls::JustifyContent::FLEX_START);
+    // Sort/filter buttons
+    auto* chapterActionsBox = new brls::Box();
+    chapterActionsBox->setAxis(brls::Axis::ROW);
 
-        episodesScroll->setContentView(m_childrenBox);
-        m_mainContent->addView(episodesScroll);
-    }
+    m_sortBtn = new brls::Button();
+    m_sortBtn->setText("Sort");
+    m_sortBtn->setWidth(60);
+    m_sortBtn->setHeight(30);
+    m_sortBtn->setMarginRight(10);
+    m_sortBtn->registerClickAction([this](brls::View* view) {
+        m_sortDescending = !m_sortDescending;
+        populateChaptersList();
+        return true;
+    });
+    chapterActionsBox->addView(m_sortBtn);
 
-    // Chapters container for books
-    if (m_item.mediaType == MediaType::BOOK) {
-        auto* chaptersLabel = new brls::Label();
-        chaptersLabel->setText("Chapters");
-        chaptersLabel->setFontSize(20);
-        chaptersLabel->setMarginBottom(10);
-        chaptersLabel->setMarginTop(10);
-        m_mainContent->addView(chaptersLabel);
+    chaptersHeaderRow->addView(chapterActionsBox);
+    m_mainContent->addView(chaptersHeaderRow);
 
-        // Scrollable chapters list
-        m_chaptersScroll = new brls::ScrollingFrame();
-        m_chaptersScroll->setHeight(250);
-        m_chaptersScroll->setMarginBottom(20);
+    // Chapters list
+    m_chaptersScroll = new brls::ScrollingFrame();
+    m_chaptersScroll->setHeight(300);
+    m_chaptersScroll->setMarginBottom(20);
 
-        m_chaptersBox = new brls::Box();
-        m_chaptersBox->setAxis(brls::Axis::COLUMN);
+    m_chaptersBox = new brls::Box();
+    m_chaptersBox->setAxis(brls::Axis::COLUMN);
 
-        m_chaptersScroll->setContentView(m_chaptersBox);
-        m_mainContent->addView(m_chaptersScroll);
-    }
+    m_chaptersScroll->setContentView(m_chaptersBox);
+    m_mainContent->addView(m_chaptersScroll);
 
     m_scrollView->setContentView(m_mainContent);
     this->addView(m_scrollView);
@@ -290,2243 +246,453 @@ MediaDetailView::MediaDetailView(const MediaItem& item)
     loadDetails();
 }
 
-brls::HScrollingFrame* MediaDetailView::createMediaRow(const std::string& title, brls::Box** contentOut) {
-    auto* label = new brls::Label();
-    label->setText(title);
-    label->setFontSize(20);
-    label->setMarginBottom(10);
-    label->setMarginTop(15);
-    if (m_musicCategoriesBox) {
-        m_musicCategoriesBox->addView(label);
-    }
-
-    auto* scrollFrame = new brls::HScrollingFrame();
-    scrollFrame->setHeight(150);
-    scrollFrame->setMarginBottom(10);
-
-    auto* content = new brls::Box();
-    content->setAxis(brls::Axis::ROW);
-    content->setJustifyContent(brls::JustifyContent::FLEX_START);
-
-    scrollFrame->setContentView(content);
-    if (m_musicCategoriesBox) {
-        m_musicCategoriesBox->addView(scrollFrame);
-    }
-
-    if (contentOut) {
-        *contentOut = content;
-    }
-
-    return scrollFrame;
+brls::View* MangaDetailView::create() {
+    return nullptr;
 }
 
-brls::View* MediaDetailView::create() {
-    return nullptr; // Factory not used
+void MangaDetailView::refresh() {
+    loadDetails();
 }
 
-void MediaDetailView::loadDetails() {
-    AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
+void MangaDetailView::loadDetails() {
+    brls::Logger::debug("MangaDetailView: Loading details for manga {}", m_manga.id);
 
-    // Load full details
-    MediaItem fullItem;
-    bool loadedFromServer = client.fetchItem(m_item.id, fullItem);
+    // Load cover
+    loadCover();
 
-    if (loadedFromServer) {
-        m_item = fullItem;
+    // Load chapters
+    loadChapters();
+}
 
-        // Update UI with full details
-        if (m_titleLabel && !m_item.title.empty()) {
-            m_titleLabel->setText(m_item.title);
-        }
+void MangaDetailView::loadCover() {
+    if (!m_coverImage) return;
 
-        if (m_summaryLabel && !m_item.description.empty()) {
-            m_summaryLabel->setText(m_item.description);
-        }
+    SuwayomiClient& client = SuwayomiClient::getInstance();
+    std::string coverUrl = client.getMangaThumbnailUrl(m_manga.id);
 
-        // Update download button state
-        if (m_downloadButton && !m_item.audioTracks.empty()) {
-            if (DownloadsManager::getInstance().isDownloaded(m_item.id)) {
-                m_downloadButton->setText("Downloaded");
-            } else {
-                m_downloadButton->setText("Download");
-            }
-        }
+    if (!coverUrl.empty()) {
+        ImageLoader::loadAsync(coverUrl, [this](brls::Image* image) {
+            brls::Logger::debug("MangaDetailView: Cover loaded");
+        }, m_coverImage);
+    }
+}
 
-        // Create chapters container if it wasn't created in constructor
-        // (happens when mediaType wasn't known from library listing)
-        if (m_item.mediaType == MediaType::BOOK && !m_chaptersBox && m_mainContent) {
-            brls::Logger::debug("Creating chapters container after loading full item details");
+void MangaDetailView::loadChapters() {
+    brls::Logger::debug("MangaDetailView: Loading chapters for manga {}", m_manga.id);
 
-            auto* chaptersLabel = new brls::Label();
-            chaptersLabel->setText("Chapters");
-            chaptersLabel->setFontSize(20);
-            chaptersLabel->setMarginBottom(10);
-            chaptersLabel->setMarginTop(10);
-            m_mainContent->addView(chaptersLabel);
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Chapter> chapters;
 
-            m_chaptersScroll = new brls::ScrollingFrame();
-            m_chaptersScroll->setHeight(250);
-            m_chaptersScroll->setMarginBottom(20);
+        if (client.fetchChapters(m_manga.id, chapters)) {
+            brls::Logger::info("MangaDetailView: Got {} chapters", chapters.size());
 
-            m_chaptersBox = new brls::Box();
-            m_chaptersBox->setAxis(brls::Axis::COLUMN);
+            brls::sync([this, chapters]() {
+                m_chapters = chapters;
+                populateChaptersList();
 
-            m_chaptersScroll->setContentView(m_chaptersBox);
-            m_mainContent->addView(m_chaptersScroll);
-        }
-    } else {
-        // Server fetch failed - try to load metadata from DownloadsManager (offline mode)
-        brls::Logger::info("MediaDetailView: Server fetch failed, loading metadata from downloads");
-        DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-        auto allDownloads = downloadsMgr.getDownloads();
-
-        // Find matching download (for audiobooks, match itemId; for podcast episodes, we check later)
-        for (const auto& dl : allDownloads) {
-            if (dl.itemId == m_item.id && dl.state == DownloadState::COMPLETED) {
-                // For podcasts, we want the first episode's parent info or any episode
-                // For audiobooks, this matches directly
-                brls::Logger::info("MediaDetailView: Found offline metadata for {}", dl.title);
-
-                // Update title if not already set from m_item
-                if (m_titleLabel && !dl.title.empty() && m_item.title.empty()) {
-                    m_titleLabel->setText(dl.title);
-                    m_item.title = dl.title;
-                }
-
-                // Update author
-                if (!dl.authorName.empty() && m_item.authorName.empty()) {
-                    m_item.authorName = dl.authorName;
-                }
-
-                // Update description
-                if (m_summaryLabel && !dl.description.empty()) {
-                    m_summaryLabel->setText(dl.description);
-                    m_item.description = dl.description;
-                }
-
-                // Load chapters for audiobooks
-                if (!dl.chapters.empty() && m_item.chapters.empty()) {
-                    for (const auto& ch : dl.chapters) {
-                        Chapter ci;
-                        ci.title = ch.title;
-                        ci.start = ch.start;
-                        ci.end = ch.end;
-                        m_item.chapters.push_back(ci);
+                // Update chapter count label
+                if (m_chapterCountLabel) {
+                    std::string info = std::to_string(m_chapters.size()) + " chapters";
+                    int unread = 0;
+                    for (const auto& ch : m_chapters) {
+                        if (!ch.read) unread++;
                     }
-                    brls::Logger::info("MediaDetailView: Loaded {} chapters from offline data", m_item.chapters.size());
+                    if (unread > 0) {
+                        info += " (" + std::to_string(unread) + " unread)";
+                    }
+                    m_chapterCountLabel->setText(info);
                 }
-
-                // For audiobooks, we only need one match
-                if (dl.episodeId.empty()) {
-                    break;
-                }
-            }
-        }
-
-        // Create chapters container for audiobooks if we have chapters
-        if (m_item.mediaType == MediaType::BOOK && !m_chaptersBox && m_mainContent && !m_item.chapters.empty()) {
-            brls::Logger::debug("Creating chapters container for offline audiobook");
-
-            auto* chaptersLabel = new brls::Label();
-            chaptersLabel->setText("Chapters");
-            chaptersLabel->setFontSize(20);
-            chaptersLabel->setMarginBottom(10);
-            chaptersLabel->setMarginTop(10);
-            m_mainContent->addView(chaptersLabel);
-
-            m_chaptersScroll = new brls::ScrollingFrame();
-            m_chaptersScroll->setHeight(250);
-            m_chaptersScroll->setMarginBottom(20);
-
-            m_chaptersBox = new brls::Box();
-            m_chaptersBox->setAxis(brls::Axis::COLUMN);
-
-            m_chaptersScroll->setContentView(m_chaptersBox);
-            m_mainContent->addView(m_chaptersScroll);
-        }
-    }
-
-    // Load thumbnail - try local cover first if offline or for downloaded content
-    if (m_posterImage && !m_item.id.empty()) {
-        // Check if we have a local cover from downloads
-        DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-        std::string localCoverPath = downloadsMgr.getLocalCoverPath(m_item.id);
-
-        if (!localCoverPath.empty()) {
-            // Load local cover
-            brls::Logger::info("MediaDetailView: Loading local cover: {}", localCoverPath);
-            loadLocalCover(localCoverPath);
-        } else if (loadedFromServer) {
-            // Fetch from server
-            std::string url = client.getCoverUrl(m_item.id, 400, 400);
-            ImageLoader::loadAsync(url, [this](brls::Image* image) {
-                // Image loaded
-            }, m_posterImage);
-        }
-        // If offline and no local cover, leave poster empty
-    }
-
-    // Load children (podcast episodes)
-    if (m_item.mediaType == MediaType::PODCAST) {
-        loadChildren();
-    }
-
-    // Populate chapters for audiobooks
-    if (m_item.mediaType == MediaType::BOOK) {
-        brls::Logger::debug("Populating chapters for book: {} chapters available", m_item.chapters.size());
-        populateChapters();
-    }
-}
-
-void MediaDetailView::loadChildren() {
-    if (!m_childrenBox) return;
-
-    AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-
-    bool loadedFromServer = client.fetchPodcastEpisodes(m_item.id, m_children);
-
-    // If server fetch failed, try to load downloaded episodes from DownloadsManager
-    if (!loadedFromServer) {
-        brls::Logger::info("MediaDetailView: Server fetch failed, loading downloaded episodes");
-        DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-        auto allDownloads = downloadsMgr.getDownloads();
-
-        m_children.clear();
-        for (const auto& dl : allDownloads) {
-            if (dl.itemId == m_item.id && dl.state == DownloadState::COMPLETED && !dl.episodeId.empty()) {
-                // Create a MediaItem from the download info
-                MediaItem episode;
-                episode.id = dl.episodeId;
-                episode.podcastId = dl.itemId;
-                episode.episodeId = dl.episodeId;
-                episode.title = dl.title;
-                episode.authorName = dl.authorName;
-                episode.duration = dl.duration;
-                episode.mediaType = MediaType::PODCAST_EPISODE;
-                episode.isDownloaded = true;
-                // Use local cover path if available
-                if (!dl.localCoverPath.empty()) {
-                    episode.coverPath = dl.localCoverPath;
-                } else {
-                    episode.coverPath = dl.coverUrl;
-                }
-                m_children.push_back(episode);
-                brls::Logger::debug("MediaDetailView: Added downloaded episode: {}", dl.title);
-            }
-        }
-
-        if (!m_children.empty()) {
-            brls::Logger::info("MediaDetailView: Found {} downloaded episodes for podcast", m_children.size());
-        }
-    }
-
-    if (!m_children.empty()) {
-        m_childrenBox->clearViews();
-
-        for (const auto& child : m_children) {
-            auto* cell = new MediaItemCell();
-            cell->setItem(child);
-            cell->setWidth(120);
-            cell->setHeight(150);
-            cell->setMarginRight(10);
-
-            cell->registerClickAction([this, child](brls::View* view) {
-                // Navigate to episode detail or play directly
-                if (child.mediaType == MediaType::PODCAST_EPISODE) {
-                    // Download then play
-                    startDownloadAndPlay(child.podcastId, child.episodeId);
-                } else {
-                    auto* detailView = new MediaDetailView(child);
-                    brls::Application::pushActivity(new brls::Activity(detailView));
-                }
-                return true;
             });
-
-            m_childrenBox->addView(cell);
+        } else {
+            brls::Logger::error("MangaDetailView: Failed to fetch chapters");
         }
-
-        // Update podcast download/delete button visibility now that we know the episodes
-        if (m_item.mediaType == MediaType::PODCAST) {
-            bool allDownloaded = areAllEpisodesDownloaded();
-            bool anyDownloaded = hasAnyDownloadedEpisodes();
-
-            // Hide download button if all episodes are downloaded
-            if (m_downloadButton) {
-                if (allDownloaded) {
-                    m_downloadButton->setVisibility(brls::Visibility::GONE);
-                } else {
-                    m_downloadButton->setVisibility(brls::Visibility::VISIBLE);
-                }
-            }
-
-            // Show delete button only if any episodes are downloaded
-            if (m_deleteButton) {
-                if (anyDownloaded) {
-                    m_deleteButton->setVisibility(brls::Visibility::VISIBLE);
-                } else {
-                    m_deleteButton->setVisibility(brls::Visibility::GONE);
-                }
-            }
-        }
-    }
+    });
 }
 
-void MediaDetailView::loadMusicCategories() {
-    // Not used for Audiobookshelf
-}
-
-void MediaDetailView::loadLocalCover(const std::string& localPath) {
-    if (localPath.empty() || !m_posterImage) return;
-
-#ifdef __vita__
-    SceUID fd = sceIoOpen(localPath.c_str(), SCE_O_RDONLY, 0);
-    if (fd >= 0) {
-        SceOff size = sceIoLseek(fd, 0, SCE_SEEK_END);
-        sceIoLseek(fd, 0, SCE_SEEK_SET);
-
-        if (size > 0 && size < 10 * 1024 * 1024) {  // Max 10MB
-            std::vector<uint8_t> data(size);
-            if (sceIoRead(fd, data.data(), size) == size) {
-                m_posterImage->setImageFromMem(data.data(), data.size());
-                brls::Logger::debug("MediaDetailView: Local cover loaded ({} bytes)", size);
-            }
-        }
-        sceIoClose(fd);
-    } else {
-        brls::Logger::warning("MediaDetailView: Failed to open local cover: {}", localPath);
-    }
-#else
-    // Non-Vita: use standard file I/O
-    std::ifstream file(localPath, std::ios::binary | std::ios::ate);
-    if (file.is_open()) {
-        std::streamsize size = file.tellg();
-        file.seekg(0, std::ios::beg);
-
-        if (size > 0 && size < 10 * 1024 * 1024) {
-            std::vector<uint8_t> data(size);
-            if (file.read(reinterpret_cast<char*>(data.data()), size)) {
-                m_posterImage->setImageFromMem(data.data(), data.size());
-                brls::Logger::debug("MediaDetailView: Local cover loaded ({} bytes)", size);
-            }
-        }
-        file.close();
-    }
-#endif
-}
-
-void MediaDetailView::populateChapters() {
+void MangaDetailView::populateChaptersList() {
     if (!m_chaptersBox) return;
 
     m_chaptersBox->clearViews();
 
-    // Check if we have chapters
-    if (m_item.chapters.empty()) {
-        // Show message if no chapters
-        auto* noChaptersLabel = new brls::Label();
-        noChaptersLabel->setText("No chapter information available");
-        noChaptersLabel->setFontSize(14);
-        noChaptersLabel->setTextColor(nvgRGB(150, 150, 150));
-        noChaptersLabel->setMarginTop(10);
-        m_chaptersBox->addView(noChaptersLabel);
-        return;
+    // Sort chapters
+    std::vector<Chapter> sortedChapters = m_chapters;
+    if (m_sortDescending) {
+        std::sort(sortedChapters.begin(), sortedChapters.end(),
+                  [](const Chapter& a, const Chapter& b) {
+                      return a.chapterNumber > b.chapterNumber;
+                  });
+    } else {
+        std::sort(sortedChapters.begin(), sortedChapters.end(),
+                  [](const Chapter& a, const Chapter& b) {
+                      return a.chapterNumber < b.chapterNumber;
+                  });
     }
 
-    // Helper to format time
-    auto formatTime = [](float seconds) -> std::string {
-        int totalSec = static_cast<int>(seconds);
-        int hours = totalSec / 3600;
-        int mins = (totalSec % 3600) / 60;
-        int secs = totalSec % 60;
+    // Apply filters
+    for (const auto& chapter : sortedChapters) {
+        if (m_filterDownloaded && !chapter.downloaded) continue;
+        if (m_filterUnread && chapter.read) continue;
 
-        char buf[32];
-        if (hours > 0) {
-            snprintf(buf, sizeof(buf), "%d:%02d:%02d", hours, mins, secs);
-        } else {
-            snprintf(buf, sizeof(buf), "%d:%02d", mins, secs);
-        }
-        return std::string(buf);
-    };
+        auto* chapterCell = new brls::DetailCell();
 
-    // Current playback position for highlighting
-    float currentTime = m_item.currentTime;
-
-    for (size_t i = 0; i < m_item.chapters.size(); ++i) {
-        const auto& chapter = m_item.chapters[i];
-
-        auto* chapterRow = new brls::Box();
-        chapterRow->setAxis(brls::Axis::ROW);
-        chapterRow->setAlignItems(brls::AlignItems::CENTER);
-        chapterRow->setHeight(50);
-        chapterRow->setMarginBottom(8);
-        chapterRow->setPadding(12);
-        chapterRow->setCornerRadius(6);
-        chapterRow->setFocusable(true);
-
-        // Highlight current chapter
-        bool isCurrentChapter = (currentTime >= chapter.start && currentTime < chapter.end);
-        if (isCurrentChapter) {
-            chapterRow->setBackgroundColor(nvgRGBA(80, 120, 80, 255));
-        } else {
-            chapterRow->setBackgroundColor(nvgRGBA(50, 50, 50, 255));
-        }
-
-        // Chapter number
-        auto* numLabel = new brls::Label();
-        numLabel->setText(std::to_string(i + 1));
-        numLabel->setFontSize(14);
-        numLabel->setWidth(35);
-        numLabel->setTextColor(nvgRGB(150, 150, 150));
-        chapterRow->addView(numLabel);
-
-        // Chapter title
-        auto* titleLabel = new brls::Label();
-        std::string title = chapter.title;
+        std::string title = chapter.name;
         if (title.empty()) {
-            title = "Chapter " + std::to_string(i + 1);
+            title = "Chapter " + std::to_string(static_cast<int>(chapter.chapterNumber));
         }
-        // Truncate if too long
-        if (title.length() > 45) {
-            title = title.substr(0, 42) + "...";
+
+        // Add read indicator
+        if (chapter.read) {
+            title = "[Read] " + title;
         }
-        titleLabel->setText(title);
-        titleLabel->setFontSize(15);
-        titleLabel->setGrow(1.0f);
-        chapterRow->addView(titleLabel);
 
-        // Duration/time
-        auto* timeLabel = new brls::Label();
-        float duration = chapter.end - chapter.start;
-        timeLabel->setText(formatTime(chapter.start) + " (" + formatTime(duration) + ")");
-        timeLabel->setFontSize(13);
-        timeLabel->setTextColor(nvgRGB(150, 150, 150));
-        chapterRow->addView(timeLabel);
+        // Add download indicator
+        if (chapter.downloaded) {
+            title = title + " [DL]";
+        }
 
-        // Click to play from chapter
-        std::string itemId = m_item.id;
-        float chapterStart = chapter.start;
-        chapterRow->registerClickAction([this, itemId, chapterStart](brls::View*) {
-            // Start playback from this chapter's start time (with download)
-            startDownloadAndPlay(itemId, "", chapterStart);
+        chapterCell->setText(title);
+
+        // Show scanlator as detail if available
+        if (!chapter.scanlator.empty()) {
+            chapterCell->setDetailText(chapter.scanlator);
+        }
+
+        Chapter capturedChapter = chapter;
+        chapterCell->registerClickAction([this, capturedChapter](brls::View* view) {
+            onChapterSelected(capturedChapter);
             return true;
         });
 
-        m_chaptersBox->addView(chapterRow);
+        m_chaptersBox->addView(chapterCell);
     }
+
+    brls::Logger::debug("MangaDetailView: Populated {} chapters", sortedChapters.size());
 }
 
-void MediaDetailView::onPlay(bool resume) {
-    // For podcasts, handle episode selection first
-    if (m_item.mediaType == MediaType::PODCAST) {
-        std::string podcastId, episodeId;
-        if (!m_children.empty()) {
-            podcastId = m_children[0].podcastId;
-            episodeId = m_children[0].episodeId;
-        } else {
-            AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-            std::vector<MediaItem> episodes;
-            if (client.fetchPodcastEpisodes(m_item.id, episodes) && !episodes.empty()) {
-                podcastId = episodes[0].podcastId;
-                episodeId = episodes[0].episodeId;
-            } else {
-                brls::Application::notify("No episodes available");
-                return;
-            }
-        }
-        // Start download for podcast episode
-        startDownloadAndPlay(podcastId, episodeId);
-        return;
-    }
+void MangaDetailView::onChapterSelected(const Chapter& chapter) {
+    brls::Logger::debug("MangaDetailView: Selected chapter {} ({})", chapter.index, chapter.name);
 
-    // For books and podcast episodes, start download
-    std::string itemId = (m_item.mediaType == MediaType::PODCAST_EPISODE) ? m_item.podcastId : m_item.id;
-    std::string episodeId = (m_item.mediaType == MediaType::PODCAST_EPISODE) ? m_item.episodeId : "";
-
-    startDownloadAndPlay(itemId, episodeId);
+    // Open reader at this chapter
+    Application::getInstance().pushReaderActivity(m_manga.id, chapter.index, m_manga.title);
 }
 
-void MediaDetailView::startDownloadAndPlay(const std::string& itemId, const std::string& episodeId,
-                                            float requestedStartTime, bool downloadOnly) {
-    brls::Logger::info("startDownloadAndPlay: itemId={}, episodeId={}, startTime={}, downloadOnly={}",
-                       itemId, episodeId, requestedStartTime, downloadOnly);
-
-    // Get settings
-    AppSettings& settings = Application::getInstance().getSettings();
-    // If downloadOnly mode, always save to downloads folder
-    bool useDownloads = downloadOnly ? true : settings.saveToDownloads;
-
-    // Initialize managers
-    TempFileManager& tempMgr = TempFileManager::getInstance();
-    DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-    tempMgr.init();
-    downloadsMgr.init();
-
-    // Check if we have a cached version - ALWAYS check downloads first, then temp
-    std::string cachedPath;
-    bool isFromDownloads = false;
-
-    // First check downloads folder (regardless of saveToDownloads setting)
-    if (downloadsMgr.isDownloaded(itemId, episodeId)) {
-        cachedPath = downloadsMgr.getPlaybackPath(itemId);
-        isFromDownloads = true;
-        brls::Logger::info("Found in downloads: {}", cachedPath);
-    }
-
-    // If not in downloads, check temp cache
-    if (cachedPath.empty()) {
-        cachedPath = tempMgr.getCachedFilePath(itemId, episodeId);
-        if (!cachedPath.empty()) {
-            // If save to downloads is enabled and we're playing (not download only),
-            // delete the temp file and re-download to downloads folder
-            if (useDownloads && !downloadOnly) {
-                brls::Logger::info("Deleting temp file to re-download to downloads folder: {}", cachedPath);
-                tempMgr.deleteTempFile(itemId, episodeId);
-                cachedPath.clear();
-            } else {
-                tempMgr.touchTempFile(itemId, episodeId);
-                brls::Logger::info("Found in temp cache: {}", cachedPath);
-            }
+void MangaDetailView::onRead(int chapterIndex) {
+    if (chapterIndex == -1) {
+        // Continue from last read
+        if (m_manga.lastChapterRead > 0) {
+            chapterIndex = m_manga.lastChapterRead;
+        } else {
+            // Start from first chapter
+            chapterIndex = 1;
         }
     }
 
-    // If cached, play immediately (fetch progress from server first if online)
-    if (!cachedPath.empty()) {
-        brls::Logger::info("Using cached file: {}", cachedPath);
+    brls::Logger::info("MangaDetailView: Reading chapter {}", chapterIndex);
+    Application::getInstance().pushReaderActivity(m_manga.id, chapterIndex, m_manga.title);
+}
 
-        // Fetch latest progress from server before playing
-        float startTime = requestedStartTime;
-        if (startTime < 0) {
-            AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-            if (client.isAuthenticated()) {
-                float serverTime = 0.0f, serverProgress = 0.0f;
-                bool serverFinished = false;
-                if (client.getProgress(itemId, serverTime, serverProgress, serverFinished, episodeId)) {
-                    startTime = serverTime;
-                    brls::Logger::info("Fetched progress from server: {}s", startTime);
+void MangaDetailView::onAddToLibrary() {
+    brls::Logger::info("MangaDetailView: Adding to library");
+
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        if (client.addMangaToLibrary(m_manga.id)) {
+            brls::sync([this]() {
+                m_manga.inLibrary = true;
+                if (m_libraryButton) {
+                    m_libraryButton->setText("Remove");
                 }
-            }
-
-            // Also check local progress if from downloads
-            if (isFromDownloads && startTime <= 0) {
-                DownloadItem* download = downloadsMgr.getDownload(itemId);
-                if (download && download->currentTime > 0) {
-                    startTime = download->currentTime;
-                    brls::Logger::info("Using local download progress: {}s", startTime);
-                }
-            }
-        }
-
-        Application::getInstance().pushPlayerActivityWithFile(itemId, episodeId, cachedPath, startTime);
-        return;
-    }
-
-    // Need to download - show progress dialog
-    auto* progressDialog = ProgressDialog::showDownloading(m_item.title);
-
-    // Store necessary data for the async operation
-    std::string title = m_item.title;
-    std::string authorName = m_item.authorName;
-    std::string itemType = m_item.type;
-    float duration = m_item.duration;
-    std::string description = m_item.description;
-    std::string coverUrl = AudiobookshelfClient::getInstance().getCoverUrl(itemId);
-
-    // Copy chapters for offline use
-    std::vector<DownloadChapter> downloadChapters;
-    for (const auto& ch : m_item.chapters) {
-        DownloadChapter dch;
-        dch.title = ch.title;
-        dch.start = ch.start;
-        dch.end = ch.end;
-        downloadChapters.push_back(dch);
-    }
-
-    // Run download in background
-    asyncRun([this, progressDialog, itemId, episodeId, title, authorName, itemType, duration, useDownloads, requestedStartTime, coverUrl, description, downloadChapters, downloadOnly]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-
-        // Start playback session
-        PlaybackSession session;
-        if (!client.startPlaybackSession(itemId, session, episodeId)) {
-            brls::Logger::error("Failed to start playback session");
-            brls::sync([progressDialog]() {
-                progressDialog->setStatus("Failed to start session");
-                brls::delay(2000, [progressDialog]() { progressDialog->dismiss(); });
+                brls::Application::notify("Added to library");
             });
-            return;
-        }
-
-        brls::Logger::info("Session started: {} tracks, currentTime={}s, duration={}s",
-                          session.audioTracks.size(), session.currentTime, session.duration);
-
-        // Determine file extension and multi-file status
-        bool isMultiFile = session.audioTracks.size() > 1;
-        std::string mimeType = "audio/mpeg";
-        if (!session.audioTracks.empty() && !session.audioTracks[0].mimeType.empty()) {
-            mimeType = session.audioTracks[0].mimeType;
-        }
-
-        std::string ext = ".mp3";
-        if (mimeType.find("mp4") != std::string::npos || mimeType.find("m4a") != std::string::npos ||
-            mimeType.find("m4b") != std::string::npos) {
-            ext = ".m4a";
-        } else if (mimeType.find("flac") != std::string::npos) {
-            ext = ".flac";
-        } else if (mimeType.find("ogg") != std::string::npos) {
-            ext = ".ogg";
-        }
-
-        // For multi-file audiobooks, use mp4 container only for m4a sources
-        // For mp3/ogg/flac sources, keep the same format (Vita FFmpeg lacks mp4 muxer)
-        std::string finalExt = ext;
-        if (isMultiFile && ext == ".m4a") {
-            finalExt = ".m4b";  // Only use m4b for m4a sources
-        }
-
-        // Determine destination path
-        TempFileManager& tempMgr = TempFileManager::getInstance();
-        DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-        std::string destPath;
-
-        if (useDownloads) {
-            std::string filename = itemId;
-            if (!episodeId.empty()) {
-                filename += "_" + episodeId;
-            }
-            filename += finalExt;
-            destPath = downloadsMgr.getDownloadsPath() + "/" + filename;
         } else {
-            tempMgr.cleanupTempFiles();  // Clean up before downloading
-            destPath = tempMgr.getTempFilePath(itemId, episodeId, finalExt);
-        }
-
-        // Use requested start time if specified, otherwise use session's current time
-        float startTime = (requestedStartTime >= 0) ? requestedStartTime : session.currentTime;
-        brls::Logger::info("Using startTime={}s (requested={}, session={}s)",
-                          startTime, requestedStartTime, session.currentTime);
-
-#ifdef __vita__
-        HttpClient httpClient;
-        httpClient.setTimeout(300);  // 5 minute timeout
-        int64_t totalDownloaded = 0;
-        bool downloadSuccess = true;
-
-        if (isMultiFile) {
-            // Multi-file audiobook handling
-            int numTracks = static_cast<int>(session.audioTracks.size());
-            std::vector<std::string> trackFiles;
-
-            // Check if combined file already exists on disk (from previous incomplete registration)
-            std::string combinedPath;
-            if (useDownloads) {
-                combinedPath = downloadsMgr.getDownloadsPath() + "/" + itemId + finalExt;
-            } else {
-                combinedPath = tempMgr.getTempFilePath(itemId, episodeId, finalExt);
-            }
-
-            SceIoStat existingStat;
-            if (sceIoGetstat(combinedPath.c_str(), &existingStat) >= 0 && existingStat.st_size > 0) {
-                brls::Logger::info("Found existing combined file: {} ({} bytes)", combinedPath, existingStat.st_size);
-
-                // Register it if not already registered
-                if (useDownloads) {
-                    downloadsMgr.registerCompletedDownload(itemId, episodeId, title, authorName,
-                        combinedPath, existingStat.st_size, duration, itemType, coverUrl, description, downloadChapters);
-                } else {
-                    tempMgr.registerTempFile(itemId, episodeId, combinedPath, title, existingStat.st_size);
-                }
-
-                // Play the existing file
-                float seekTime = (requestedStartTime >= 0) ? requestedStartTime : session.currentTime;
-                brls::sync([progressDialog, itemId, episodeId, combinedPath, seekTime]() {
-                    progressDialog->dismiss();
-                    Application::getInstance().pushPlayerActivityWithFile(itemId, episodeId, combinedPath, seekTime);
-                });
-                return;
-            }
-
-            if (downloadOnly) {
-                // Download-only mode: download ALL tracks first, combine, register, no playback
-                brls::Logger::info("Download-only mode: Downloading all {} tracks for multi-file audiobook", numTracks);
-
-                // Download all tracks sequentially
-                for (int trackIdx = 0; trackIdx < numTracks && downloadSuccess; trackIdx++) {
-                    const AudioTrack& track = session.audioTracks[trackIdx];
-                    std::string trackUrl = client.getStreamUrl(track.contentUrl, "");
-
-                    if (trackUrl.empty()) {
-                        brls::Logger::error("Failed to get URL for track {}", trackIdx);
-                        downloadSuccess = false;
-                        break;
-                    }
-
-                    std::string trackExt = ext;
-                    if (!track.mimeType.empty() && (track.mimeType.find("mp4") != std::string::npos ||
-                        track.mimeType.find("m4a") != std::string::npos)) {
-                        trackExt = ".m4a";
-                    }
-
-                    std::string trackPath = tempMgr.getTempFilePath(itemId + "_track" + std::to_string(trackIdx), "", trackExt);
-                    trackFiles.push_back(trackPath);
-
-                    int currentTrack = trackIdx;
-                    brls::sync([progressDialog, currentTrack, numTracks]() {
-                        char buf[64];
-                        snprintf(buf, sizeof(buf), "Downloading track %d/%d...", currentTrack + 1, numTracks);
-                        progressDialog->setStatus(buf);
-                    });
-
-                    SceUID fd = sceIoOpen(trackPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
-                    if (fd < 0) {
-                        brls::Logger::error("Failed to create track file: {}", trackPath);
-                        downloadSuccess = false;
-                        break;
-                    }
-
-                    int64_t trackDownloaded = 0;
-                    int64_t trackSize = 0;
-
-                    bool trackOk = httpClient.downloadFile(trackUrl,
-                        [&](const char* data, size_t size) -> bool {
-                            int written = sceIoWrite(fd, data, size);
-                            if (written < 0) return false;
-                            trackDownloaded += size;
-
-                            // Update progress for this track
-                            if (trackSize > 0) {
-                                int64_t currentTrackNum = currentTrack;
-                                brls::sync([progressDialog, trackDownloaded, trackSize, currentTrackNum, numTracks]() {
-                                    char buf[96];
-                                    int percent = static_cast<int>((trackDownloaded * 100) / trackSize);
-                                    int dlMB = static_cast<int>(trackDownloaded / (1024 * 1024));
-                                    int totalMB = static_cast<int>(trackSize / (1024 * 1024));
-                                    snprintf(buf, sizeof(buf), "Track %d/%d: %d%% (%d/%d MB)",
-                                            static_cast<int>(currentTrackNum) + 1, numTracks, percent, dlMB, totalMB);
-                                    progressDialog->setStatus(buf);
-                                });
-                            }
-                            return true;
-                        },
-                        [&](int64_t size) {
-                            if (size > 0) trackSize = size;
-                        }
-                    );
-
-                    sceIoClose(fd);
-
-                    if (!trackOk) {
-                        brls::Logger::error("Failed to download track {}", trackIdx);
-                        sceIoRemove(trackPath.c_str());
-                        downloadSuccess = false;
-                    } else {
-                        totalDownloaded += trackDownloaded;
-                        brls::Logger::info("Track {}/{} complete ({} bytes)", trackIdx + 1, numTracks, trackDownloaded);
-                    }
-                }
-
-                // Combine all tracks if all downloaded successfully
-                if (downloadSuccess) {
-                    brls::sync([progressDialog]() {
-                        progressDialog->setStatus("Combining audio files...");
-                    });
-
-                    brls::Logger::info("Combining {} tracks into {}", numTracks, destPath);
-
-                    int totalTracks = numTracks;
-                    if (concatenateAudioFiles(trackFiles, destPath, [progressDialog, totalTracks](int current, int total) {
-                        brls::sync([progressDialog, current, totalTracks]() {
-                            char buf[64];
-                            snprintf(buf, sizeof(buf), "Combining file %d/%d...", current, totalTracks);
-                            progressDialog->setStatus(buf);
-                        });
-                    })) {
-                        brls::Logger::info("Successfully combined {} tracks", numTracks);
-
-                        // Get final file size
-                        SceIoStat stat;
-                        if (sceIoGetstat(destPath.c_str(), &stat) >= 0) {
-                            totalDownloaded = stat.st_size;
-                        }
-
-                        // Clean up individual track files
-                        for (const auto& trackFile : trackFiles) {
-                            sceIoRemove(trackFile.c_str());
-                        }
-                    } else {
-                        brls::Logger::error("Failed to combine tracks");
-                        downloadSuccess = false;
-                        // Clean up partial files
-                        for (const auto& trackFile : trackFiles) {
-                            sceIoRemove(trackFile.c_str());
-                        }
-                    }
-                } else {
-                    // Clean up partial downloads
-                    for (const auto& trackFile : trackFiles) {
-                        if (!trackFile.empty()) {
-                            sceIoRemove(trackFile.c_str());
-                        }
-                    }
-                }
-
-                // Continue to the result handling below (will register download and update UI)
-
-            } else {
-                // Play mode: download track containing resume position, start playback, download rest in background
-                std::string currentTrackPath;
-                int currentTrackIdx = 0;
-                float trackSeekTime = 0.0f;  // Initialize to 0 for safety
-                bool foundTrack = false;
-
-                brls::Logger::info("Multi-file play mode: Finding track for resume position {}s", startTime);
-
-                // Find which track contains the current playback position
-                for (size_t i = 0; i < session.audioTracks.size(); i++) {
-                    const AudioTrack& track = session.audioTracks[i];
-                    float trackEnd = track.startOffset + track.duration;
-
-                    brls::Logger::debug("Track {}: startOffset={}s, duration={}s, end={}s",
-                                       i, track.startOffset, track.duration, trackEnd);
-
-                    if (startTime >= track.startOffset && startTime < trackEnd) {
-                        currentTrackIdx = static_cast<int>(i);
-                        trackSeekTime = startTime - track.startOffset;
-                        foundTrack = true;
-                        brls::Logger::info("Resume position {}s is in track {} (offset {}s, seek within track {}s)",
-                                          startTime, currentTrackIdx + 1, track.startOffset, trackSeekTime);
-                        break;
-                    }
-                }
-
-                // If no track found (startTime is 0 or beyond all tracks), use first track from start
-                if (!foundTrack) {
-                    currentTrackIdx = 0;
-                    trackSeekTime = 0.0f;
-                    brls::Logger::info("No matching track found for {}s, starting from track 1 at 0s", startTime);
-                }
-
-                // Download track containing resume position first, then rest in background
-                brls::Logger::info("Downloading track {}/{} for multi-file audiobook (seek to {}s within track)",
-                                  currentTrackIdx + 1, numTracks, trackSeekTime);
-
-                // First, download the track containing resume position so we can start playing
-                {
-                    const AudioTrack& track = session.audioTracks[currentTrackIdx];
-                    std::string trackUrl = client.getStreamUrl(track.contentUrl, "");
-
-                    if (trackUrl.empty()) {
-                        brls::Logger::error("Failed to get URL for current track {}", currentTrackIdx);
-                        downloadSuccess = false;
-                    } else {
-                        std::string trackExt = ext;
-                        if (!track.mimeType.empty() && (track.mimeType.find("mp4") != std::string::npos ||
-                            track.mimeType.find("m4a") != std::string::npos)) {
-                            trackExt = ".m4a";
-                        }
-
-                        currentTrackPath = tempMgr.getTempFilePath(itemId + "_track" + std::to_string(currentTrackIdx), "", trackExt);
-
-                        brls::sync([progressDialog, currentTrackIdx, numTracks]() {
-                            char buf[64];
-                            snprintf(buf, sizeof(buf), "Downloading track %d/%d...", currentTrackIdx + 1, numTracks);
-                            progressDialog->setStatus(buf);
-                        });
-
-                        SceUID fd = sceIoOpen(currentTrackPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
-                        if (fd >= 0) {
-                            int64_t totalSize = 0;
-                            downloadSuccess = httpClient.downloadFile(trackUrl,
-                                [&](const char* data, size_t size) -> bool {
-                                    int written = sceIoWrite(fd, data, size);
-                                    if (written < 0) return false;
-                                    totalDownloaded += size;
-                                    if (totalSize > 0) {
-                                        brls::sync([progressDialog, totalDownloaded, totalSize]() {
-                                            progressDialog->updateDownloadProgress(totalDownloaded, totalSize);
-                                        });
-                                    }
-                                    return true;
-                                },
-                                [&](int64_t size) { totalSize = size; }
-                            );
-                            sceIoClose(fd);
-                            if (!downloadSuccess) {
-                                sceIoRemove(currentTrackPath.c_str());
-                            }
-                        } else {
-                            downloadSuccess = false;
-                        }
-                    }
-                }
-
-                if (downloadSuccess) {
-                    // Start playback immediately with the current track
-                    float seekTime = trackSeekTime;
-                    brls::sync([progressDialog, itemId, episodeId, currentTrackPath, seekTime]() {
-                        progressDialog->dismiss();
-                        Application::getInstance().pushPlayerActivityWithFile(itemId, episodeId, currentTrackPath, seekTime);
-                    });
-
-                    // Now download remaining tracks in background and combine when done
-                    std::vector<AudioTrack> allTracks = session.audioTracks;
-                    std::string baseExt = ext;
-                    std::string combinedExt = finalExt;  // Use the correct extension based on source format
-                    std::string finalPath = useDownloads
-                        ? downloadsMgr.getDownloadsPath() + "/" + itemId + combinedExt
-                        : tempMgr.getTempFilePath(itemId, episodeId, combinedExt);
-
-                    asyncRunLargeStack([allTracks, currentTrackIdx, currentTrackPath, itemId, episodeId, baseExt, finalPath, title, authorName, duration, itemType, useDownloads, coverUrl, description, downloadChapters]() {
-                        brls::Logger::info("Background: Downloading remaining tracks...");
-
-                        HttpClient bgHttpClient;
-                        bgHttpClient.setTimeout(300);
-                        TempFileManager& bgTempMgr = TempFileManager::getInstance();
-                        DownloadsManager& bgDownloadsMgr = DownloadsManager::getInstance();
-
-                        std::vector<std::string> allTrackFiles(allTracks.size());
-                        allTrackFiles[currentTrackIdx] = currentTrackPath;
-
-                        // Track progress by track count (we don't have size info from AudioTrack)
-                        int tracksDownloaded = 1;  // Already downloaded current track
-                        int totalTracksToDownload = static_cast<int>(allTracks.size());
-
-                        // Set initial background progress
-                        BackgroundDownloadProgress bgProgress;
-                        bgProgress.active = true;
-                        bgProgress.itemId = itemId;
-                        bgProgress.currentTrack = currentTrackIdx + 1;
-                        bgProgress.totalTracks = totalTracksToDownload;
-                        bgProgress.downloadedBytes = 0;  // Will track per-track progress
-                        bgProgress.totalBytes = 0;       // Unknown total
-                        bgProgress.status = "Downloading remaining tracks...";
-                        Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-
-                        // Download all other tracks
-                        AudiobookshelfClient& bgClient = AudiobookshelfClient::getInstance();
-                        bool allDownloaded = true;
-
-                        for (size_t i = 0; i < allTracks.size() && allDownloaded; i++) {
-                            if (static_cast<int>(i) == currentTrackIdx) continue;  // Already downloaded
-
-                            const AudioTrack& track = allTracks[i];
-                            std::string trackUrl = bgClient.getStreamUrl(track.contentUrl, "");
-
-                            if (trackUrl.empty()) {
-                                brls::Logger::error("Background: Failed to get URL for track {}", i);
-                                allDownloaded = false;
-                                break;
-                            }
-
-                            std::string trackExt = baseExt;
-                            if (!track.mimeType.empty() && (track.mimeType.find("mp4") != std::string::npos ||
-                                track.mimeType.find("m4a") != std::string::npos)) {
-                                trackExt = ".m4a";
-                            }
-
-                            std::string trackPath = bgTempMgr.getTempFilePath(itemId + "_track" + std::to_string(i), "", trackExt);
-                            allTrackFiles[i] = trackPath;
-
-                            brls::Logger::info("Background: Downloading track {}/{}...", i + 1, allTracks.size());
-
-                            // Update background progress
-                            bgProgress.currentTrack = static_cast<int>(i) + 1;
-                            char statusBuf[64];
-                            snprintf(statusBuf, sizeof(statusBuf), "Downloading track %d/%d...",
-                                    static_cast<int>(i) + 1, static_cast<int>(allTracks.size()));
-                            bgProgress.status = statusBuf;
-                            Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-
-                            SceUID fd = sceIoOpen(trackPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
-                            if (fd < 0) {
-                                allDownloaded = false;
-                                break;
-                            }
-
-                            int64_t trackDownloaded = 0;
-                            int64_t trackTotalSize = 0;
-                            bool trackOk = bgHttpClient.downloadFile(trackUrl,
-                                [&](const char* data, size_t size) -> bool {
-                                    int written = sceIoWrite(fd, data, size);
-                                    if (written < 0) return false;
-                                    trackDownloaded += size;
-                                    // Update progress periodically (every 64KB)
-                                    if ((trackDownloaded % (64 * 1024)) < size) {
-                                        bgProgress.downloadedBytes = trackDownloaded;
-                                        bgProgress.totalBytes = trackTotalSize;
-                                        Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-                                    }
-                                    return true;
-                                },
-                                [&](int64_t size) {
-                                    if (size > 0) trackTotalSize = size;
-                                }
-                            );
-
-                            sceIoClose(fd);
-
-                            if (!trackOk) {
-                                brls::Logger::error("Background: Failed to download track {}", i);
-                                sceIoRemove(trackPath.c_str());
-                                allDownloaded = false;
-                            } else {
-                                tracksDownloaded++;
-                                bgProgress.downloadedBytes = 0;  // Reset for next track
-                                bgProgress.totalBytes = 0;
-                                Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-                            }
-                        }
-
-                        // Combine all tracks if all downloaded successfully
-                        if (allDownloaded) {
-                            brls::Logger::info("Background: Combining {} tracks...", allTracks.size());
-
-                            bgProgress.status = "Combining audio files...";
-                            Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-
-                            int totalFiles = static_cast<int>(allTrackFiles.size());
-                            if (concatenateAudioFiles(allTrackFiles, finalPath, [&bgProgress, totalFiles](int current, int total) {
-                                char statusBuf[64];
-                                snprintf(statusBuf, sizeof(statusBuf), "Combining file %d/%d...", current, totalFiles);
-                                bgProgress.status = statusBuf;
-                                bgProgress.currentTrack = current;
-                                bgProgress.totalTracks = totalFiles;
-                                Application::getInstance().setBackgroundDownloadProgress(bgProgress);
-                            })) {
-                                brls::Logger::info("Background: Successfully combined into {}", finalPath);
-
-                                // Get total file size
-                                SceIoStat stat;
-                                int64_t totalSize = 0;
-                                if (sceIoGetstat(finalPath.c_str(), &stat) >= 0) {
-                                    totalSize = stat.st_size;
-                                }
-
-                                // Register the combined file
-                                if (useDownloads) {
-                                    bgDownloadsMgr.registerCompletedDownload(itemId, episodeId, title,
-                                        authorName, finalPath, totalSize, duration, itemType,
-                                        coverUrl, description, downloadChapters);
-                                } else {
-                                    bgTempMgr.registerTempFile(itemId, episodeId, finalPath, title, totalSize);
-                                }
-
-                                // Clean up individual track files
-                                for (const auto& trackFile : allTrackFiles) {
-                                    sceIoRemove(trackFile.c_str());
-                                }
-
-                                // Clear background progress
-                                Application::getInstance().clearBackgroundDownloadProgress();
-
-                                brls::sync([]() {
-                                    brls::Application::notify("Audiobook fully downloaded");
-                                });
-                            } else {
-                                brls::Logger::error("Background: Failed to combine tracks");
-                                Application::getInstance().clearBackgroundDownloadProgress();
-                            }
-                        } else {
-                            // Clean up partial downloads
-                            for (const auto& trackFile : allTrackFiles) {
-                                if (!trackFile.empty()) {
-                                    sceIoRemove(trackFile.c_str());
-                                }
-                            }
-                            Application::getInstance().clearBackgroundDownloadProgress();
-                        }
-                    });
-
-                    // Return early - playback already started
-                    return;
-                }
-            }
-
-        } else {
-            // Single file download
-            std::string streamUrl;
-            if (!session.audioTracks.empty() && !session.audioTracks[0].contentUrl.empty()) {
-                streamUrl = client.getStreamUrl(session.audioTracks[0].contentUrl, "");
-            } else {
-                streamUrl = client.getDirectStreamUrl(itemId, 0);
-            }
-
-            if (streamUrl.empty()) {
-                brls::Logger::error("Failed to get stream URL");
-                downloadSuccess = false;
-            } else {
-                SceUID fd = sceIoOpen(destPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
-                if (fd < 0) {
-                    brls::Logger::error("Failed to create file: {}", destPath);
-                    downloadSuccess = false;
-                } else {
-                    int64_t totalSize = 0;
-
-                    downloadSuccess = httpClient.downloadFile(streamUrl,
-                        [&](const char* data, size_t size) -> bool {
-                            int written = sceIoWrite(fd, data, size);
-                            if (written < 0) return false;
-                            totalDownloaded += size;
-
-                            // Update progress with speed display
-                            if (totalSize > 0) {
-                                brls::sync([progressDialog, totalDownloaded, totalSize]() {
-                                    progressDialog->updateDownloadProgress(totalDownloaded, totalSize);
-                                });
-                            }
-                            return true;
-                        },
-                        [&](int64_t size) {
-                            totalSize = size;
-                            brls::Logger::info("File size: {} bytes", size);
-                        }
-                    );
-
-                    sceIoClose(fd);
-
-                    if (!downloadSuccess) {
-                        sceIoRemove(destPath.c_str());
-                    }
-                }
-            }
-        }
-
-        // Handle result
-        if (downloadSuccess) {
-            // Register the file
-            if (useDownloads) {
-                downloadsMgr.registerCompletedDownload(itemId, episodeId, title,
-                    authorName, destPath, totalDownloaded, duration, itemType,
-                    coverUrl, description, downloadChapters);
-            } else {
-                tempMgr.registerTempFile(itemId, episodeId, destPath, title, totalDownloaded);
-            }
-
-            brls::Logger::info("Download complete: {}", destPath);
-
-            if (downloadOnly) {
-                // Download only mode - just show success and update button
-                brls::sync([progressDialog, this]() {
-                    progressDialog->setStatus("Download complete!");
-                    if (m_downloadButton) m_downloadButton->setText("Downloaded");
-                    brls::delay(1500, [progressDialog]() { progressDialog->dismiss(); });
-                });
-            } else {
-                // Push to player with pre-downloaded file
-                float seekTime = startTime;
-                brls::sync([progressDialog, itemId, episodeId, destPath, seekTime]() {
-                    progressDialog->dismiss();
-                    Application::getInstance().pushPlayerActivityWithFile(itemId, episodeId, destPath, seekTime);
-                });
-            }
-        } else {
-            brls::sync([progressDialog, downloadOnly, this]() {
-                progressDialog->setStatus("Download failed");
-                if (downloadOnly && m_downloadButton) m_downloadButton->setText("Download");
-                brls::delay(2000, [progressDialog]() { progressDialog->dismiss(); });
+            brls::sync([]() {
+                brls::Application::notify("Failed to add to library");
             });
         }
-#else
-        // Non-Vita: just use streaming URL directly
-        std::string streamUrl;
-        if (!session.audioTracks.empty() && !session.audioTracks[0].contentUrl.empty()) {
-            streamUrl = client.getStreamUrl(session.audioTracks[0].contentUrl, "");
-        } else {
-            streamUrl = client.getDirectStreamUrl(itemId, 0);
-        }
-
-        brls::sync([progressDialog, itemId, episodeId, streamUrl, startTime]() {
-            progressDialog->dismiss();
-            Application::getInstance().pushPlayerActivityWithFile(itemId, episodeId, streamUrl, startTime);
-        });
-#endif
     });
 }
 
-void MediaDetailView::onDownload() {
-    brls::Logger::info("onDownload called for item: {} ({})", m_item.title, m_item.id);
+void MangaDetailView::onRemoveFromLibrary() {
+    brls::Logger::info("MangaDetailView: Removing from library");
 
-    // Use the same download logic as streaming but save to downloads
-    std::string itemId = (m_item.mediaType == MediaType::PODCAST_EPISODE) ? m_item.podcastId : m_item.id;
-    std::string episodeId = (m_item.mediaType == MediaType::PODCAST_EPISODE) ? m_item.episodeId : "";
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
 
-    // Check if already downloaded (check both itemId and episodeId)
-    if (DownloadsManager::getInstance().isDownloaded(itemId, episodeId)) {
-        brls::Application::notify("Already downloaded");
-        return;
-    }
-
-    startDownloadOnly(itemId, episodeId);
+        if (client.removeMangaFromLibrary(m_manga.id)) {
+            brls::sync([this]() {
+                m_manga.inLibrary = false;
+                if (m_libraryButton) {
+                    m_libraryButton->setText("Add");
+                }
+                brls::Application::notify("Removed from library");
+            });
+        } else {
+            brls::sync([]() {
+                brls::Application::notify("Failed to remove from library");
+            });
+        }
+    });
 }
 
-void MediaDetailView::onDeleteDownload() {
-    brls::Logger::info("onDeleteDownload called for item: {} ({})", m_item.title, m_item.id);
+void MangaDetailView::showDownloadOptions() {
+    brls::Dialog* dialog = new brls::Dialog("Download Options");
 
-    std::string itemId = (m_item.mediaType == MediaType::PODCAST_EPISODE) ? m_item.podcastId : m_item.id;
-    std::string title = m_item.title;
+    dialog->addButton("Download All", [this, dialog]() {
+        dialog->close();
+        downloadAllChapters();
+    });
 
-    // Show confirmation dialog
-    brls::Dialog* dialog = new brls::Dialog("Delete downloaded content?\n\n\"" + title + "\"");
+    dialog->addButton("Download Unread", [this, dialog]() {
+        dialog->close();
+        downloadUnreadChapters();
+    });
 
     dialog->addButton("Cancel", [dialog]() {
-        dialog->close();
-    });
-
-    dialog->addButton("Delete", [dialog, itemId, this]() {
-        DownloadsManager::getInstance().deleteDownload(itemId);
-        brls::Application::notify("Download deleted");
-
-        // Update UI - hide delete button
-        if (m_deleteButton) {
-            m_deleteButton->setVisibility(brls::Visibility::GONE);
-        }
-
-        // Show download button if saveToDownloads is not enabled
-        AppSettings& settings = Application::getInstance().getSettings();
-        if (!settings.saveToDownloads) {
-            // Re-create the download button if it doesn't exist
-            if (!m_downloadButton) {
-                // Will be visible on next view load
-            }
-        }
-
         dialog->close();
     });
 
     dialog->open();
 }
 
-bool MediaDetailView::areAllEpisodesDownloaded() {
-    if (m_item.mediaType != MediaType::PODCAST) return false;
-    if (m_children.empty()) return false;
-
-    DownloadsManager& mgr = DownloadsManager::getInstance();
-    for (const auto& ep : m_children) {
-        if (!mgr.isDownloaded(m_item.id, ep.episodeId)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool MediaDetailView::hasAnyDownloadedEpisodes() {
-    if (m_item.mediaType != MediaType::PODCAST) return false;
-
-    DownloadsManager& mgr = DownloadsManager::getInstance();
-
-    // Check children if available
-    if (!m_children.empty()) {
-        for (const auto& ep : m_children) {
-            if (mgr.isDownloaded(m_item.id, ep.episodeId)) {
-                return true;
-            }
-        }
-    }
-
-    // Also check downloads directly for this podcast
-    auto downloads = mgr.getDownloads();
-    for (const auto& dl : downloads) {
-        if (dl.itemId == m_item.id && dl.state == DownloadState::COMPLETED) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-void MediaDetailView::deleteAllDownloadedEpisodes() {
-    brls::Logger::info("deleteAllDownloadedEpisodes called for podcast: {} ({})", m_item.title, m_item.id);
-
-    std::string podcastId = m_item.id;
-    std::string podcastTitle = m_item.title;
-
-    // Get downloaded episodes for this podcast
-    DownloadsManager& mgr = DownloadsManager::getInstance();
-    auto downloads = mgr.getDownloads();
-
-    // Collect downloaded episode info: <episodeId, title>
-    std::vector<std::pair<std::string, std::string>> downloadedEpisodes;
-    for (const auto& dl : downloads) {
-        if (dl.itemId == podcastId && dl.state == DownloadState::COMPLETED) {
-            downloadedEpisodes.push_back({dl.episodeId, dl.title});
-        }
-    }
-
-    if (downloadedEpisodes.empty()) {
-        brls::Application::notify("No downloaded episodes found");
-        return;
-    }
-
-    if (downloadedEpisodes.size() == 1) {
-        // Single episode - show simple confirmation
-        std::string episodeTitle = downloadedEpisodes[0].second;
-        std::string episodeId = downloadedEpisodes[0].first;
-
-        brls::Dialog* dialog = new brls::Dialog("Delete downloaded episode?\n\n\"" + episodeTitle + "\"");
-
-        dialog->addButton("Cancel", [dialog]() {
-            dialog->close();
-        });
-
-        dialog->addButton("Delete", [dialog, podcastId, episodeId, this]() {
-            DownloadsManager::getInstance().deleteDownloadByEpisodeId(podcastId, episodeId);
-            brls::Application::notify("Episode deleted");
-
-            // Update UI
-            if (m_deleteButton) {
-                m_deleteButton->setVisibility(brls::Visibility::GONE);
-            }
-            if (m_downloadButton) {
-                m_downloadButton->setVisibility(brls::Visibility::VISIBLE);
-            }
-
-            dialog->close();
-        });
-
-        dialog->open();
-    } else {
-        // Multiple episodes - show dialog with Delete All and clickable episode list
-        showDeleteEpisodesDialog(downloadedEpisodes, podcastId, podcastTitle);
-    }
-}
-
-void MediaDetailView::showDeleteEpisodesDialog(
-    const std::vector<std::pair<std::string, std::string>>& episodes,
-    const std::string& podcastId,
-    const std::string& podcastTitle) {
-
-    // Create a dialog with Delete All button and clickable episode list
-    auto* dialog = new brls::Dialog("Downloaded Episodes (" + std::to_string(episodes.size()) + ")");
-
-    // Register circle button to close dialog
-    dialog->registerAction("Back", brls::ControllerButton::BUTTON_B, [dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
-    }, true);
-
-    // Create content box
-    auto* content = new brls::Box();
-    content->setAxis(brls::Axis::COLUMN);
-    content->setPadding(20);
-    content->setWidth(700);
-
-    // Delete All button at top with confirmation
-    auto* deleteAllBtn = new brls::Button();
-    deleteAllBtn->setText("Delete All Downloaded Episodes");
-    deleteAllBtn->setMarginBottom(15);
-
-    // Copy episodes for the lambda
-    std::vector<std::pair<std::string, std::string>> episodesCopy = episodes;
-
-    deleteAllBtn->registerClickAction([this, dialog, episodesCopy, podcastId, podcastTitle](brls::View*) {
-        // Show confirmation dialog
-        brls::Dialog* confirmDialog = new brls::Dialog(
-            "Delete all " + std::to_string(episodesCopy.size()) + " downloaded episodes from\n\"" + podcastTitle + "\"?");
-
-        confirmDialog->addButton("Cancel", [confirmDialog]() {
-            confirmDialog->close();
-        });
-
-        confirmDialog->addButton("Delete All", [this, dialog, confirmDialog, episodesCopy, podcastId]() {
-            DownloadsManager& mgr = DownloadsManager::getInstance();
-
-            int deleted = 0;
-            for (const auto& ep : episodesCopy) {
-                if (mgr.deleteDownloadByEpisodeId(podcastId, ep.first)) {
-                    deleted++;
-                }
-            }
-
-            brls::Application::notify("Deleted " + std::to_string(deleted) + " episode(s)");
-
-            // Update UI
-            if (m_deleteButton) {
-                m_deleteButton->setVisibility(brls::Visibility::GONE);
-            }
-            if (m_downloadButton) {
-                m_downloadButton->setVisibility(brls::Visibility::VISIBLE);
-            }
-
-            confirmDialog->close();
-            dialog->dismiss();
-        });
-
-        confirmDialog->open();
-        return true;
-    });
-    content->addView(deleteAllBtn);
-
-    // Separator
-    auto* separator = new brls::Rectangle();
-    separator->setHeight(1);
-    separator->setColor(nvgRGB(80, 80, 80));
-    separator->setMarginBottom(15);
-    content->addView(separator);
-
-    // Instructions
-    auto* instructionsLabel = new brls::Label();
-    instructionsLabel->setText("Click an episode to delete it:");
-    instructionsLabel->setFontSize(14);
-    instructionsLabel->setTextColor(nvgRGB(180, 180, 180));
-    instructionsLabel->setMarginBottom(10);
-    content->addView(instructionsLabel);
-
-    // Create scrolling list of episodes - clicking each deletes just that one
-    auto* scrollView = new brls::ScrollingFrame();
-    scrollView->setHeight(300);
-
-    auto* listBox = new brls::Box();
-    listBox->setAxis(brls::Axis::COLUMN);
-
-    for (const auto& ep : episodes) {
-        auto* row = new brls::Box();
-        row->setAxis(brls::Axis::ROW);
-        row->setAlignItems(brls::AlignItems::CENTER);
-        row->setPadding(12);
-        row->setMarginBottom(8);
-        row->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-        row->setCornerRadius(6);
-        row->setFocusable(true);
-
-        // Episode title
-        auto* titleLabel = new brls::Label();
-        std::string title = ep.second;
-        if (title.length() > 50) {
-            title = title.substr(0, 47) + "...";
-        }
-        titleLabel->setText(title);
-        titleLabel->setFontSize(15);
-        titleLabel->setGrow(1.0f);
-        row->addView(titleLabel);
-
-        // Delete indicator
-        auto* deleteLabel = new brls::Label();
-        deleteLabel->setText("[X]");
-        deleteLabel->setFontSize(14);
-        deleteLabel->setTextColor(nvgRGB(200, 100, 100));
-        deleteLabel->setWidth(40);
-        row->addView(deleteLabel);
-
-        // Click to delete this episode
-        std::string episodeId = ep.first;
-        std::string episodeTitle = ep.second;
-        row->registerClickAction([this, dialog, podcastId, episodeId, episodeTitle, row](brls::View*) {
-            // Show confirmation for single episode
-            brls::Dialog* confirmDialog = new brls::Dialog("Delete this episode?\n\n\"" + episodeTitle + "\"");
-
-            confirmDialog->addButton("Cancel", [confirmDialog]() {
-                confirmDialog->close();
-            });
-
-            confirmDialog->addButton("Delete", [this, dialog, confirmDialog, podcastId, episodeId, row]() {
-                DownloadsManager& mgr = DownloadsManager::getInstance();
-                if (mgr.deleteDownloadByEpisodeId(podcastId, episodeId)) {
-                    brls::Application::notify("Episode deleted");
-
-                    // Hide this row
-                    row->setVisibility(brls::Visibility::GONE);
-
-                    // Check if any episodes remain
-                    if (!hasAnyDownloadedEpisodes()) {
-                        if (m_deleteButton) {
-                            m_deleteButton->setVisibility(brls::Visibility::GONE);
-                        }
-                        if (m_downloadButton) {
-                            m_downloadButton->setVisibility(brls::Visibility::VISIBLE);
-                        }
-                        dialog->dismiss();
-                    }
-                } else {
-                    brls::Application::notify("Failed to delete episode");
-                }
-
-                confirmDialog->close();
-            });
-
-            confirmDialog->open();
-            return true;
-        });
-
-        listBox->addView(row);
-    }
-
-    scrollView->setContentView(listBox);
-    content->addView(scrollView);
-
-    // Close button
-    auto* closeBtn = new brls::Button();
-    closeBtn->setText("Close");
-    closeBtn->setMarginTop(15);
-    closeBtn->registerClickAction([dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
-    });
-    content->addView(closeBtn);
-
-    dialog->addView(content);
-    brls::Application::pushActivity(new brls::Activity(dialog));
-}
-
-void MediaDetailView::startDownloadOnly(const std::string& itemId, const std::string& episodeId) {
-    brls::Logger::info("startDownloadOnly: itemId={}, episodeId={}", itemId, episodeId);
-
-    // Check if already downloaded (check both itemId and episodeId)
-    DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-    downloadsMgr.init();
-
-    if (downloadsMgr.isDownloaded(itemId, episodeId)) {
-        brls::Application::notify("Already downloaded");
-        return;
-    }
-
-    // Update button state
-    if (m_downloadButton) {
-        m_downloadButton->setText("Downloading...");
-    }
-
-    // Use the same code path as play, but with downloadOnly=true
-    // This will save to downloads folder and not start playback
-    startDownloadAndPlay(itemId, episodeId, -1.0f, true);
-}
-
-void MediaDetailView::batchDownloadEpisodes(const std::vector<MediaItem>& episodes) {
-    if (episodes.empty()) {
-        brls::Application::notify("No episodes to download");
-        return;
-    }
-
-    brls::Logger::info("batchDownloadEpisodes: Starting batch download of {} episodes", episodes.size());
-
-    // Show progress dialog
-    auto* progressDialog = ProgressDialog::showDownloading("Downloading Episodes");
-    progressDialog->setStatus("Preparing downloads...");
-
-    // Store data for async operation - use parent podcast ID for all episodes
-    std::string podcastTitle = m_item.title;
-    std::string podcastId = m_item.id;  // Parent podcast ID
-
-    asyncRun([this, progressDialog, episodes, podcastTitle, podcastId]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-        downloadsMgr.init();
-
-        int completed = 0;
-        int failed = 0;
-        int totalEpisodes = static_cast<int>(episodes.size());
-
-        for (size_t i = 0; i < episodes.size(); i++) {
-            const auto& ep = episodes[i];
-            // Use parent podcast ID, not episode's podcastId field (which may be empty)
-            std::string itemId = podcastId;
-            std::string episodeId = ep.episodeId;
-
-            brls::Logger::info("batchDownloadEpisodes: Downloading episode {} of {}: {} (episodeId: {})",
-                              i + 1, totalEpisodes, ep.title, episodeId);
-
-            // Update progress dialog
-            std::string epTitle = ep.title;  // Copy to avoid reference issues
-            brls::sync([progressDialog, i, totalEpisodes, epTitle]() {
-                char buf[128];
-                snprintf(buf, sizeof(buf), "Downloading %d/%d:\n%s",
-                        static_cast<int>(i + 1), totalEpisodes, epTitle.c_str());
-                progressDialog->setStatus(buf);
-                progressDialog->setProgress(static_cast<float>(i) / totalEpisodes);
-            });
-
-            // Check if already downloaded (check both itemId and episodeId)
-            if (downloadsMgr.isDownloaded(itemId, episodeId)) {
-                brls::Logger::info("Episode already downloaded: {}", ep.title);
-                completed++;
-                continue;
-            }
-
-            // Start playback session to get download URL
-            PlaybackSession session;
-            if (!client.startPlaybackSession(itemId, session, episodeId)) {
-                brls::Logger::error("Failed to start session for episode: {}", ep.title);
-                failed++;
-                continue;
-            }
-
-            if (session.audioTracks.empty()) {
-                brls::Logger::error("No audio tracks for episode: {}", ep.title);
-                failed++;
-                continue;
-            }
-
-            // Get download URL
-            std::string trackUrl = client.getStreamUrl(session.audioTracks[0].contentUrl, "");
-            if (trackUrl.empty()) {
-                brls::Logger::error("Failed to get download URL for episode: {}", ep.title);
-                failed++;
-                continue;
-            }
-
-            // Determine file extension
-            std::string ext = ".mp3";
-            std::string mimeType = session.audioTracks[0].mimeType;
-            if (mimeType.find("mp4") != std::string::npos || mimeType.find("m4a") != std::string::npos) {
-                ext = ".m4a";
-            }
-
-            // Destination path
-            std::string filename = episodeId.empty() ? itemId : episodeId;
-            filename += ext;
-            std::string destPath = downloadsMgr.getDownloadsPath() + "/" + filename;
-
-            brls::Logger::info("Downloading to: {}", destPath);
-
-#ifdef __vita__
-            HttpClient httpClient;
-            httpClient.setTimeout(300);
-
-            SceUID fd = sceIoOpen(destPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
-            if (fd < 0) {
-                brls::Logger::error("Failed to create file: {}", destPath);
-                failed++;
-                continue;
-            }
-
-            int64_t totalDownloaded = 0;
-            int64_t totalSize = 0;
-            int currentEpisodeNum = static_cast<int>(i) + 1;
-
-            bool success = httpClient.downloadFile(trackUrl,
-                [&](const char* data, size_t size) -> bool {
-                    int written = sceIoWrite(fd, data, size);
-                    if (written < 0) return false;
-                    totalDownloaded += size;
-
-                    // Update progress with detailed MB info like audiobooks
-                    if (totalSize > 0) {
-                        float episodeProgress = static_cast<float>(totalDownloaded) / totalSize;
-                        float overallProgress = (static_cast<float>(i) + episodeProgress) / totalEpisodes;
-                        int percent = static_cast<int>(episodeProgress * 100);
-                        int dlMB = static_cast<int>(totalDownloaded / (1024 * 1024));
-                        int sizeMB = static_cast<int>(totalSize / (1024 * 1024));
-                        brls::sync([progressDialog, overallProgress, currentEpisodeNum, totalEpisodes, percent, dlMB, sizeMB, epTitle]() {
-                            char buf[160];
-                            snprintf(buf, sizeof(buf), "Episode %d/%d: %d%% (%d/%d MB)\n%s",
-                                    currentEpisodeNum, totalEpisodes, percent, dlMB, sizeMB, epTitle.c_str());
-                            progressDialog->setStatus(buf);
-                            progressDialog->setProgress(overallProgress);
-                        });
-                    }
-                    return true;
-                },
-                [&](int64_t size) { totalSize = size; }
-            );
-
-            sceIoClose(fd);
-
-            if (success) {
-                // Register the download - use podcast author for episodes
-                std::string coverUrl = client.getCoverUrl(itemId);
-                // Use the actual podcast author, fall back to podcast title if no author
-                std::string podcastAuthor = m_item.authorName.empty() ? m_item.title : m_item.authorName;
-                downloadsMgr.registerCompletedDownload(
-                    itemId, episodeId, ep.title, podcastAuthor,
-                    destPath, totalDownloaded, ep.duration, "episode",
-                    coverUrl, "", {}
-                );
-
-                // Download cover
-                if (!coverUrl.empty()) {
-                    downloadsMgr.downloadCoverImage(episodeId.empty() ? itemId : episodeId, coverUrl);
-                }
-
-                completed++;
-                brls::Logger::info("Downloaded episode: {}", ep.title);
-            } else {
-                sceIoRemove(destPath.c_str());
-                failed++;
-                brls::Logger::error("Failed to download episode: {}", ep.title);
-            }
-#else
-            // Non-Vita: simplified download
-            completed++;
-#endif
-        }
-
-        // Ensure state is saved
-        downloadsMgr.saveState();
-
-        // Show completion dialog
-        brls::sync([progressDialog, completed, failed, totalEpisodes]() {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "Downloaded %d of %d episodes\n(%d failed)",
-                    completed, totalEpisodes, failed);
-            progressDialog->setStatus(buf);
-            progressDialog->setProgress(1.0f);
-
-            brls::delay(2000, [progressDialog]() {
-                progressDialog->dismiss();
-            });
-        });
-
-        brls::Logger::info("batchDownloadEpisodes: Completed {} of {} episodes", completed, totalEpisodes);
-    });
-}
-
-void MediaDetailView::showDownloadOptions() {
-    if (m_item.mediaType != MediaType::PODCAST) {
-        return;
-    }
-
-    // Count episodes and find undownloaded ones
-    DownloadsManager& downloadsMgr = DownloadsManager::getInstance();
-    std::vector<MediaItem> undownloadedEpisodes;
-
-    for (const auto& ep : m_children) {
-        bool isDownloaded = downloadsMgr.isDownloaded(m_item.id, ep.episodeId);
-        if (!isDownloaded) {
-            undownloadedEpisodes.push_back(ep);
-        }
-    }
-
-    // If only 1 episode total OR only 1 undownloaded episode, download directly
-    if (m_children.size() == 1 || undownloadedEpisodes.size() == 1) {
-        if (undownloadedEpisodes.empty()) {
-            brls::Application::notify("All episodes already downloaded");
-            return;
-        }
-        // Download the single undownloaded episode directly
-        batchDownloadEpisodes(undownloadedEpisodes);
-        return;
-    }
-
-    // If no undownloaded episodes, notify and return
-    if (undownloadedEpisodes.empty()) {
-        brls::Application::notify("All episodes already downloaded");
-        return;
-    }
-
-    // Count unheard (not finished) episodes
-    int unheardCount = 0;
-    for (const auto& ep : m_children) {
-        bool isDownloaded = downloadsMgr.isDownloaded(m_item.id, ep.episodeId);
-        if (ep.progress < 1.0f && !isDownloaded) {
-            unheardCount++;
-        }
-    }
-
-    // Show full dialog for multiple episodes
-    int episodeCount = static_cast<int>(m_children.size());
-    std::string title = "Download Episodes (" + std::to_string(episodeCount) + ")";
-
-    auto* dialog = new brls::Dialog(title);
-
-    // Register circle button to close dialog
-    dialog->registerAction("Back", brls::ControllerButton::BUTTON_B, [dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
-    }, true);
-
-    // Create content box
-    auto* content = new brls::Box();
-    content->setAxis(brls::Axis::COLUMN);
-    content->setPadding(20);
-    content->setWidth(700);
-
-    // Horizontal row for the 3 download options
-    auto* optionsRow = new brls::Box();
-    optionsRow->setAxis(brls::Axis::ROW);
-    optionsRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-    optionsRow->setMarginBottom(15);
-
-    // Download All option box
-    auto* downloadAllBox = new brls::Box();
-    downloadAllBox->setAxis(brls::Axis::COLUMN);
-    downloadAllBox->setAlignItems(brls::AlignItems::CENTER);
-    downloadAllBox->setJustifyContent(brls::JustifyContent::CENTER);
-    downloadAllBox->setPadding(12);
-    downloadAllBox->setWidth(210);
-    downloadAllBox->setHeight(60);
-    downloadAllBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-    downloadAllBox->setCornerRadius(6);
-    downloadAllBox->setFocusable(true);
-
-    auto* downloadAllLabel = new brls::Label();
-    downloadAllLabel->setText("Download All");
-    downloadAllLabel->setFontSize(14);
-    downloadAllBox->addView(downloadAllLabel);
-
-    auto* downloadAllCount = new brls::Label();
-    downloadAllCount->setText("(" + std::to_string(episodeCount) + ")");
-    downloadAllCount->setFontSize(12);
-    downloadAllCount->setTextColor(nvgRGB(150, 150, 150));
-    downloadAllBox->addView(downloadAllCount);
-
-    downloadAllBox->registerClickAction([this, dialog](brls::View*) {
-        dialog->dismiss();
-        downloadAll();
-        return true;
-    });
-    optionsRow->addView(downloadAllBox);
-
-    // Download Unheard option box
-    auto* unheardBox = new brls::Box();
-    unheardBox->setAxis(brls::Axis::COLUMN);
-    unheardBox->setAlignItems(brls::AlignItems::CENTER);
-    unheardBox->setJustifyContent(brls::JustifyContent::CENTER);
-    unheardBox->setPadding(12);
-    unheardBox->setWidth(210);
-    unheardBox->setHeight(60);
-    unheardBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-    unheardBox->setCornerRadius(6);
-    unheardBox->setFocusable(true);
-
-    auto* unheardLabel = new brls::Label();
-    unheardLabel->setText("Unheard");
-    unheardLabel->setFontSize(14);
-    unheardBox->addView(unheardLabel);
-
-    auto* unheardCountLabel = new brls::Label();
-    unheardCountLabel->setText("(" + std::to_string(unheardCount) + ")");
-    unheardCountLabel->setFontSize(12);
-    unheardCountLabel->setTextColor(nvgRGB(150, 150, 150));
-    unheardBox->addView(unheardCountLabel);
-
-    unheardBox->registerClickAction([this, dialog](brls::View*) {
-        dialog->dismiss();
-        downloadUnwatched();
-        return true;
-    });
-    optionsRow->addView(unheardBox);
-
-    // Download Next 5 option box - only show if 5 or more unheard, otherwise show placeholder
-    auto* next5Box = new brls::Box();
-    next5Box->setAxis(brls::Axis::COLUMN);
-    next5Box->setAlignItems(brls::AlignItems::CENTER);
-    next5Box->setJustifyContent(brls::JustifyContent::CENTER);
-    next5Box->setPadding(12);
-    next5Box->setWidth(210);
-    next5Box->setHeight(60);
-    next5Box->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-    next5Box->setCornerRadius(6);
-
-    if (unheardCount >= 5) {
-        next5Box->setFocusable(true);
-
-        auto* next5Label = new brls::Label();
-        next5Label->setText("Next 5");
-        next5Label->setFontSize(14);
-        next5Box->addView(next5Label);
-
-        auto* next5SubLabel = new brls::Label();
-        next5SubLabel->setText("Unheard");
-        next5SubLabel->setFontSize(12);
-        next5SubLabel->setTextColor(nvgRGB(150, 150, 150));
-        next5Box->addView(next5SubLabel);
-
-        next5Box->registerClickAction([this, dialog](brls::View*) {
-            dialog->dismiss();
-            downloadUnwatched(5);
-            return true;
-        });
-    } else {
-        // Greyed out / disabled look
-        next5Box->setFocusable(false);
-        next5Box->setBackgroundColor(nvgRGBA(45, 45, 45, 255));
-
-        auto* next5Label = new brls::Label();
-        next5Label->setText("Next 5");
-        next5Label->setFontSize(14);
-        next5Label->setTextColor(nvgRGB(100, 100, 100));
-        next5Box->addView(next5Label);
-
-        auto* next5SubLabel = new brls::Label();
-        next5SubLabel->setText("(< 5 unheard)");
-        next5SubLabel->setFontSize(12);
-        next5SubLabel->setTextColor(nvgRGB(80, 80, 80));
-        next5Box->addView(next5SubLabel);
-    }
-    optionsRow->addView(next5Box);
-
-    content->addView(optionsRow);
-
-    // Separator
-    auto* separator = new brls::Rectangle();
-    separator->setHeight(1);
-    separator->setColor(nvgRGB(80, 80, 80));
-    separator->setMarginBottom(15);
-    content->addView(separator);
-
-    // Instructions
-    auto* instructionsLabel = new brls::Label();
-    instructionsLabel->setText("Or click an episode to download it:");
-    instructionsLabel->setFontSize(14);
-    instructionsLabel->setTextColor(nvgRGB(180, 180, 180));
-    instructionsLabel->setMarginBottom(10);
-    content->addView(instructionsLabel);
-
-    // Create scrolling list of episodes
-    auto* scrollView = new brls::ScrollingFrame();
-    scrollView->setHeight(280);
-
-    auto* listBox = new brls::Box();
-    listBox->setAxis(brls::Axis::COLUMN);
-
-    for (const auto& ep : m_children) {
-        bool isDownloaded = downloadsMgr.isDownloaded(m_item.id, ep.episodeId);
-
-        auto* row = new brls::Box();
-        row->setAxis(brls::Axis::ROW);
-        row->setAlignItems(brls::AlignItems::CENTER);
-        row->setPadding(12);
-        row->setMarginBottom(8);
-        row->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-        row->setCornerRadius(6);
-        row->setFocusable(true);
-
-        // Episode title
-        auto* titleLabel = new brls::Label();
-        std::string epTitle = ep.title;
-        if (epTitle.length() > 45) {
-            epTitle = epTitle.substr(0, 42) + "...";
-        }
-        titleLabel->setText(epTitle);
-        titleLabel->setFontSize(15);
-        titleLabel->setGrow(1.0f);
-        row->addView(titleLabel);
-
-        // Status indicator
-        auto* statusLabel = new brls::Label();
-        if (isDownloaded) {
-            statusLabel->setText("[OK]");
-            statusLabel->setTextColor(nvgRGB(100, 200, 100));
-        } else {
-            statusLabel->setText("[+]");
-            statusLabel->setTextColor(nvgRGB(100, 180, 100));
-        }
-        statusLabel->setFontSize(14);
-        statusLabel->setWidth(40);
-        row->addView(statusLabel);
-
-        // Click to download this episode (if not already downloaded)
-        std::string episodeId = ep.episodeId;
-        std::string episodeTitle = ep.title;
-        float episodeDuration = ep.duration;
-        row->registerClickAction([this, dialog, episodeId, episodeTitle, episodeDuration, isDownloaded](brls::View*) {
-            if (isDownloaded) {
-                brls::Application::notify("Already downloaded");
-            } else {
-                dialog->dismiss();
-                // Download single episode
-                MediaItem singleEp;
-                singleEp.episodeId = episodeId;
-                singleEp.title = episodeTitle;
-                singleEp.duration = episodeDuration;
-                batchDownloadEpisodes({singleEp});
-            }
-            return true;
-        });
-
-        listBox->addView(row);
-    }
-
-    scrollView->setContentView(listBox);
-    content->addView(scrollView);
-
-    // Close button
-    auto* closeBtn = new brls::Button();
-    closeBtn->setText("Close");
-    closeBtn->setMarginTop(15);
-    closeBtn->registerClickAction([dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
-    });
-    content->addView(closeBtn);
-
-    dialog->addView(content);
-    brls::Application::pushActivity(new brls::Activity(dialog));
-}
-
-void MediaDetailView::downloadAll() {
-    auto* progressDialog = new ProgressDialog("Preparing Downloads");
-    progressDialog->setStatus("Fetching episode list...");
-    progressDialog->show();
-
-    std::string podcastId = m_item.id;
-
-    asyncRun([this, progressDialog, podcastId]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> episodes;
-
-        if (client.fetchPodcastEpisodes(podcastId, episodes)) {
-            size_t itemCount = episodes.size();
-            brls::sync([progressDialog, itemCount]() {
-                progressDialog->setStatus("Found " + std::to_string(itemCount) + " episodes");
-            });
-
-            brls::Logger::info("downloadAll: Found {} episodes to download", episodes.size());
-
-            // Dismiss the preparation dialog and start batch download
-            brls::sync([this, progressDialog, episodes]() {
-                progressDialog->dismiss();
-                // Use the same download method as the play button
-                batchDownloadEpisodes(episodes);
-            });
-        } else {
-            brls::sync([progressDialog]() {
-                progressDialog->setStatus("Failed to fetch episodes");
-                brls::delay(1500, [progressDialog]() {
-                    progressDialog->dismiss();
-                });
-            });
-        }
-    });
-}
-
-void MediaDetailView::downloadUnwatched(int maxCount) {
-    auto* progressDialog = new ProgressDialog("Preparing Downloads");
-    progressDialog->setStatus("Fetching unheard episodes...");
-    progressDialog->show();
-
-    std::string podcastId = m_item.id;
-
-    asyncRun([this, progressDialog, podcastId, maxCount]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> unheardEpisodes;
-
-        std::vector<MediaItem> allEpisodes;
-        if (client.fetchPodcastEpisodes(podcastId, allEpisodes)) {
-            for (auto& ep : allEpisodes) {
-                // Episode is unheard if not finished AND has no progress
-                if (!ep.isFinished && ep.currentTime == 0) {
-                    unheardEpisodes.push_back(ep);
-                    if (maxCount > 0 && static_cast<int>(unheardEpisodes.size()) >= maxCount) {
-                        break;
-                    }
-                }
+void MangaDetailView::downloadAllChapters() {
+    brls::Logger::info("MangaDetailView: Downloading all chapters");
+    brls::Application::notify("Queueing all chapters for download...");
+
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        std::vector<int> chapterIndexes;
+        for (const auto& ch : m_chapters) {
+            if (!ch.downloaded) {
+                chapterIndexes.push_back(ch.index);
             }
         }
 
-        size_t itemCount = unheardEpisodes.size();
-        brls::sync([progressDialog, itemCount]() {
-            progressDialog->setStatus("Found " + std::to_string(itemCount) + " unheard");
-        });
-
-        if (unheardEpisodes.empty()) {
-            brls::sync([progressDialog]() {
-                progressDialog->setStatus("No unheard episodes found");
-                brls::delay(1500, [progressDialog]() {
-                    progressDialog->dismiss();
-                });
-            });
-            return;
-        }
-
-        brls::Logger::info("downloadUnwatched: Found {} unheard episodes to download", unheardEpisodes.size());
-
-        // Dismiss the preparation dialog and start batch download
-        brls::sync([this, progressDialog, unheardEpisodes]() {
-            progressDialog->dismiss();
-            // Use the same download method as the play button
-            batchDownloadEpisodes(unheardEpisodes);
-        });
-    });
-}
-
-void MediaDetailView::findNewEpisodes() {
-    brls::Application::notify("Checking RSS feed for new episodes...");
-
-    std::string podcastId = m_item.id;
-    std::string podcastTitle = m_item.title;
-
-    asyncRun([this, podcastId, podcastTitle]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        std::vector<MediaItem> newEpisodes;
-
-        if (client.checkNewEpisodes(podcastId, newEpisodes)) {
-            brls::sync([this, newEpisodes, podcastId, podcastTitle]() {
-                if (newEpisodes.empty()) {
-                    brls::Application::notify("No new episodes found");
-                } else {
-                    showNewEpisodesDialog(newEpisodes, podcastId, podcastTitle);
-                }
+        if (client.queueChapterDownloads(m_manga.id, chapterIndexes)) {
+            client.startDownloads();
+            brls::sync([chapterIndexes]() {
+                brls::Application::notify("Queued " + std::to_string(chapterIndexes.size()) + " chapters");
             });
         } else {
             brls::sync([]() {
-                brls::Application::notify("Failed to check for new episodes");
+                brls::Application::notify("Failed to queue downloads");
             });
         }
     });
 }
 
-void MediaDetailView::showNewEpisodesDialog(const std::vector<MediaItem>& episodes,
-                                             const std::string& podcastId,
-                                             const std::string& podcastTitle) {
-    // Create a dialog to show new episodes
-    auto* dialog = new brls::Dialog("New Episodes (" + std::to_string(episodes.size()) + ")");
+void MangaDetailView::downloadUnreadChapters() {
+    brls::Logger::info("MangaDetailView: Downloading unread chapters");
+    brls::Application::notify("Queueing unread chapters for download...");
 
-    // Register circle button to close dialog
-    dialog->registerAction("Back", brls::ControllerButton::BUTTON_B, [dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
-    }, true);
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
 
-    auto* contentBox = new brls::Box();
-    contentBox->setAxis(brls::Axis::COLUMN);
-    contentBox->setPadding(15);
-    contentBox->setWidth(700);
-
-    // Add "Download All" button at the top
-    auto* downloadAllBtn = new brls::Button();
-    downloadAllBtn->setText("Download All to Server");
-    downloadAllBtn->setMarginBottom(15);
-    downloadAllBtn->registerClickAction([this, episodes, podcastId, dialog](brls::View*) {
-        dialog->dismiss();
-        downloadNewEpisodesToServer(podcastId, episodes);
-        return true;
-    });
-    contentBox->addView(downloadAllBtn);
-
-    // Separator
-    auto* separator = new brls::Rectangle();
-    separator->setHeight(1);
-    separator->setColor(nvgRGB(80, 80, 80));
-    separator->setMarginBottom(15);
-    contentBox->addView(separator);
-
-    // Instructions
-    auto* instructionsLabel = new brls::Label();
-    instructionsLabel->setText("Select episodes to add to server:");
-    instructionsLabel->setFontSize(14);
-    instructionsLabel->setTextColor(nvgRGB(180, 180, 180));
-    instructionsLabel->setMarginBottom(10);
-    contentBox->addView(instructionsLabel);
-
-    // Create scrollable list of episodes
-    auto* scrollFrame = new brls::ScrollingFrame();
-    scrollFrame->setHeight(350);
-
-    auto* episodesList = new brls::Box();
-    episodesList->setAxis(brls::Axis::COLUMN);
-
-    // Store selected episodes
-    auto selectedEpisodes = std::make_shared<std::vector<std::string>>();
-
-    for (const auto& ep : episodes) {
-        auto* episodeRow = new brls::Box();
-        episodeRow->setAxis(brls::Axis::ROW);
-        episodeRow->setAlignItems(brls::AlignItems::CENTER);
-        episodeRow->setMarginBottom(15);  // More space between episodes
-        episodeRow->setPadding(15);
-        episodeRow->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-        episodeRow->setCornerRadius(8);
-        episodeRow->setFocusable(true);
-
-        // Episode info
-        auto* infoBox = new brls::Box();
-        infoBox->setAxis(brls::Axis::COLUMN);
-        infoBox->setGrow(1.0f);
-        infoBox->setJustifyContent(brls::JustifyContent::CENTER);
-
-        // Title - show first line
-        auto* titleLabel = new brls::Label();
-        std::string title = ep.title;
-        std::string title2;
-
-        // Split long titles into two lines
-        if (title.length() > 50) {
-            size_t splitPos = title.rfind(' ', 50);
-            if (splitPos != std::string::npos && splitPos > 20) {
-                title2 = title.substr(splitPos + 1);
-                title = title.substr(0, splitPos);
-                // Truncate second line if still too long
-                if (title2.length() > 50) {
-                    title2 = title2.substr(0, 47) + "...";
-                }
-            } else {
-                // No good split point, just truncate
-                title = title.substr(0, 47) + "...";
+        std::vector<int> chapterIndexes;
+        for (const auto& ch : m_chapters) {
+            if (!ch.downloaded && !ch.read) {
+                chapterIndexes.push_back(ch.index);
             }
         }
-        titleLabel->setText(title);
-        titleLabel->setFontSize(15);
-        infoBox->addView(titleLabel);
 
-        // Second line of title if needed
-        if (!title2.empty()) {
-            auto* title2Label = new brls::Label();
-            title2Label->setText(title2);
-            title2Label->setFontSize(14);
-            title2Label->setTextColor(nvgRGB(200, 200, 200));
-            title2Label->setMarginTop(2);
-            infoBox->addView(title2Label);
+        if (client.queueChapterDownloads(m_manga.id, chapterIndexes)) {
+            client.startDownloads();
+            brls::sync([chapterIndexes]() {
+                brls::Application::notify("Queued " + std::to_string(chapterIndexes.size()) + " chapters");
+            });
+        } else {
+            brls::sync([]() {
+                brls::Application::notify("Failed to queue downloads");
+            });
         }
-
-        if (!ep.pubDate.empty()) {
-            auto* dateLabel = new brls::Label();
-            dateLabel->setText(ep.pubDate);
-            dateLabel->setFontSize(12);
-            dateLabel->setTextColor(nvgRGB(150, 150, 150));
-            dateLabel->setMarginTop(6);
-            infoBox->addView(dateLabel);
-        }
-
-        episodeRow->addView(infoBox);
-
-        // Status label (shows "Added!" after adding)
-        auto* statusLabel = new brls::Label();
-        statusLabel->setText("");
-        statusLabel->setFontSize(14);
-        statusLabel->setTextColor(nvgRGB(100, 200, 100));
-        statusLabel->setWidth(80);
-        episodeRow->addView(statusLabel);
-
-        // Click on row to add episode - pass full episode data for new RSS episodes
-        MediaItem epCopy = ep;
-        std::string pId = podcastId;
-        episodeRow->registerClickAction([this, epCopy, pId, statusLabel](brls::View*) {
-            // Download this single episode to server with full data
-            std::vector<MediaItem> eps = {epCopy};
-            AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-            if (client.downloadNewEpisodesToServer(pId, eps)) {
-                statusLabel->setText("Added!");
-                brls::Application::notify("Episode queued for download on server");
-            } else {
-                brls::Application::notify("Failed to add episode");
-            }
-            return true;
-        });
-
-        episodesList->addView(episodeRow);
-    }
-
-    scrollFrame->setContentView(episodesList);
-    contentBox->addView(scrollFrame);
-
-    // Close button
-    auto* closeBtn = new brls::Button();
-    closeBtn->setText("Close");
-    closeBtn->setMarginTop(15);
-    closeBtn->registerClickAction([dialog](brls::View*) {
-        dialog->dismiss();
-        return true;
     });
-    contentBox->addView(closeBtn);
-
-    dialog->addView(contentBox);
-    brls::Application::pushActivity(new brls::Activity(dialog));
 }
 
-void MediaDetailView::downloadNewEpisodesToServer(const std::string& podcastId,
-                                                   const std::vector<MediaItem>& episodes) {
-    brls::Application::notify("Adding " + std::to_string(episodes.size()) + " episodes to server...");
+void MangaDetailView::deleteAllDownloads() {
+    brls::Logger::info("MangaDetailView: Deleting all downloads");
 
-    asyncRun([podcastId, episodes]() {
-        AudiobookshelfClient& client = AudiobookshelfClient::getInstance();
-        // Use full episode data for new RSS episodes
-        bool success = client.downloadNewEpisodesToServer(podcastId, episodes);
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
 
-        brls::sync([success, episodes]() {
-            if (success) {
-                brls::Application::notify("Queued " + std::to_string(episodes.size()) + " episodes for download");
-            } else {
-                brls::Application::notify("Failed to queue episodes");
+        std::vector<int> chapterIndexes;
+        for (const auto& ch : m_chapters) {
+            if (ch.downloaded) {
+                chapterIndexes.push_back(ch.index);
             }
-        });
+        }
+
+        if (client.deleteChapterDownloads(m_manga.id, chapterIndexes)) {
+            brls::sync([this]() {
+                brls::Application::notify("Downloads deleted");
+                loadChapters();  // Refresh chapter list
+            });
+        } else {
+            brls::sync([]() {
+                brls::Application::notify("Failed to delete downloads");
+            });
+        }
     });
+}
+
+void MangaDetailView::markAllRead() {
+    brls::Logger::info("MangaDetailView: Marking all chapters as read");
+
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        std::vector<int> chapterIndexes;
+        for (const auto& ch : m_chapters) {
+            if (!ch.read) {
+                chapterIndexes.push_back(ch.index);
+            }
+        }
+
+        if (client.markChaptersRead(m_manga.id, chapterIndexes)) {
+            brls::sync([this]() {
+                brls::Application::notify("Marked all as read");
+                loadChapters();  // Refresh
+            });
+        }
+    });
+}
+
+void MangaDetailView::markAllUnread() {
+    brls::Logger::info("MangaDetailView: Marking all chapters as unread");
+
+    asyncRun([this]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        std::vector<int> chapterIndexes;
+        for (const auto& ch : m_chapters) {
+            if (ch.read) {
+                chapterIndexes.push_back(ch.index);
+            }
+        }
+
+        if (client.markChaptersUnread(m_manga.id, chapterIndexes)) {
+            brls::sync([this]() {
+                brls::Application::notify("Marked all as unread");
+                loadChapters();  // Refresh
+            });
+        }
+    });
+}
+
+void MangaDetailView::onDownloadChapters() {
+    showDownloadOptions();
+}
+
+void MangaDetailView::onDeleteDownloads() {
+    brls::Dialog* dialog = new brls::Dialog("Delete all downloaded chapters?");
+
+    dialog->addButton("Cancel", [dialog]() {
+        dialog->close();
+    });
+
+    dialog->addButton("Delete", [this, dialog]() {
+        dialog->close();
+        deleteAllDownloads();
+    });
+
+    dialog->open();
+}
+
+void MangaDetailView::showChapterMenu(const Chapter& chapter) {
+    brls::Dialog* dialog = new brls::Dialog(chapter.name);
+
+    dialog->addButton("Read", [this, chapter, dialog]() {
+        dialog->close();
+        onChapterSelected(chapter);
+    });
+
+    if (chapter.read) {
+        dialog->addButton("Mark Unread", [this, chapter, dialog]() {
+            dialog->close();
+            asyncRun([this, chapter]() {
+                SuwayomiClient::getInstance().markChapterUnread(m_manga.id, chapter.index);
+                brls::sync([this]() { loadChapters(); });
+            });
+        });
+    } else {
+        dialog->addButton("Mark Read", [this, chapter, dialog]() {
+            dialog->close();
+            asyncRun([this, chapter]() {
+                SuwayomiClient::getInstance().markChapterRead(m_manga.id, chapter.index);
+                brls::sync([this]() { loadChapters(); });
+            });
+        });
+    }
+
+    if (chapter.downloaded) {
+        dialog->addButton("Delete Download", [this, chapter, dialog]() {
+            dialog->close();
+            deleteChapterDownload(chapter);
+        });
+    } else {
+        dialog->addButton("Download", [this, chapter, dialog]() {
+            dialog->close();
+            downloadChapter(chapter);
+        });
+    }
+
+    dialog->addButton("Close", [dialog]() {
+        dialog->close();
+    });
+
+    dialog->open();
+}
+
+void MangaDetailView::markChapterRead(const Chapter& chapter) {
+    asyncRun([this, chapter]() {
+        SuwayomiClient::getInstance().markChapterRead(m_manga.id, chapter.index);
+        brls::sync([this]() { loadChapters(); });
+    });
+}
+
+void MangaDetailView::downloadChapter(const Chapter& chapter) {
+    brls::Application::notify("Downloading chapter...");
+
+    asyncRun([this, chapter]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+
+        if (client.queueChapterDownload(m_manga.id, chapter.index)) {
+            client.startDownloads();
+            brls::sync([this]() {
+                brls::Application::notify("Download started");
+            });
+        } else {
+            brls::sync([]() {
+                brls::Application::notify("Failed to start download");
+            });
+        }
+    });
+}
+
+void MangaDetailView::deleteChapterDownload(const Chapter& chapter) {
+    asyncRun([this, chapter]() {
+        if (SuwayomiClient::getInstance().deleteChapterDownload(m_manga.id, chapter.index)) {
+            brls::sync([this]() {
+                brls::Application::notify("Download deleted");
+                loadChapters();
+            });
+        }
+    });
+}
+
+void MangaDetailView::showCategoryDialog() {
+    // TODO: Implement category selection
+    brls::Application::notify("Category management not yet implemented");
+}
+
+void MangaDetailView::showTrackingDialog() {
+    // TODO: Implement tracking
+    brls::Application::notify("Tracking not yet implemented");
+}
+
+void MangaDetailView::updateTracking() {
+    // TODO: Implement tracking update
 }
 
 } // namespace vitasuwayomi

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1,19 +1,16 @@
 /**
  * VitaSuwayomi - Settings Tab implementation
+ * Settings for manga reader app
  */
 
 #include "view/settings_tab.hpp"
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "app/downloads_manager.hpp"
-#include "app/temp_file_manager.hpp"
-#include "player/mpv_player.hpp"
-#include "activity/player_activity.hpp"
-#include <set>
 
 // Version defined in CMakeLists.txt or here
-#ifndef VITA_ABS_VERSION
-#define VITA_ABS_VERSION "2.0.0"
+#ifndef VITA_SUWAYOMI_VERSION
+#define VITA_SUWAYOMI_VERSION "1.0.0"
 #endif
 
 namespace vitasuwayomi {
@@ -36,13 +33,8 @@ SettingsTab::SettingsTab() {
     // Create all sections
     createAccountSection();
     createUISection();
-    createLayoutSection();
-    createContentDisplaySection();
-    createPlaybackSection();
-    createAudioSection();
-    createStreamingSection();
+    createReaderSection();
     createDownloadsSection();
-    createDebugSection();
     createAboutSection();
 
     m_scrollView->setContentView(m_contentBox);
@@ -54,16 +46,8 @@ void SettingsTab::createAccountSection() {
 
     // Section header
     auto* header = new brls::Header();
-    header->setTitle("Account");
+    header->setTitle("Server");
     m_contentBox->addView(header);
-
-    // User info cell
-    m_userLabel = new brls::Label();
-    m_userLabel->setText("User: " + (app.getUsername().empty() ? "Not logged in" : app.getUsername()));
-    m_userLabel->setFontSize(18);
-    m_userLabel->setMarginLeft(16);
-    m_userLabel->setMarginBottom(8);
-    m_contentBox->addView(m_userLabel);
 
     // Server info cell
     m_serverLabel = new brls::Label();
@@ -73,15 +57,15 @@ void SettingsTab::createAccountSection() {
     m_serverLabel->setMarginBottom(16);
     m_contentBox->addView(m_serverLabel);
 
-    // Logout button
-    auto* logoutCell = new brls::DetailCell();
-    logoutCell->setText("Logout");
-    logoutCell->setDetailText("Sign out from current account");
-    logoutCell->registerClickAction([this](brls::View* view) {
-        onLogout();
+    // Disconnect button
+    auto* disconnectCell = new brls::DetailCell();
+    disconnectCell->setText("Disconnect");
+    disconnectCell->setDetailText("Disconnect from current server");
+    disconnectCell->registerClickAction([this](brls::View* view) {
+        onDisconnect();
         return true;
     });
-    m_contentBox->addView(logoutCell);
+    m_contentBox->addView(disconnectCell);
 }
 
 void SettingsTab::createUISection() {
@@ -127,307 +111,71 @@ void SettingsTab::createUISection() {
     m_contentBox->addView(m_debugLogToggle);
 }
 
-void SettingsTab::createLayoutSection() {
-    // Layout section removed - collapse sidebar and hidden libraries settings removed
-}
-
-void SettingsTab::createContentDisplaySection() {
+void SettingsTab::createReaderSection() {
     Application& app = Application::getInstance();
     AppSettings& settings = app.getSettings();
 
     // Section header
     auto* header = new brls::Header();
-    header->setTitle("Content Display");
+    header->setTitle("Reader");
     m_contentBox->addView(header);
 
-    // Show collections toggle
-    m_collectionsToggle = new brls::BooleanCell();
-    m_collectionsToggle->init("Show Collections", settings.showCollections, [&settings](bool value) {
-        settings.showCollections = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(m_collectionsToggle);
-
-    // Show series toggle
-    auto* seriesToggle = new brls::BooleanCell();
-    seriesToggle->init("Show Series", settings.showSeries, [&settings](bool value) {
-        settings.showSeries = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(seriesToggle);
-
-    // Show authors toggle
-    auto* authorsToggle = new brls::BooleanCell();
-    authorsToggle->init("Show Authors", settings.showAuthors, [&settings](bool value) {
-        settings.showAuthors = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(authorsToggle);
-
-    // Show progress toggle
-    auto* progressToggle = new brls::BooleanCell();
-    progressToggle->init("Show Progress Bars", settings.showProgress, [&settings](bool value) {
-        settings.showProgress = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(progressToggle);
-
-    // Show only downloaded toggle
-    auto* downloadedOnlyToggle = new brls::BooleanCell();
-    downloadedOnlyToggle->init("Show Only Downloaded", settings.showOnlyDownloaded, [&settings](bool value) {
-        settings.showOnlyDownloaded = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(downloadedOnlyToggle);
-
-    // Info label for downloaded only
-    auto* downloadedInfoLabel = new brls::Label();
-    downloadedInfoLabel->setText("When enabled, library shows only downloaded content");
-    downloadedInfoLabel->setFontSize(14);
-    downloadedInfoLabel->setMarginLeft(16);
-    downloadedInfoLabel->setMarginTop(4);
-    m_contentBox->addView(downloadedInfoLabel);
-}
-
-void SettingsTab::createPlaybackSection() {
-    Application& app = Application::getInstance();
-    AppSettings& settings = app.getSettings();
-
-    // Section header
-    auto* header = new brls::Header();
-    header->setTitle("Playback");
-    m_contentBox->addView(header);
-
-    // Auto-play next toggle
-    m_autoPlayToggle = new brls::BooleanCell();
-    m_autoPlayToggle->init("Auto-Play Next Chapter", settings.autoPlayNext, [&settings](bool value) {
-        settings.autoPlayNext = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(m_autoPlayToggle);
-
-    // Resume playback toggle
-    m_resumeToggle = new brls::BooleanCell();
-    m_resumeToggle->init("Resume Playback", settings.resumePlayback, [&settings](bool value) {
-        settings.resumePlayback = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(m_resumeToggle);
-
-    // Seek interval selector
-    m_seekIntervalSelector = new brls::SelectorCell();
-    m_seekIntervalSelector->init("Seek Interval",
-        {"5 seconds", "10 seconds", "15 seconds", "30 seconds", "60 seconds"},
-        settings.seekInterval == 5 ? 0 :
-        settings.seekInterval == 10 ? 1 :
-        settings.seekInterval == 15 ? 2 :
-        settings.seekInterval == 30 ? 3 : 4,
-        [this](int index) {
-            onSeekIntervalChanged(index);
-        });
-    m_contentBox->addView(m_seekIntervalSelector);
-
-    // Playback speed selector
-    auto* speedSelector = new brls::SelectorCell();
-    speedSelector->init("Playback Speed",
-        {"0.5x", "0.75x", "1.0x", "1.25x", "1.5x", "1.75x", "2.0x"},
-        static_cast<int>(settings.playbackSpeed),
+    // Reading mode selector
+    m_readingModeSelector = new brls::SelectorCell();
+    m_readingModeSelector->init("Reading Mode",
+        {"Left to Right", "Right to Left (Manga)", "Vertical", "Webtoon"},
+        static_cast<int>(settings.readingMode),
         [&settings](int index) {
-            settings.playbackSpeed = static_cast<PlaybackSpeed>(index);
+            settings.readingMode = static_cast<ReadingMode>(index);
             Application::getInstance().saveSettings();
         });
-    m_contentBox->addView(speedSelector);
+    m_contentBox->addView(m_readingModeSelector);
 
-    // Podcast auto-complete threshold selector
-    auto* podcastCompleteSelector = new brls::SelectorCell();
-    podcastCompleteSelector->init("Podcast Auto-Complete",
-        {"Disabled", "Last 10 sec", "Last 30 sec", "Last 60 sec", "90%", "95%", "99%"},
-        static_cast<int>(settings.podcastAutoComplete),
+    // Page scale mode selector
+    m_pageScaleModeSelector = new brls::SelectorCell();
+    m_pageScaleModeSelector->init("Page Scale",
+        {"Fit Screen", "Fit Width", "Fit Height", "Original"},
+        static_cast<int>(settings.pageScaleMode),
         [&settings](int index) {
-            settings.podcastAutoComplete = static_cast<AutoCompleteThreshold>(index);
+            settings.pageScaleMode = static_cast<PageScaleMode>(index);
             Application::getInstance().saveSettings();
         });
-    m_contentBox->addView(podcastCompleteSelector);
+    m_contentBox->addView(m_pageScaleModeSelector);
 
-    // Prevent sleep toggle
-    auto* sleepToggle = new brls::BooleanCell();
-    sleepToggle->init("Prevent Screen Sleep", settings.preventSleep, [&settings](bool value) {
-        settings.preventSleep = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(sleepToggle);
-
-    // Show download progress in player
-    auto* downloadProgressToggle = new brls::BooleanCell();
-    downloadProgressToggle->init("Show Download Progress", settings.showDownloadProgress, [&settings](bool value) {
-        settings.showDownloadProgress = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(downloadProgressToggle);
-}
-
-void SettingsTab::createAudioSection() {
-    Application& app = Application::getInstance();
-    AppSettings& settings = app.getSettings();
-
-    // Section header
-    auto* header = new brls::Header();
-    header->setTitle("Audio");
-    m_contentBox->addView(header);
-
-    // Audio quality selector
-    auto* qualitySelector = new brls::SelectorCell();
-    qualitySelector->init("Audio Quality",
-        {"Original", "High (256 kbps)", "Medium (128 kbps)", "Low (64 kbps)"},
-        static_cast<int>(settings.audioQuality),
+    // Reader background selector
+    m_readerBgSelector = new brls::SelectorCell();
+    m_readerBgSelector->init("Background",
+        {"Black", "White", "Gray"},
+        static_cast<int>(settings.readerBackground),
         [&settings](int index) {
-            settings.audioQuality = static_cast<AudioQuality>(index);
+            settings.readerBackground = static_cast<ReaderBackground>(index);
             Application::getInstance().saveSettings();
         });
-    m_contentBox->addView(qualitySelector);
+    m_contentBox->addView(m_readerBgSelector);
 
-    // Volume boost toggle
-    auto* boostToggle = new brls::BooleanCell();
-    boostToggle->init("Volume Boost", settings.boostVolume, [&settings](bool value) {
-        settings.boostVolume = value;
+    // Keep screen on toggle
+    auto* keepScreenOnToggle = new brls::BooleanCell();
+    keepScreenOnToggle->init("Keep Screen On", settings.keepScreenOn, [&settings](bool value) {
+        settings.keepScreenOn = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(boostToggle);
+    m_contentBox->addView(keepScreenOnToggle);
 
-    // Show chapter list toggle
-    auto* chapterToggle = new brls::BooleanCell();
-    chapterToggle->init("Show Chapter List", settings.showChapterList, [&settings](bool value) {
-        settings.showChapterList = value;
+    // Show page number toggle
+    auto* showPageNumToggle = new brls::BooleanCell();
+    showPageNumToggle->init("Show Page Number", settings.showPageNumber, [&settings](bool value) {
+        settings.showPageNumber = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(chapterToggle);
-}
+    m_contentBox->addView(showPageNumToggle);
 
-void SettingsTab::createStreamingSection() {
-    Application& app = Application::getInstance();
-    AppSettings& settings = app.getSettings();
-
-    // Section header
-    auto* header = new brls::Header();
-    header->setTitle("Streaming Cache");
-    m_contentBox->addView(header);
-
-    // Description
-    auto* descLabel = new brls::Label();
-    descLabel->setText("Streamed audio is cached locally for faster replay");
-    descLabel->setFontSize(14);
-    descLabel->setMarginLeft(16);
-    descLabel->setMarginBottom(8);
-    m_contentBox->addView(descLabel);
-
-    // Max temp files selector
-    auto* maxFilesSelector = new brls::SelectorCell();
-    int maxFilesIndex = 0;
-    if (settings.maxTempFiles == 3) maxFilesIndex = 0;
-    else if (settings.maxTempFiles == 5) maxFilesIndex = 1;
-    else if (settings.maxTempFiles == 10) maxFilesIndex = 2;
-    else if (settings.maxTempFiles == 20) maxFilesIndex = 3;
-    else maxFilesIndex = 1; // Default to 5
-
-    maxFilesSelector->init("Max Cached Files",
-        {"3 files", "5 files", "10 files", "20 files"},
-        maxFilesIndex,
-        [&settings](int index) {
-            switch (index) {
-                case 0: settings.maxTempFiles = 3; break;
-                case 1: settings.maxTempFiles = 5; break;
-                case 2: settings.maxTempFiles = 10; break;
-                case 3: settings.maxTempFiles = 20; break;
-            }
-            Application::getInstance().saveSettings();
-        });
-    m_contentBox->addView(maxFilesSelector);
-
-    // Max temp size selector
-    auto* maxSizeSelector = new brls::SelectorCell();
-    int maxSizeIndex = 0;
-    if (settings.maxTempSizeMB == 100) maxSizeIndex = 0;
-    else if (settings.maxTempSizeMB == 250) maxSizeIndex = 1;
-    else if (settings.maxTempSizeMB == 500) maxSizeIndex = 2;
-    else if (settings.maxTempSizeMB == 1000) maxSizeIndex = 3;
-    else if (settings.maxTempSizeMB == 0) maxSizeIndex = 4;
-    else maxSizeIndex = 2; // Default to 500 MB
-
-    maxSizeSelector->init("Max Cache Size",
-        {"100 MB", "250 MB", "500 MB", "1 GB", "Unlimited"},
-        maxSizeIndex,
-        [&settings](int index) {
-            switch (index) {
-                case 0: settings.maxTempSizeMB = 100; break;
-                case 1: settings.maxTempSizeMB = 250; break;
-                case 2: settings.maxTempSizeMB = 500; break;
-                case 3: settings.maxTempSizeMB = 1000; break;
-                case 4: settings.maxTempSizeMB = 0; break; // 0 = unlimited
-            }
-            Application::getInstance().saveSettings();
-        });
-    m_contentBox->addView(maxSizeSelector);
-
-    // Save to downloads toggle
-    auto* saveToDownloadsToggle = new brls::BooleanCell();
-    saveToDownloadsToggle->init("Save to Downloads", settings.saveToDownloads, [&settings](bool value) {
-        settings.saveToDownloads = value;
+    // Tap to navigate toggle
+    auto* tapNavToggle = new brls::BooleanCell();
+    tapNavToggle->init("Tap to Navigate", settings.tapToNavigate, [&settings](bool value) {
+        settings.tapToNavigate = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(saveToDownloadsToggle);
-
-    // Save to downloads description
-    auto* saveInfoLabel = new brls::Label();
-    saveInfoLabel->setText("When enabled, streamed files are saved permanently");
-    saveInfoLabel->setFontSize(14);
-    saveInfoLabel->setMarginLeft(16);
-    saveInfoLabel->setMarginTop(4);
-    m_contentBox->addView(saveInfoLabel);
-
-    // Clear cache button
-    TempFileManager& tempMgr = TempFileManager::getInstance();
-    tempMgr.init();
-    int64_t cacheSize = tempMgr.getTotalTempSize();
-    int cacheCount = tempMgr.getTempFileCount();
-
-    auto* clearCacheCell = new brls::DetailCell();
-    clearCacheCell->setText("Clear Streaming Cache");
-
-    std::string cacheInfo;
-    if (cacheCount == 0) {
-        cacheInfo = "Empty";
-    } else {
-        // Format size
-        if (cacheSize >= 1024 * 1024) {
-            cacheInfo = std::to_string(cacheSize / (1024 * 1024)) + " MB (" + std::to_string(cacheCount) + " files)";
-        } else if (cacheSize >= 1024) {
-            cacheInfo = std::to_string(cacheSize / 1024) + " KB (" + std::to_string(cacheCount) + " files)";
-        } else {
-            cacheInfo = std::to_string(cacheSize) + " bytes (" + std::to_string(cacheCount) + " files)";
-        }
-    }
-    clearCacheCell->setDetailText(cacheInfo);
-
-    clearCacheCell->registerClickAction([clearCacheCell](brls::View* view) {
-        brls::Dialog* dialog = new brls::Dialog("Clear all cached streaming files?");
-
-        dialog->addButton("Cancel", [dialog]() {
-            dialog->close();
-        });
-
-        dialog->addButton("Clear", [dialog, clearCacheCell]() {
-            TempFileManager::getInstance().clearAllTempFiles();
-            if (clearCacheCell) {
-                clearCacheCell->setDetailText("Empty");
-            }
-            dialog->close();
-            brls::Application::notify("Streaming cache cleared");
-        });
-
-        dialog->open();
-        return true;
-    });
-    m_contentBox->addView(clearCacheCell);
+    m_contentBox->addView(tapNavToggle);
 }
 
 void SettingsTab::createDownloadsSection() {
@@ -439,48 +187,56 @@ void SettingsTab::createDownloadsSection() {
     header->setTitle("Downloads");
     m_contentBox->addView(header);
 
-    // Auto-start downloads toggle
-    m_autoStartDownloadsToggle = new brls::BooleanCell();
-    m_autoStartDownloadsToggle->init("Auto-Start Downloads", settings.autoStartDownloads, [&settings](bool value) {
-        settings.autoStartDownloads = value;
+    // Download to server toggle (use server-side downloads)
+    auto* serverDownloadToggle = new brls::BooleanCell();
+    serverDownloadToggle->init("Download to Server", settings.downloadToServer, [&settings](bool value) {
+        settings.downloadToServer = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(m_autoStartDownloadsToggle);
+    m_contentBox->addView(serverDownloadToggle);
+
+    // Info label for server downloads
+    auto* serverDlInfoLabel = new brls::Label();
+    serverDlInfoLabel->setText("When enabled, downloads are stored on the Suwayomi server");
+    serverDlInfoLabel->setFontSize(14);
+    serverDlInfoLabel->setMarginLeft(16);
+    serverDlInfoLabel->setMarginTop(4);
+    m_contentBox->addView(serverDlInfoLabel);
+
+    // Auto download new chapters toggle
+    auto* autoDownloadToggle = new brls::BooleanCell();
+    autoDownloadToggle->init("Auto-Download New Chapters", settings.autoDownloadChapters, [&settings](bool value) {
+        settings.autoDownloadChapters = value;
+        Application::getInstance().saveSettings();
+    });
+    m_contentBox->addView(autoDownloadToggle);
 
     // WiFi only toggle
-    m_wifiOnlyToggle = new brls::BooleanCell();
-    m_wifiOnlyToggle->init("Download Over WiFi Only", settings.downloadOverWifiOnly, [&settings](bool value) {
+    auto* wifiOnlyToggle = new brls::BooleanCell();
+    wifiOnlyToggle->init("Download Over WiFi Only", settings.downloadOverWifiOnly, [&settings](bool value) {
         settings.downloadOverWifiOnly = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(m_wifiOnlyToggle);
+    m_contentBox->addView(wifiOnlyToggle);
 
     // Concurrent downloads selector
-    m_concurrentDownloadsSelector = new brls::SelectorCell();
-    m_concurrentDownloadsSelector->init("Max Concurrent Downloads",
+    auto* concurrentSelector = new brls::SelectorCell();
+    concurrentSelector->init("Max Concurrent Downloads",
         {"1", "2", "3"},
         settings.maxConcurrentDownloads - 1,
         [&settings](int index) {
             settings.maxConcurrentDownloads = index + 1;
             Application::getInstance().saveSettings();
         });
-    m_contentBox->addView(m_concurrentDownloadsSelector);
+    m_contentBox->addView(concurrentSelector);
 
-    // Delete after finish toggle
-    m_deleteAfterWatchToggle = new brls::BooleanCell();
-    m_deleteAfterWatchToggle->init("Delete After Finishing", settings.deleteAfterFinish, [&settings](bool value) {
-        settings.deleteAfterFinish = value;
+    // Delete after read toggle
+    auto* deleteAfterReadToggle = new brls::BooleanCell();
+    deleteAfterReadToggle->init("Delete After Reading", settings.deleteAfterRead, [&settings](bool value) {
+        settings.deleteAfterRead = value;
         Application::getInstance().saveSettings();
     });
-    m_contentBox->addView(m_deleteAfterWatchToggle);
-
-    // Sync progress toggle
-    m_syncProgressToggle = new brls::BooleanCell();
-    m_syncProgressToggle->init("Sync Progress on Connect", settings.syncProgressOnConnect, [&settings](bool value) {
-        settings.syncProgressOnConnect = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(m_syncProgressToggle);
+    m_contentBox->addView(deleteAfterReadToggle);
 
     // Sync progress now button
     auto* syncNowCell = new brls::DetailCell();
@@ -497,7 +253,7 @@ void SettingsTab::createDownloadsSection() {
     m_clearDownloadsCell = new brls::DetailCell();
     m_clearDownloadsCell->setText("Clear All Downloads");
     auto downloads = DownloadsManager::getInstance().getDownloads();
-    m_clearDownloadsCell->setDetailText(std::to_string(downloads.size()) + " items");
+    m_clearDownloadsCell->setDetailText(std::to_string(downloads.size()) + " manga");
     m_clearDownloadsCell->registerClickAction([this](brls::View* view) {
         brls::Dialog* dialog = new brls::Dialog("Delete all downloaded content?");
 
@@ -508,10 +264,10 @@ void SettingsTab::createDownloadsSection() {
         dialog->addButton("Delete All", [dialog, this]() {
             auto downloads = DownloadsManager::getInstance().getDownloads();
             for (const auto& item : downloads) {
-                DownloadsManager::getInstance().deleteDownload(item.itemId);
+                DownloadsManager::getInstance().deleteMangaDownload(item.mangaId);
             }
             if (m_clearDownloadsCell) {
-                m_clearDownloadsCell->setDetailText("0 items");
+                m_clearDownloadsCell->setDetailText("0 manga");
             }
             dialog->close();
             brls::Application::notify("All downloads deleted");
@@ -531,32 +287,6 @@ void SettingsTab::createDownloadsSection() {
     m_contentBox->addView(pathLabel);
 }
 
-void SettingsTab::createDebugSection() {
-    // Section header
-    auto* header = new brls::Header();
-    header->setTitle("Debug");
-    m_contentBox->addView(header);
-
-    // Test local playback button
-    auto* testLocalCell = new brls::DetailCell();
-    testLocalCell->setText("Test Local Playback");
-    testLocalCell->setDetailText("ux0:data/VitaSuwayomi/test.mp3");
-    testLocalCell->registerClickAction([this](brls::View* view) {
-        onTestLocalPlayback();
-        return true;
-    });
-    m_contentBox->addView(testLocalCell);
-
-    // Info label
-    auto* infoLabel = new brls::Label();
-    infoLabel->setText("Place test.mp3 or test.mp4 in ux0:data/VitaSuwayomi/");
-    infoLabel->setFontSize(14);
-    infoLabel->setMarginLeft(16);
-    infoLabel->setMarginTop(8);
-    infoLabel->setMarginBottom(16);
-    m_contentBox->addView(infoLabel);
-}
-
 void SettingsTab::createAboutSection() {
     // Section header
     auto* header = new brls::Header();
@@ -566,16 +296,24 @@ void SettingsTab::createAboutSection() {
     // Version info
     auto* versionCell = new brls::DetailCell();
     versionCell->setText("Version");
-    versionCell->setDetailText(VITA_ABS_VERSION);
+    versionCell->setDetailText(VITA_SUWAYOMI_VERSION);
     m_contentBox->addView(versionCell);
 
     // App description
     auto* descLabel = new brls::Label();
-    descLabel->setText("VitaSuwayomi - Audiobookshelf Client for PlayStation Vita");
+    descLabel->setText("VitaSuwayomi - Manga Reader for PlayStation Vita");
     descLabel->setFontSize(16);
     descLabel->setMarginLeft(16);
     descLabel->setMarginTop(8);
     m_contentBox->addView(descLabel);
+
+    // Server info
+    auto* serverInfoLabel = new brls::Label();
+    serverInfoLabel->setText("Connects to Suwayomi-Server");
+    serverInfoLabel->setFontSize(14);
+    serverInfoLabel->setMarginLeft(16);
+    serverInfoLabel->setMarginTop(4);
+    m_contentBox->addView(serverInfoLabel);
 
     // Credit
     auto* creditLabel = new brls::Label();
@@ -587,21 +325,19 @@ void SettingsTab::createAboutSection() {
     m_contentBox->addView(creditLabel);
 }
 
-void SettingsTab::onLogout() {
-    brls::Dialog* dialog = new brls::Dialog("Are you sure you want to logout?");
+void SettingsTab::onDisconnect() {
+    brls::Dialog* dialog = new brls::Dialog("Disconnect from server?");
 
     dialog->addButton("Cancel", [dialog]() {
         dialog->close();
     });
 
-    dialog->addButton("Logout", [dialog, this]() {
+    dialog->addButton("Disconnect", [dialog, this]() {
         dialog->close();
 
-        // Clear credentials
-        AudiobookshelfClient::getInstance().logout();
-        Application::getInstance().setAuthToken("");
+        // Clear server connection
         Application::getInstance().setServerUrl("");
-        Application::getInstance().setUsername("");
+        Application::getInstance().setConnected(false);
         Application::getInstance().saveSettings();
 
         // Go back to login
@@ -618,74 +354,6 @@ void SettingsTab::onThemeChanged(int index) {
     settings.theme = static_cast<AppTheme>(index);
     app.applyTheme();
     app.saveSettings();
-}
-
-void SettingsTab::onSeekIntervalChanged(int index) {
-    Application& app = Application::getInstance();
-    AppSettings& settings = app.getSettings();
-
-    switch (index) {
-        case 0: settings.seekInterval = 5; break;
-        case 1: settings.seekInterval = 10; break;
-        case 2: settings.seekInterval = 15; break;
-        case 3: settings.seekInterval = 30; break;
-        case 4: settings.seekInterval = 60; break;
-    }
-
-    app.saveSettings();
-}
-
-
-void SettingsTab::onTestLocalPlayback() {
-    brls::Logger::info("SettingsTab: Testing local playback...");
-
-    // Check for test files
-    const std::string basePath = "ux0:data/VitaSuwayomi/";
-    std::string testFile;
-
-    std::vector<std::string> testFiles = {
-        basePath + "test.mp4",
-        basePath + "test.mp3",
-        basePath + "test.ogg",
-        basePath + "test.wav"
-    };
-
-    for (const auto& file : testFiles) {
-        FILE* f = fopen(file.c_str(), "rb");
-        if (f) {
-            fclose(f);
-            testFile = file;
-            brls::Logger::info("SettingsTab: Found test file: {}", testFile);
-            break;
-        }
-    }
-
-    if (testFile.empty()) {
-        brls::Application::notify("No test file found in ux0:data/VitaSuwayomi/");
-        brls::Logger::error("SettingsTab: No test file found");
-        return;
-    }
-
-    brls::Logger::info("SettingsTab: Pushing player activity for: {}", testFile);
-    PlayerActivity* activity = PlayerActivity::createForDirectFile(testFile);
-    brls::Application::pushActivity(activity);
-}
-
-// Stub methods for removed Plex-specific features
-void SettingsTab::createTranscodeSection() {
-    // Removed - Audiobookshelf doesn't use video transcoding
-}
-
-void SettingsTab::onQualityChanged(int index) {
-    // Removed - Audiobookshelf uses audio quality instead
-}
-
-void SettingsTab::onSubtitleSizeChanged(int index) {
-    // Removed - Audiobookshelf is audio-only
-}
-
-void SettingsTab::onManageSidebarOrder() {
-    // Removed - Simplified for Audiobookshelf
 }
 
 } // namespace vitasuwayomi


### PR DESCRIPTION
Remove all Audiobookshelf-specific code and rewrite for Suwayomi

Complete rewrite of all view files to use Suwayomi manga types:
- home_tab.cpp: Continue Reading and Recent Updates for manga
- library_section_tab.cpp: Manga library with categories and filters
- search_tab.cpp: Source browsing and manga search across sources
- settings_tab.cpp: Reader settings for manga reading modes
- media_detail_view.cpp: Manga details with chapters list
- login_activity.cpp: Server connection instead of auth
- main_activity.cpp: Library/Browse/Extensions/Downloads/Settings tabs

Added forwarding headers:
- manga_item_cell.hpp -> media_item_cell.hpp
- manga_detail_view.hpp -> media_detail_view.hpp

Removed all references to:
- AudiobookshelfClient
- MediaItem, MediaType, Library, Collection
- Podcast episodes, audiobooks, audio tracks
- Player activity and audio-related settings

---
_Generated by [Claude Code](https://claude.ai/code)_