### PR TITLE
Use correct Suwayomi GraphQL API for category filtering

### DIFF
--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -389,6 +389,7 @@ private:
     bool globalSearchGraphQL(const std::string& query, std::vector<GlobalSearchResult>& results);
     bool setMangaCategoriesGraphQL(int mangaId, const std::vector<int>& categoryIds);
     bool fetchCategoryMangaGraphQL(int categoryId, std::vector<Manga>& manga);
+    bool fetchCategoryMangaGraphQLFallback(int categoryId, std::vector<Manga>& manga);
 
     // Parse GraphQL response data
     Manga parseMangaFromGraphQL(const std::string& json);

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -44,6 +44,7 @@ private:
     void updateSortButtonText();
     void navigateToPreviousCategory();
     void navigateToNextCategory();
+    void scrollToCategoryIndex(int index);
 
     // Check if this tab is still valid (not destroyed)
     bool isValid() const { return m_alive && *m_alive; }
@@ -59,8 +60,11 @@ private:
     brls::Label* m_titleLabel = nullptr;
 
     // Category tabs row
-    brls::Box* m_categoryTabsBox = nullptr;
+    brls::Box* m_categoryTabsBox = nullptr;        // Outer container (clips)
+    brls::Box* m_categoryScrollContainer = nullptr; // Inner container (scrolls)
     std::vector<brls::Button*> m_categoryButtons;
+    float m_categoryScrollOffset = 0.0f;           // Current scroll offset
+    int m_selectedCategoryIndex = 0;               // Index of selected category
 
     // Action buttons
     brls::Button* m_updateBtn = nullptr;

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -42,6 +42,8 @@ private:
     void sortMangaList();
     void cycleSortMode();
     void updateSortButtonText();
+    void navigateToPreviousCategory();
+    void navigateToNextCategory();
 
     // Check if this tab is still valid (not destroyed)
     bool isValid() const { return m_alive && *m_alive; }
@@ -58,7 +60,6 @@ private:
 
     // Category tabs row
     brls::Box* m_categoryTabsBox = nullptr;
-    brls::ScrollingFrame* m_categoryScroller = nullptr;
     std::vector<brls::Button*> m_categoryButtons;
 
     // Action buttons

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -48,7 +48,7 @@ LibrarySectionTab::LibrarySectionTab() {
     m_categoryTabsBox->setGrow(1.0f);
     m_categoryTabsBox->setMarginLeft(0);
     m_categoryTabsBox->setMarginRight(10);
-    m_categoryTabsBox->setClipToBounds(true);
+    m_categoryTabsBox->setClipsToBounds(true);
 
     topRow->addView(m_categoryTabsBox);
 


### PR DESCRIPTION
Switches category filtering to the correct Suwayomi GraphQL API and improves the category tabs — L/R navigation, scroll-follows-focus, a layout fix, and a `setClipToBounds`→`setClipsToBounds` typo fix.

---
_Generated by [Claude Code](https://claude.ai/code)_