### PR TITLE
Scroll category tabs on focus/hover instead of click

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ target_link_libraries(${PROJECT_NAME}
     png
     bz2
 
+    # WebP decoding support for cover images
+    webp
+
     # Vita SDK stubs (provide symbols for above libraries)
     vita2d
     SceNet_stub

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <functional>
 #include <mutex>
+#include <set>
 
 // Application version
 #define VITA_SUWAYOMI_VERSION "1.0.0"
@@ -72,6 +73,7 @@ struct AppSettings {
     bool updateOnStart = false;
     bool updateOnlyWifi = true;
     int defaultCategoryId = 0;
+    std::set<int> hiddenCategoryIds;  // Categories hidden from library view
 
     // Download Settings
     bool downloadToServer = true;      // Download on server side vs local

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -391,6 +391,26 @@ private:
     bool fetchCategoryMangaGraphQL(int categoryId, std::vector<Manga>& manga);
     bool fetchCategoryMangaGraphQLFallback(int categoryId, std::vector<Manga>& manga);
 
+    // Extension GraphQL methods
+    bool fetchExtensionListGraphQL(std::vector<Extension>& extensions);
+    bool installExtensionGraphQL(const std::string& pkgName);
+    bool updateExtensionGraphQL(const std::string& pkgName);
+    bool uninstallExtensionGraphQL(const std::string& pkgName);
+
+    // Download GraphQL methods
+    bool enqueueChapterDownloadGraphQL(int chapterId);
+    bool dequeueChapterDownloadGraphQL(int chapterId);
+    bool enqueueChapterDownloadsGraphQL(const std::vector<int>& chapterIds);
+    bool startDownloadsGraphQL();
+    bool stopDownloadsGraphQL();
+    bool clearDownloadQueueGraphQL();
+
+    // Single source GraphQL
+    bool fetchSourceGraphQL(int64_t sourceId, Source& source);
+
+    // Parse extension from GraphQL
+    Extension parseExtensionFromGraphQL(const std::string& json);
+
     // Parse GraphQL response data
     Manga parseMangaFromGraphQL(const std::string& json);
     Chapter parseChapterFromGraphQL(const std::string& json);

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -9,6 +9,9 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <queue>
+#include <atomic>
+#include <condition_variable>
 
 namespace vitasuwayomi {
 
@@ -31,11 +34,34 @@ public:
     // Cancel all pending loads
     static void cancelAll();
 
+    // Set max concurrent loads (default: 4)
+    static void setMaxConcurrentLoads(int max);
+
+    // Set max thumbnail size for downscaling (default: 200)
+    static void setMaxThumbnailSize(int maxSize);
+
 private:
+    // Pending load request
+    struct LoadRequest {
+        std::string url;
+        LoadCallback callback;
+        brls::Image* target;
+    };
+
+    static void processQueue();
+    static void executeLoad(const LoadRequest& request);
+
     static std::map<std::string, std::vector<uint8_t>> s_cache;
     static std::mutex s_cacheMutex;
     static std::string s_authUsername;
     static std::string s_authPassword;
+
+    // Concurrent load limiting
+    static std::queue<LoadRequest> s_loadQueue;
+    static std::mutex s_queueMutex;
+    static std::atomic<int> s_activeLoads;
+    static int s_maxConcurrentLoads;
+    static int s_maxThumbnailSize;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -60,12 +60,12 @@ private:
     // UI Components
     brls::Label* m_titleLabel = nullptr;
 
-    // Category tabs row (windowed - only shows 5 buttons at a time)
+    // Category tabs row
     brls::Box* m_categoryTabsBox = nullptr;        // Outer container (clips)
-    brls::Box* m_categoryScrollContainer = nullptr; // Inner container
-    std::vector<brls::Button*> m_categoryButtons;  // Max 5 buttons
+    brls::Box* m_categoryScrollContainer = nullptr; // Inner container (scrolls)
+    std::vector<brls::Button*> m_categoryButtons;
     int m_selectedCategoryIndex = 0;               // Index in m_categories
-    int m_windowStartIndex = 0;                    // First category shown in window
+    float m_categoryScrollOffset = 0.0f;           // Current scroll offset
 
     // Action buttons
     brls::Button* m_updateBtn = nullptr;

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -46,6 +46,7 @@ private:
     void navigateToNextCategory();
     void scrollToCategoryIndex(int index);
     void updateCategoryButtonTexts();
+    void showCategoryMenu();
 
     // Check if this tab is still valid (not destroyed)
     bool isValid() const { return m_alive && *m_alive; }
@@ -70,13 +71,15 @@ private:
     // Action buttons
     brls::Button* m_updateBtn = nullptr;
     brls::Button* m_sortBtn = nullptr;
+    brls::Button* m_menuBtn = nullptr;
 
     // Main content grid
     RecyclingGrid* m_contentGrid = nullptr;
 
     // Data
     std::vector<Manga> m_mangaList;
-    std::vector<Category> m_categories;
+    std::vector<Category> m_categories;       // Visible categories
+    std::vector<Category> m_allCategories;    // All categories (including hidden)
 
     bool m_loaded = false;
     bool m_categoriesLoaded = false;

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -45,6 +45,7 @@ private:
     void navigateToPreviousCategory();
     void navigateToNextCategory();
     void scrollToCategoryIndex(int index);
+    void updateCategoryButtonTexts();
 
     // Check if this tab is still valid (not destroyed)
     bool isValid() const { return m_alive && *m_alive; }
@@ -59,12 +60,12 @@ private:
     // UI Components
     brls::Label* m_titleLabel = nullptr;
 
-    // Category tabs row
+    // Category tabs row (windowed - only shows 5 buttons at a time)
     brls::Box* m_categoryTabsBox = nullptr;        // Outer container (clips)
-    brls::Box* m_categoryScrollContainer = nullptr; // Inner container (scrolls)
-    std::vector<brls::Button*> m_categoryButtons;
-    float m_categoryScrollOffset = 0.0f;           // Current scroll offset
-    int m_selectedCategoryIndex = 0;               // Index of selected category
+    brls::Box* m_categoryScrollContainer = nullptr; // Inner container
+    std::vector<brls::Button*> m_categoryButtons;  // Max 5 buttons
+    int m_selectedCategoryIndex = 0;               // Index in m_categories
+    int m_windowStartIndex = 0;                    // First category shown in window
 
     // Action buttons
     brls::Button* m_updateBtn = nullptr;

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -34,7 +34,8 @@ private:
     brls::Label* m_subtitleLabel = nullptr;     // Shows author or chapter count
     brls::Label* m_descriptionLabel = nullptr;  // Shows on focus
     brls::Rectangle* m_progressBar = nullptr;   // Unread chapter indicator
-    brls::Label* m_unreadBadge = nullptr;       // Unread count badge
+    brls::Label* m_unreadBadge = nullptr;       // Unread count badge (top-right)
+    brls::Label* m_downloadBadge = nullptr;     // Download indicator (top-left)
 };
 
 // Alias for backward compatibility

--- a/include/view/settings_tab.hpp
+++ b/include/view/settings_tab.hpp
@@ -16,12 +16,14 @@ public:
 private:
     void createAccountSection();
     void createUISection();
+    void createLibrarySection();
     void createReaderSection();
     void createDownloadsSection();
     void createAboutSection();
 
     void onDisconnect();
     void onThemeChanged(int index);
+    void showCategoryVisibilityDialog();
 
     brls::ScrollingFrame* m_scrollView = nullptr;
     brls::Box* m_contentBox = nullptr;
@@ -34,6 +36,9 @@ private:
     brls::BooleanCell* m_clockToggle = nullptr;
     brls::BooleanCell* m_animationsToggle = nullptr;
     brls::BooleanCell* m_debugLogToggle = nullptr;
+
+    // Library section
+    brls::DetailCell* m_hideCategoriesCell = nullptr;
 
     // Reader section
     brls::SelectorCell* m_readingModeSelector = nullptr;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -296,6 +296,21 @@ bool Application::loadSettings() {
     m_settings.updateOnlyWifi = extractBool("updateOnlyWifi", true);
     m_settings.defaultCategoryId = extractInt("defaultCategoryId");
 
+    // Load hidden categories (comma-separated IDs)
+    m_settings.hiddenCategoryIds.clear();
+    std::string hiddenCatsStr = extractString("hiddenCategoryIds");
+    if (!hiddenCatsStr.empty()) {
+        std::stringstream ss(hiddenCatsStr);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            if (!token.empty()) {
+                int catId = atoi(token.c_str());
+                m_settings.hiddenCategoryIds.insert(catId);
+            }
+        }
+        brls::Logger::debug("Loaded {} hidden categories", m_settings.hiddenCategoryIds.size());
+    }
+
     // Load download settings
     m_settings.downloadToServer = extractBool("downloadToServer", true);
     m_settings.autoDownloadChapters = extractBool("autoDownloadChapters", false);
@@ -360,6 +375,14 @@ bool Application::saveSettings() {
     json += "  \"updateOnStart\": " + std::string(m_settings.updateOnStart ? "true" : "false") + ",\n";
     json += "  \"updateOnlyWifi\": " + std::string(m_settings.updateOnlyWifi ? "true" : "false") + ",\n";
     json += "  \"defaultCategoryId\": " + std::to_string(m_settings.defaultCategoryId) + ",\n";
+
+    // Hidden categories (stored as comma-separated IDs)
+    std::string hiddenCatsStr;
+    for (int catId : m_settings.hiddenCategoryIds) {
+        if (!hiddenCatsStr.empty()) hiddenCatsStr += ",";
+        hiddenCatsStr += std::to_string(catId);
+    }
+    json += "  \"hiddenCategoryIds\": \"" + hiddenCatsStr + "\",\n";
 
     // Download settings
     json += "  \"downloadToServer\": " + std::string(m_settings.downloadToServer ? "true" : "false") + ",\n";

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -1,5 +1,6 @@
 /**
  * VitaSuwayomi - Asynchronous Image Loader implementation
+ * With concurrent load limiting and image downscaling for PS Vita memory constraints
  */
 
 #include "utils/image_loader.hpp"
@@ -12,9 +13,44 @@
 
 namespace vitasuwayomi {
 
-// Helper function to convert WebP to TGA format (which stb_image can load)
-// TGA is simple: header + raw RGBA data
-static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t webpSize) {
+// Static member initialization
+std::map<std::string, std::vector<uint8_t>> ImageLoader::s_cache;
+std::mutex ImageLoader::s_cacheMutex;
+std::string ImageLoader::s_authUsername;
+std::string ImageLoader::s_authPassword;
+std::queue<ImageLoader::LoadRequest> ImageLoader::s_loadQueue;
+std::mutex ImageLoader::s_queueMutex;
+std::atomic<int> ImageLoader::s_activeLoads{0};
+int ImageLoader::s_maxConcurrentLoads = 4;  // Limit concurrent loads for Vita
+int ImageLoader::s_maxThumbnailSize = 200;  // Max dimension for thumbnails
+
+// Helper function to downscale RGBA image using simple box filter
+static void downscaleRGBA(const uint8_t* src, int srcW, int srcH,
+                          uint8_t* dst, int dstW, int dstH) {
+    float scaleX = (float)srcW / dstW;
+    float scaleY = (float)srcH / dstH;
+
+    for (int y = 0; y < dstH; y++) {
+        for (int x = 0; x < dstW; x++) {
+            // Simple point sampling for speed
+            int srcX = (int)(x * scaleX);
+            int srcY = (int)(y * scaleY);
+            if (srcX >= srcW) srcX = srcW - 1;
+            if (srcY >= srcH) srcY = srcH - 1;
+
+            int srcIdx = (srcY * srcW + srcX) * 4;
+            int dstIdx = (y * dstW + x) * 4;
+
+            dst[dstIdx + 0] = src[srcIdx + 0];
+            dst[dstIdx + 1] = src[srcIdx + 1];
+            dst[dstIdx + 2] = src[srcIdx + 2];
+            dst[dstIdx + 3] = src[srcIdx + 3];
+        }
+    }
+}
+
+// Helper function to convert WebP to TGA format with optional downscaling
+static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t webpSize, int maxSize) {
     std::vector<uint8_t> tgaData;
 
     // Get WebP image info
@@ -33,52 +69,198 @@ static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t web
         return tgaData;
     }
 
+    // Calculate target size with aspect ratio preservation
+    int targetW = width;
+    int targetH = height;
+    bool needsDownscale = false;
+
+    if (maxSize > 0 && (width > maxSize || height > maxSize)) {
+        float scale = (float)maxSize / std::max(width, height);
+        targetW = (int)(width * scale);
+        targetH = (int)(height * scale);
+        if (targetW < 1) targetW = 1;
+        if (targetH < 1) targetH = 1;
+        needsDownscale = true;
+        brls::Logger::debug("ImageLoader: Downscaling from {}x{} to {}x{}", width, height, targetW, targetH);
+    }
+
+    // Downscale if needed
+    uint8_t* finalRgba = rgba;
+    std::vector<uint8_t> scaledRgba;
+
+    if (needsDownscale) {
+        scaledRgba.resize(targetW * targetH * 4);
+        downscaleRGBA(rgba, width, height, scaledRgba.data(), targetW, targetH);
+        finalRgba = scaledRgba.data();
+    }
+
     // Create TGA file in memory
-    // TGA header is 18 bytes
-    size_t imageSize = width * height * 4; // RGBA
+    size_t imageSize = targetW * targetH * 4;
     tgaData.resize(18 + imageSize);
 
     // TGA header
     uint8_t* header = tgaData.data();
     memset(header, 0, 18);
     header[2] = 2;          // Uncompressed true-color image
-    header[12] = width & 0xFF;
-    header[13] = (width >> 8) & 0xFF;
-    header[14] = height & 0xFF;
-    header[15] = (height >> 8) & 0xFF;
+    header[12] = targetW & 0xFF;
+    header[13] = (targetW >> 8) & 0xFF;
+    header[14] = targetH & 0xFF;
+    header[15] = (targetH >> 8) & 0xFF;
     header[16] = 32;        // 32 bits per pixel (RGBA)
     header[17] = 0x28;      // Image descriptor: top-left origin + 8 alpha bits
 
-    // TGA stores pixels in BGRA order, bottom-to-top by default
-    // But with header[17] = 0x28, we have top-left origin
-    // Convert RGBA to BGRA
+    // Convert RGBA to BGRA for TGA
     uint8_t* pixels = tgaData.data() + 18;
-    for (int y = 0; y < height; y++) {
-        for (int x = 0; x < width; x++) {
-            int srcIdx = (y * width + x) * 4;
-            int dstIdx = (y * width + x) * 4;
-            pixels[dstIdx + 0] = rgba[srcIdx + 2];  // B
-            pixels[dstIdx + 1] = rgba[srcIdx + 1];  // G
-            pixels[dstIdx + 2] = rgba[srcIdx + 0];  // R
-            pixels[dstIdx + 3] = rgba[srcIdx + 3];  // A
+    for (int y = 0; y < targetH; y++) {
+        for (int x = 0; x < targetW; x++) {
+            int srcIdx = (y * targetW + x) * 4;
+            int dstIdx = (y * targetW + x) * 4;
+            pixels[dstIdx + 0] = finalRgba[srcIdx + 2];  // B
+            pixels[dstIdx + 1] = finalRgba[srcIdx + 1];  // G
+            pixels[dstIdx + 2] = finalRgba[srcIdx + 0];  // R
+            pixels[dstIdx + 3] = finalRgba[srcIdx + 3];  // A
         }
     }
 
     // Free WebP decoded data
     WebPFree(rgba);
 
-    brls::Logger::info("ImageLoader: Converted WebP to TGA ({} bytes)", tgaData.size());
+    brls::Logger::debug("ImageLoader: Converted WebP to TGA {}x{} ({} bytes)", targetW, targetH, tgaData.size());
     return tgaData;
 }
-
-std::map<std::string, std::vector<uint8_t>> ImageLoader::s_cache;
-std::mutex ImageLoader::s_cacheMutex;
-std::string ImageLoader::s_authUsername;
-std::string ImageLoader::s_authPassword;
 
 void ImageLoader::setAuthCredentials(const std::string& username, const std::string& password) {
     s_authUsername = username;
     s_authPassword = password;
+}
+
+void ImageLoader::setMaxConcurrentLoads(int max) {
+    s_maxConcurrentLoads = max > 0 ? max : 1;
+}
+
+void ImageLoader::setMaxThumbnailSize(int maxSize) {
+    s_maxThumbnailSize = maxSize > 0 ? maxSize : 0;
+}
+
+void ImageLoader::processQueue() {
+    std::lock_guard<std::mutex> lock(s_queueMutex);
+
+    // Process queue while we have capacity
+    while (!s_loadQueue.empty() && s_activeLoads < s_maxConcurrentLoads) {
+        LoadRequest request = s_loadQueue.front();
+        s_loadQueue.pop();
+        s_activeLoads++;
+
+        // Execute load asynchronously
+        brls::async([request]() {
+            executeLoad(request);
+            s_activeLoads--;
+            // Try to process more from queue
+            processQueue();
+        });
+    }
+}
+
+void ImageLoader::executeLoad(const LoadRequest& request) {
+    const std::string& url = request.url;
+    LoadCallback callback = request.callback;
+    brls::Image* target = request.target;
+
+    HttpClient client;
+
+    // Add authentication if credentials are set
+    if (!s_authUsername.empty() && !s_authPassword.empty()) {
+        std::string credentials = s_authUsername + ":" + s_authPassword;
+        static const char* b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::string encoded;
+        int val = 0, valb = -6;
+        for (unsigned char c : credentials) {
+            val = (val << 8) + c;
+            valb += 8;
+            while (valb >= 0) {
+                encoded.push_back(b64chars[(val >> valb) & 0x3F]);
+                valb -= 6;
+            }
+        }
+        if (valb > -6) encoded.push_back(b64chars[((val << 8) >> (valb + 8)) & 0x3F]);
+        while (encoded.size() % 4) encoded.push_back('=');
+        client.setDefaultHeader("Authorization", "Basic " + encoded);
+    }
+
+    HttpResponse resp = client.get(url);
+
+    if (resp.success && !resp.body.empty()) {
+        brls::Logger::debug("ImageLoader: Loaded {} bytes from {}", resp.body.size(), url);
+
+        // Check if it's WebP and convert to TGA
+        bool isWebP = false;
+        bool isValidImage = false;
+
+        if (resp.body.size() > 12) {
+            unsigned char* data = reinterpret_cast<unsigned char*>(resp.body.data());
+
+            // JPEG: FF D8 FF
+            if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) {
+                isValidImage = true;
+            }
+            // PNG: 89 50 4E 47
+            else if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47) {
+                isValidImage = true;
+            }
+            // GIF: 47 49 46
+            else if (data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46) {
+                isValidImage = true;
+            }
+            // WebP: RIFF....WEBP
+            else if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 &&
+                     data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50) {
+                isWebP = true;
+                isValidImage = true;
+            }
+        }
+
+        if (!isValidImage) {
+            brls::Logger::warning("ImageLoader: Invalid image format for {}", url);
+            return;
+        }
+
+        // Convert WebP to TGA if needed (with downscaling)
+        std::vector<uint8_t> imageData;
+        if (isWebP) {
+            imageData = convertWebPtoTGA(
+                reinterpret_cast<const uint8_t*>(resp.body.data()),
+                resp.body.size(),
+                s_maxThumbnailSize
+            );
+            if (imageData.empty()) {
+                brls::Logger::error("ImageLoader: WebP conversion failed for {}", url);
+                return;
+            }
+        } else {
+            imageData.assign(resp.body.begin(), resp.body.end());
+        }
+
+        // Cache the image (with size limit)
+        {
+            std::lock_guard<std::mutex> lock(s_cacheMutex);
+            // More aggressive cache eviction for Vita memory
+            if (s_cache.size() > 50) {
+                brls::Logger::debug("ImageLoader: Cache full, clearing {} entries", s_cache.size());
+                s_cache.clear();
+            }
+            s_cache[url] = imageData;
+        }
+
+        // Update UI on main thread
+        brls::sync([imageData, callback, target]() {
+            if (target) {
+                target->setImageFromMem(imageData.data(), imageData.size());
+                if (callback) callback(target);
+            }
+        });
+    } else {
+        brls::Logger::error("ImageLoader: Failed to load {}: {}", url, resp.error);
+    }
 }
 
 void ImageLoader::loadAsync(const std::string& url, LoadCallback callback, brls::Image* target) {
@@ -89,125 +271,20 @@ void ImageLoader::loadAsync(const std::string& url, LoadCallback callback, brls:
         std::lock_guard<std::mutex> lock(s_cacheMutex);
         auto it = s_cache.find(url);
         if (it != s_cache.end()) {
-            // Load from cache
             target->setImageFromMem(it->second.data(), it->second.size());
             if (callback) callback(target);
             return;
         }
     }
 
-    // Capture auth credentials for async use
-    std::string authUser = s_authUsername;
-    std::string authPass = s_authPassword;
+    // Add to queue
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        s_loadQueue.push({url, callback, target});
+    }
 
-    // Load asynchronously
-    brls::async([url, callback, target, authUser, authPass]() {
-        HttpClient client;
-
-        // Add authentication if credentials are set
-        if (!authUser.empty() && !authPass.empty()) {
-            // Base64 encode username:password for Basic Auth
-            std::string credentials = authUser + ":" + authPass;
-            static const char* b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-            std::string encoded;
-            int val = 0, valb = -6;
-            for (unsigned char c : credentials) {
-                val = (val << 8) + c;
-                valb += 8;
-                while (valb >= 0) {
-                    encoded.push_back(b64chars[(val >> valb) & 0x3F]);
-                    valb -= 6;
-                }
-            }
-            if (valb > -6) encoded.push_back(b64chars[((val << 8) >> (valb + 8)) & 0x3F]);
-            while (encoded.size() % 4) encoded.push_back('=');
-            client.setDefaultHeader("Authorization", "Basic " + encoded);
-        }
-
-        HttpResponse resp = client.get(url);
-
-        if (resp.success && !resp.body.empty()) {
-            brls::Logger::debug("ImageLoader: Loaded {} bytes from {} (status={})",
-                resp.body.size(), url, resp.statusCode);
-
-            // Check if response looks like an image (basic header check)
-            bool isValidImage = false;
-            if (resp.body.size() > 8) {
-                // Check for common image headers
-                unsigned char* data = reinterpret_cast<unsigned char*>(resp.body.data());
-                // JPEG: FF D8 FF
-                if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) {
-                    isValidImage = true;
-                }
-                // PNG: 89 50 4E 47
-                else if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47) {
-                    isValidImage = true;
-                }
-                // GIF: 47 49 46
-                else if (data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46) {
-                    isValidImage = true;
-                }
-                // WebP: RIFF....WEBP (will be converted)
-                else if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46) {
-                    brls::Logger::debug("ImageLoader: WebP detected, will convert: {}", url);
-                }
-            }
-
-            // Check if it's WebP and convert to TGA
-            bool isWebP = false;
-            if (resp.body.size() > 12) {
-                unsigned char* data = reinterpret_cast<unsigned char*>(resp.body.data());
-                // WebP: RIFF....WEBP
-                if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 &&
-                    data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50) {
-                    isWebP = true;
-                    isValidImage = true; // We'll convert it
-                }
-            }
-
-            if (!isValidImage) {
-                brls::Logger::warning("ImageLoader: Response may not be a valid image: {} (first bytes: {:02X} {:02X} {:02X})",
-                    url,
-                    resp.body.size() > 0 ? (unsigned char)resp.body[0] : 0,
-                    resp.body.size() > 1 ? (unsigned char)resp.body[1] : 0,
-                    resp.body.size() > 2 ? (unsigned char)resp.body[2] : 0);
-            }
-
-            // Convert WebP to TGA if needed
-            std::vector<uint8_t> imageData;
-            if (isWebP) {
-                imageData = convertWebPtoTGA(
-                    reinterpret_cast<const uint8_t*>(resp.body.data()),
-                    resp.body.size()
-                );
-                if (imageData.empty()) {
-                    brls::Logger::error("ImageLoader: WebP conversion failed for {}", url);
-                    return;
-                }
-            } else {
-                imageData.assign(resp.body.begin(), resp.body.end());
-            }
-
-            {
-                std::lock_guard<std::mutex> lock(s_cacheMutex);
-                // Limit cache size
-                if (s_cache.size() > 100) {
-                    s_cache.clear();
-                }
-                s_cache[url] = imageData;
-            }
-
-            // Update UI on main thread
-            brls::sync([imageData, callback, target, url]() {
-                target->setImageFromMem(imageData.data(), imageData.size());
-                if (callback) callback(target);
-            });
-        } else {
-            brls::Logger::error("ImageLoader: Failed to load {}: status={} bodySize={} error={}",
-                url, resp.statusCode, resp.body.size(),
-                resp.error.empty() ? "no error message" : resp.error);
-        }
-    });
+    // Try to process queue
+    processQueue();
 }
 
 void ImageLoader::preload(const std::string& url) {
@@ -217,82 +294,32 @@ void ImageLoader::preload(const std::string& url) {
     {
         std::lock_guard<std::mutex> lock(s_cacheMutex);
         if (s_cache.find(url) != s_cache.end()) {
-            return; // Already in cache
+            return;
         }
     }
 
-    // Capture auth credentials for async use
-    std::string authUser = s_authUsername;
-    std::string authPass = s_authPassword;
+    // Add to queue with null target
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        s_loadQueue.push({url, nullptr, nullptr});
+    }
 
-    // Preload asynchronously (no callback, just cache)
-    brls::async([url, authUser, authPass]() {
-        HttpClient client;
-
-        // Add authentication if credentials are set
-        if (!authUser.empty() && !authPass.empty()) {
-            std::string credentials = authUser + ":" + authPass;
-            static const char* b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-            std::string encoded;
-            int val = 0, valb = -6;
-            for (unsigned char c : credentials) {
-                val = (val << 8) + c;
-                valb += 8;
-                while (valb >= 0) {
-                    encoded.push_back(b64chars[(val >> valb) & 0x3F]);
-                    valb -= 6;
-                }
-            }
-            if (valb > -6) encoded.push_back(b64chars[((val << 8) >> (valb + 8)) & 0x3F]);
-            while (encoded.size() % 4) encoded.push_back('=');
-            client.setDefaultHeader("Authorization", "Basic " + encoded);
-        }
-
-        HttpResponse resp = client.get(url);
-
-        if (resp.success && !resp.body.empty()) {
-            std::vector<uint8_t> imageData;
-
-            // Check if it's WebP and convert
-            bool isWebP = false;
-            if (resp.body.size() > 12) {
-                unsigned char* data = reinterpret_cast<unsigned char*>(resp.body.data());
-                if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 &&
-                    data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50) {
-                    isWebP = true;
-                }
-            }
-
-            if (isWebP) {
-                imageData = convertWebPtoTGA(
-                    reinterpret_cast<const uint8_t*>(resp.body.data()),
-                    resp.body.size()
-                );
-                if (imageData.empty()) {
-                    brls::Logger::error("ImageLoader: WebP conversion failed for preload: {}", url);
-                    return;
-                }
-            } else {
-                imageData.assign(resp.body.begin(), resp.body.end());
-            }
-
-            std::lock_guard<std::mutex> lock(s_cacheMutex);
-            if (s_cache.size() > 100) {
-                s_cache.clear();
-            }
-            s_cache[url] = imageData;
-            brls::Logger::debug("ImageLoader: Preloaded {} bytes from {}", imageData.size(), url);
-        }
-    });
+    processQueue();
 }
 
 void ImageLoader::clearCache() {
     std::lock_guard<std::mutex> lock(s_cacheMutex);
     s_cache.clear();
+    brls::Logger::info("ImageLoader: Cache cleared");
 }
 
 void ImageLoader::cancelAll() {
-    // Borealis handles thread cancellation
+    std::lock_guard<std::mutex> lock(s_queueMutex);
+    // Clear the queue
+    while (!s_loadQueue.empty()) {
+        s_loadQueue.pop();
+    }
+    brls::Logger::info("ImageLoader: Cancelled {} pending loads", s_loadQueue.size());
 }
 
 } // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -66,9 +66,9 @@ LibrarySectionTab::LibrarySectionTab() {
 
     // Sort button
     m_sortBtn = new brls::Button();
-    m_sortBtn->setText("A-Z");
+    m_sortBtn->setText("Sort");
     m_sortBtn->setMarginLeft(10);
-    m_sortBtn->setWidth(55);
+    m_sortBtn->setWidth(70);
     m_sortBtn->setHeight(35);
     m_sortBtn->registerClickAction([this](brls::View* view) {
         cycleSortMode();
@@ -76,11 +76,11 @@ LibrarySectionTab::LibrarySectionTab() {
     });
     buttonBox->addView(m_sortBtn);
 
-    // Update button - use shorter text "Upd" to save space
+    // Update button
     m_updateBtn = new brls::Button();
-    m_updateBtn->setText("Upd");
+    m_updateBtn->setText("Update");
     m_updateBtn->setMarginLeft(8);
-    m_updateBtn->setWidth(50);
+    m_updateBtn->setWidth(90);
     m_updateBtn->setHeight(35);
     m_updateBtn->registerClickAction([this](brls::View* view) {
         triggerLibraryUpdate();

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -11,6 +11,7 @@
 #include "app/suwayomi_client.hpp"
 #include "app/downloads_manager.hpp"
 #include "utils/async.hpp"
+#include "utils/image_loader.hpp"
 
 namespace vitasuwayomi {
 
@@ -364,6 +365,10 @@ void LibrarySectionTab::loadCategoryManga(int categoryId) {
     if (m_titleLabel) {
         m_titleLabel->setText(m_currentCategoryName);
     }
+
+    // Cancel pending image loads and clear cache to free memory before loading new category
+    ImageLoader::cancelAll();
+    ImageLoader::clearCache();
 
     // Clear current display while loading
     m_mangaList.clear();

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -238,6 +238,7 @@ void LibrarySectionTab::createCategoryTabs() {
     }
 
     // Create a button for each visible category (only show name, no count)
+    int buttonIndex = 0;
     for (const auto& category : visibleCategories) {
         auto* btn = new brls::Button();
 
@@ -258,8 +259,15 @@ void LibrarySectionTab::createCategoryTabs() {
             return true;
         });
 
+        // Scroll to this button when it gains focus (hover)
+        int idx = buttonIndex;
+        btn->getFocusEvent()->subscribe([this, idx](brls::View* view) {
+            scrollToCategoryIndex(idx);
+        });
+
         m_categoryScrollContainer->addView(btn);
         m_categoryButtons.push_back(btn);
+        buttonIndex++;
     }
 
     // Store visible categories for button style updates

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -342,13 +342,13 @@ void LibrarySectionTab::updateCategoryButtonStyles() {
             isSelected = (m_categories[i].id == m_currentCategoryId);
         }
 
-        // Style the button based on selection state
+        // Style the button based on selection state (Komikku-style)
         if (isSelected) {
-            // Highlight selected category
-            btn->setBackgroundColor(nvgRGBA(80, 150, 200, 255));
+            // Highlight selected category with teal accent
+            btn->setBackgroundColor(nvgRGBA(0, 150, 136, 255));
         } else {
-            // Normal style
-            btn->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
+            // Normal style - dark gray
+            btn->setBackgroundColor(nvgRGBA(50, 50, 50, 255));
         }
     }
 }

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -89,6 +89,18 @@ LibrarySectionTab::LibrarySectionTab() {
     });
     buttonBox->addView(m_updateBtn);
 
+    // Menu button for category settings
+    m_menuBtn = new brls::Button();
+    m_menuBtn->setText("Menu");
+    m_menuBtn->setMarginLeft(8);
+    m_menuBtn->setWidth(70);
+    m_menuBtn->setHeight(40);
+    m_menuBtn->registerClickAction([this](brls::View* view) {
+        showCategoryMenu();
+        return true;
+    });
+    buttonBox->addView(m_menuBtn);
+
     topRow->addView(buttonBox);
 
     this->addView(topRow);
@@ -173,6 +185,7 @@ void LibrarySectionTab::loadCategories() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
 
+                m_allCategories = categories;  // Store all categories (including hidden)
                 m_categories = categories;
                 m_categoriesLoaded = true;
                 createCategoryTabs();
@@ -210,13 +223,20 @@ void LibrarySectionTab::createCategoryTabs() {
     m_selectedCategoryIndex = 0;
     m_categoryScrollOffset = 0.0f;
 
-    // Filter out empty categories (mangaCount == 0)
+    // Filter out empty categories (mangaCount == 0) and hidden categories
     // Also filter the "Default" category (id 0) if it's empty
     std::vector<Category> visibleCategories;
+    const auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
     for (const auto& cat : m_categories) {
         // Skip empty categories
         if (cat.mangaCount <= 0) {
             brls::Logger::debug("LibrarySectionTab: Hiding empty category '{}' (id={})",
+                              cat.name, cat.id);
+            continue;
+        }
+        // Skip hidden categories
+        if (hiddenIds.find(cat.id) != hiddenIds.end()) {
+            brls::Logger::debug("LibrarySectionTab: Hiding user-hidden category '{}' (id={})",
                               cat.name, cat.id);
             continue;
         }
@@ -594,6 +614,78 @@ void LibrarySectionTab::scrollToCategoryIndex(int index) {
 
     // Apply the scroll offset
     m_categoryScrollContainer->setTranslationX(m_categoryScrollOffset);
+}
+
+void LibrarySectionTab::showCategoryMenu() {
+    // Show dialog with category visibility options
+    brls::Dialog* dialog = new brls::Dialog("Category Settings");
+
+    // Create a scrolling container for the category list
+    auto* scrollView = new brls::ScrollingFrame();
+    scrollView->setWidth(400);
+    scrollView->setHeight(300);
+
+    auto* contentBox = new brls::Box();
+    contentBox->setAxis(brls::Axis::COLUMN);
+    contentBox->setPadding(10);
+
+    auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
+
+    // Add a toggle for each category
+    for (const auto& cat : m_allCategories) {
+        // Skip empty categories - they can't be shown anyway
+        if (cat.mangaCount <= 0) continue;
+
+        auto* toggle = new brls::BooleanCell();
+        std::string catName = cat.name;
+        if (catName.length() > 20) {
+            catName = catName.substr(0, 18) + "..";
+        }
+
+        // Category is visible if NOT in hidden list
+        bool isVisible = (hiddenIds.find(cat.id) == hiddenIds.end());
+
+        int catId = cat.id;
+        toggle->init(catName + " (" + std::to_string(cat.mangaCount) + ")", isVisible,
+            [this, catId](bool value) {
+                auto& hidden = Application::getInstance().getSettings().hiddenCategoryIds;
+                if (value) {
+                    // Show category (remove from hidden)
+                    hidden.erase(catId);
+                } else {
+                    // Hide category (add to hidden)
+                    hidden.insert(catId);
+                }
+                Application::getInstance().saveSettings();
+            });
+
+        contentBox->addView(toggle);
+    }
+
+    // If no categories, show message
+    if (m_allCategories.empty()) {
+        auto* label = new brls::Label();
+        label->setText("No categories available");
+        label->setFontSize(16);
+        contentBox->addView(label);
+    }
+
+    scrollView->setContentView(contentBox);
+
+    // Add the scroll view to the dialog
+    dialog->addView(scrollView);
+
+    dialog->addButton("Apply", [dialog, this]() {
+        dialog->close();
+        // Refresh to apply visibility changes
+        refresh();
+    });
+
+    dialog->addButton("Cancel", [dialog]() {
+        dialog->close();
+    });
+
+    dialog->open();
 }
 
 } // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -335,9 +335,9 @@ void LibrarySectionTab::updateCategoryButtonTexts() {
                 catName = "Cat " + std::to_string(m_categories[catIndex].id);
             }
 
-            // Truncate long names
-            if (catName.length() > 12) {
-                catName = catName.substr(0, 10) + "..";
+            // Truncate long names (after 25 chars)
+            if (catName.length() > 25) {
+                catName = catName.substr(0, 23) + "..";
             }
 
             btn->setText(catName);
@@ -346,12 +346,11 @@ void LibrarySectionTab::updateCategoryButtonTexts() {
             // Calculate width based on text length
             int textWidth = static_cast<int>(catName.length()) * 9 + 30;
             if (textWidth < 60) textWidth = 60;
-            if (textWidth > 120) textWidth = 120;
+            if (textWidth > 250) textWidth = 250;
             btn->setWidth(textWidth);
 
             // Set up click handler for this category
             int catId = m_categories[catIndex].id;
-            btn->clearActions();
             btn->registerClickAction([this, catId](brls::View* view) {
                 selectCategory(catId);
                 return true;

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -405,9 +405,16 @@ void MangaDetailView::populateChaptersList() {
         }
 
         // Download button - shows state based on local download state
+        // Material Design icon codepoints (UTF-8):
+        // file_download: U+E2C4, check_circle: U+E86C, hourglass: U+E88B, error: U+E000
+        static const std::string ICON_DOWNLOAD = "\xEE\x8B\x84";      // file_download
+        static const std::string ICON_CHECK = "\xEE\xA1\xAC";         // check_circle
+        static const std::string ICON_HOURGLASS = "\xEE\xA2\x8B";     // hourglass_empty
+        static const std::string ICON_ERROR = "\xEE\x80\x80";         // error
+
         Chapter capturedChapter = chapter;
         auto* dlBtn = new brls::Button();
-        dlBtn->setWidth(55);
+        dlBtn->setWidth(45);
         dlBtn->setHeight(40);
         dlBtn->setFocusable(true);
 
@@ -429,25 +436,25 @@ void MangaDetailView::populateChaptersList() {
             dlBtn->setText(std::to_string(percent) + "%");
             dlBtn->setBackgroundColor(nvgRGBA(52, 152, 219, 200));  // Blue
         } else if (isLocallyDownloaded) {
-            dlBtn->setText("OK");  // Downloaded checkmark
+            dlBtn->setText(ICON_CHECK);  // Checkmark icon
             dlBtn->setBackgroundColor(nvgRGBA(46, 204, 113, 200));  // Green
             dlBtn->registerClickAction([this, capturedChapter](brls::View* view) {
                 deleteChapterDownload(capturedChapter);
                 return true;
             });
         } else if (isLocallyQueued) {
-            dlBtn->setText("Q");  // Queued
+            dlBtn->setText(ICON_HOURGLASS);  // Hourglass icon
             dlBtn->setBackgroundColor(nvgRGBA(241, 196, 15, 200));  // Yellow
         } else if (isLocallyFailed) {
-            dlBtn->setText("ERR");  // Error
+            dlBtn->setText(ICON_ERROR);  // Error icon
             dlBtn->setBackgroundColor(nvgRGBA(231, 76, 60, 200));  // Red
             dlBtn->registerClickAction([this, capturedChapter](brls::View* view) {
                 downloadChapter(capturedChapter);  // Retry
                 return true;
             });
         } else {
-            // Not downloaded - show download button
-            dlBtn->setText("DL");
+            // Not downloaded - show download icon
+            dlBtn->setText(ICON_DOWNLOAD);  // Download icon
             dlBtn->setBackgroundColor(nvgRGBA(60, 60, 60, 200));
             dlBtn->registerClickAction([this, capturedChapter](brls::View* view) {
                 downloadChapter(capturedChapter);

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -16,12 +16,12 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     : m_manga(manga) {
     brls::Logger::info("MangaDetailView: Creating for '{}' id={}", manga.title, manga.id);
 
-    // NOBORU-style: horizontal layout with left panel (cover) and right panel (info)
+    // Komikku-style: horizontal layout with left panel (cover) and right panel (info)
     this->setAxis(brls::Axis::ROW);
     this->setJustifyContent(brls::JustifyContent::FLEX_START);
     this->setAlignItems(brls::AlignItems::STRETCH);
     this->setGrow(1.0f);
-    this->setBackgroundColor(nvgRGB(26, 26, 46)); // #1a1a2e
+    this->setBackgroundColor(nvgRGB(18, 18, 18)); // Komikku dark background
 
     // Register back button
     this->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View* view) {
@@ -34,7 +34,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     leftPanel->setAxis(brls::Axis::COLUMN);
     leftPanel->setWidth(260);
     leftPanel->setPadding(20);
-    leftPanel->setBackgroundColor(nvgRGB(22, 33, 62)); // #16213e
+    leftPanel->setBackgroundColor(nvgRGB(28, 28, 28)); // Komikku side panel
 
     // Cover image container (centered)
     auto* coverContainer = new brls::Box();
@@ -45,16 +45,17 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_coverImage = new brls::Image();
     m_coverImage->setSize(brls::Size(180, 260));
     m_coverImage->setScalingType(brls::ImageScalingType::FIT);
-    m_coverImage->setCornerRadius(4);
+    m_coverImage->setCornerRadius(12);  // Komikku-style rounded corners
     coverContainer->addView(m_coverImage);
     leftPanel->addView(coverContainer);
 
-    // Continue Reading button (teal/primary)
+    // Continue Reading button (Komikku teal accent)
     m_readButton = new brls::Button();
     m_readButton->setWidth(220);
     m_readButton->setHeight(44);
-    m_readButton->setMarginBottom(8);
-    m_readButton->setCornerRadius(6);
+    m_readButton->setMarginBottom(10);
+    m_readButton->setCornerRadius(22);  // Pill-shaped button
+    m_readButton->setBackgroundColor(nvgRGBA(0, 150, 136, 255)); // Teal
 
     std::string readText = "Start Reading";
     if (m_manga.lastChapterRead > 0) {
@@ -73,8 +74,9 @@ MangaDetailView::MangaDetailView(const Manga& manga)
         m_libraryButton = new brls::Button();
         m_libraryButton->setWidth(220);
         m_libraryButton->setHeight(44);
-        m_libraryButton->setMarginBottom(8);
-        m_libraryButton->setCornerRadius(6);
+        m_libraryButton->setMarginBottom(10);
+        m_libraryButton->setCornerRadius(22);  // Pill-shaped
+        m_libraryButton->setBackgroundColor(nvgRGBA(66, 66, 66, 255));
         m_libraryButton->setText("Add to Library");
         m_libraryButton->registerClickAction([this](brls::View* view) {
             onAddToLibrary();
@@ -88,7 +90,8 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_downloadButton = new brls::Button();
     m_downloadButton->setWidth(220);
     m_downloadButton->setHeight(44);
-    m_downloadButton->setCornerRadius(6);
+    m_downloadButton->setCornerRadius(22);  // Pill-shaped
+    m_downloadButton->setBackgroundColor(nvgRGBA(66, 66, 66, 255));
     m_downloadButton->setText("Download");
     m_downloadButton->registerClickAction([this](brls::View* view) {
         showDownloadOptions();
@@ -345,7 +348,7 @@ void MangaDetailView::populateChaptersList() {
                   });
     }
 
-    // Create chapter cells (NOBORU style: 60px height each)
+    // Create chapter cells (Komikku-style: rounded, clean design)
     for (const auto& chapter : sortedChapters) {
         if (m_filterDownloaded && !chapter.downloaded) continue;
         if (m_filterUnread && chapter.read) continue;
@@ -354,9 +357,11 @@ void MangaDetailView::populateChaptersList() {
         chapterRow->setAxis(brls::Axis::ROW);
         chapterRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
         chapterRow->setAlignItems(brls::AlignItems::CENTER);
-        chapterRow->setHeight(60);
-        chapterRow->setPadding(8, 12, 8, 12);
-        chapterRow->setMarginBottom(2);
+        chapterRow->setHeight(56);
+        chapterRow->setPadding(10, 14, 10, 14);
+        chapterRow->setMarginBottom(4);
+        chapterRow->setCornerRadius(8);
+        chapterRow->setBackgroundColor(nvgRGBA(40, 40, 40, 255));
         chapterRow->setFocusable(true);
 
         // Left side: chapter info
@@ -414,8 +419,9 @@ void MangaDetailView::populateChaptersList() {
 
         Chapter capturedChapter = chapter;
         auto* dlBtn = new brls::Button();
-        dlBtn->setWidth(45);
-        dlBtn->setHeight(40);
+        dlBtn->setWidth(40);
+        dlBtn->setHeight(36);
+        dlBtn->setCornerRadius(18);  // Circular button
         dlBtn->setFocusable(true);
 
         // Check local download state first

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -63,7 +63,7 @@ MangaItemCell::MangaItemCell() {
     // Cover image - fills the card
     m_thumbnailImage = new brls::Image();
     m_thumbnailImage->setSize(brls::Size(140, 180));
-    m_thumbnailImage->setScalingType(brls::ImageScalingType::CROP);
+    m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
     m_thumbnailImage->setCornerRadius(8);
     this->addView(m_thumbnailImage);
 
@@ -99,11 +99,10 @@ MangaItemCell::MangaItemCell() {
     m_unreadBadge->setFontSize(10);
     m_unreadBadge->setTextColor(nvgRGB(255, 255, 255));
     m_unreadBadge->setBackgroundColor(nvgRGBA(0, 150, 136, 255)); // Teal badge
-    m_unreadBadge->setPadding(2, 6, 2, 6);
-    m_unreadBadge->setCornerRadius(10);
+    m_unreadBadge->setMargins(6, 6, 0, 0);
     m_unreadBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_unreadBadge->setPositionTop(6);
-    m_unreadBadge->setPositionRight(6);
+    m_unreadBadge->setPositionTop(0);
+    m_unreadBadge->setPositionRight(0);
     m_unreadBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_unreadBadge);
 
@@ -112,11 +111,10 @@ MangaItemCell::MangaItemCell() {
     m_downloadBadge->setFontSize(12);
     m_downloadBadge->setTextColor(nvgRGB(255, 255, 255));
     m_downloadBadge->setBackgroundColor(nvgRGBA(76, 175, 80, 255)); // Green badge
-    m_downloadBadge->setPadding(2, 4, 2, 4);
-    m_downloadBadge->setCornerRadius(4);
+    m_downloadBadge->setMargins(6, 0, 0, 6);
     m_downloadBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_downloadBadge->setPositionTop(6);
-    m_downloadBadge->setPositionLeft(6);
+    m_downloadBadge->setPositionTop(0);
+    m_downloadBadge->setPositionLeft(0);
     m_downloadBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_downloadBadge);
 
@@ -170,8 +168,8 @@ void MangaItemCell::setManga(const Manga& manga) {
     if (m_downloadBadge) {
         static const std::string ICON_CHECK = "\xEE\xA1\xAC";  // check_circle
         DownloadsManager& dm = DownloadsManager::getInstance();
-        auto downloads = dm.getMangaDownloads(manga.id);
-        if (!downloads.empty()) {
+        DownloadItem* download = dm.getMangaDownload(manga.id);
+        if (download != nullptr) {
             m_downloadBadge->setText(ICON_CHECK);
             m_downloadBadge->setVisibility(brls::Visibility::VISIBLE);
         } else {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -16,8 +16,8 @@ RecyclingGrid::RecyclingGrid() {
     m_contentBox->setPadding(10);
     this->setContentView(m_contentBox);
 
-    // PS Vita screen: 960x544, use 5 columns of 150px square items
-    m_columns = 5;
+    // PS Vita screen: 960x544, use 6 columns for Komikku-style layout
+    m_columns = 6;
     m_visibleRows = 3;
 }
 
@@ -59,9 +59,9 @@ void RecyclingGrid::rebuildGrid() {
 
         auto* cell = new MangaItemCell();
         cell->setManga(m_items[i]);
-        cell->setWidth(150);
-        cell->setHeight(185);  // Square cover (140) + labels (~45)
-        cell->setMarginRight(10);
+        cell->setWidth(140);
+        cell->setHeight(180);  // Komikku-style: cover with title overlay
+        cell->setMarginRight(12);
 
         int index = (int)i;
         cell->registerClickAction([this, index](brls::View* view) {


### PR DESCRIPTION
Improves the library category tabs and book view: scroll tabs on focus/hover, fix cutoff/blank buttons, larger Sort/Update buttons, per-chapter download buttons, local downloads to Vita storage, category hiding, a Komikku-style redesign, WebP cover decoding, and cover-loading performance and crash fixes for libraries of 30+ books.

---
_Generated by [Claude Code](https://claude.ai/code)_