### PR TITLE
Fix download icons and add NOBORU-style touch controls

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -84,6 +84,7 @@ private:
     void preloadAdjacentPages();
     void markChapterAsRead();
     void applySettings();
+    void saveSettingsToApp();  // Persist settings to AppSettings
 
     // Touch handling
     void handleTouch(brls::Point point);

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -98,6 +98,7 @@ private:
     // UI components - NOBORU style
     BRLS_BIND(brls::Box, container, "reader/container");
     BRLS_BIND(RotatableImage, pageImage, "reader/page_image");
+    BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");  // Preview of next/prev page
     BRLS_BIND(brls::Box, topBar, "reader/top_bar");
     BRLS_BIND(brls::Box, bottomBar, "reader/bottom_bar");
     BRLS_BIND(brls::Box, pageCounter, "reader/page_counter");
@@ -139,6 +140,16 @@ private:
     bool m_isPanning = false;
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
+
+    // NOBORU-style swipe animation (partial page preview)
+    bool m_isSwipeAnimating = false;
+    float m_swipeOffset = 0.0f;           // Current swipe offset in pixels
+    int m_previewPageIndex = -1;          // Index of page being previewed (-1 = none)
+    bool m_previewIsNext = true;          // true = previewing next page, false = previous
+    void updateSwipePreview(float offset);
+    void loadPreviewPage(int index);
+    void completeSwipeAnimation(bool turnPage);
+    void resetSwipeState();
 
     // NOBORU-style touch controls
     // Double-tap detection

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -98,6 +98,7 @@ private:
     // UI components - NOBORU style
     BRLS_BIND(brls::Box, container, "reader/container");
     BRLS_BIND(RotatableImage, pageImage, "reader/page_image");
+    BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");  // Preview page for swipe
     BRLS_BIND(brls::Box, topBar, "reader/top_bar");
     BRLS_BIND(brls::Box, bottomBar, "reader/bottom_bar");
     BRLS_BIND(brls::Box, pageCounter, "reader/page_counter");
@@ -149,12 +150,13 @@ private:
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
 
-    // NOBORU-style swipe animation (shows margins during swipe)
+    // NOBORU-style swipe animation (shows next/prev page sliding in)
     bool m_isSwipeAnimating = false;
     float m_swipeOffset = 0.0f;           // Current swipe offset in pixels
-    int m_targetPageIndex = -1;           // Index of page to navigate to (-1 = none)
+    int m_previewPageIndex = -1;          // Index of page being previewed (-1 = none)
     bool m_swipingToNext = true;          // true = swiping to next page, false = previous
-    void updateSwipeMargins(float offset);
+    void updateSwipePreview(float offset);
+    void loadPreviewPage(int index);
     void completeSwipeAnimation(bool turnPage);
     void resetSwipeState();
 

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <borealis.hpp>
+#include <chrono>
 #include "app/suwayomi_client.hpp"
 #include "app/application.hpp"
 #include "view/rotatable_image.hpp"
@@ -138,6 +139,29 @@ private:
     bool m_isPanning = false;
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
+
+    // NOBORU-style touch controls
+    // Double-tap detection
+    std::chrono::steady_clock::time_point m_lastTapTime;
+    brls::Point m_lastTapPosition;
+    static constexpr int DOUBLE_TAP_THRESHOLD_MS = 300;  // Max time between taps
+    static constexpr float DOUBLE_TAP_DISTANCE = 50.0f;  // Max distance between taps
+
+    // Zoom state
+    bool m_isZoomed = false;
+    float m_zoomLevel = 1.0f;
+    brls::Point m_zoomOffset = {0, 0};
+
+    // Multi-touch tracking for pinch-to-zoom
+    bool m_isPinching = false;
+    float m_initialPinchDistance = 0.0f;
+    float m_initialZoomLevel = 1.0f;
+
+    // Touch control methods
+    void handleDoubleTap(brls::Point position);
+    void handlePinchZoom(float scaleFactor);
+    void resetZoom();
+    void zoomTo(float level, brls::Point center);
 };
 
 } // namespace vitasuwayomi

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -98,7 +98,6 @@ private:
     // UI components - NOBORU style
     BRLS_BIND(brls::Box, container, "reader/container");
     BRLS_BIND(RotatableImage, pageImage, "reader/page_image");
-    BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");  // Preview of next/prev page
     BRLS_BIND(brls::Box, topBar, "reader/top_bar");
     BRLS_BIND(brls::Box, bottomBar, "reader/bottom_bar");
     BRLS_BIND(brls::Box, pageCounter, "reader/page_counter");
@@ -133,21 +132,29 @@ private:
     std::vector<Chapter> m_chapters;
     int m_totalChapters = 0;
 
+    // Next chapter preloading
+    std::vector<Page> m_nextChapterPages;
+    bool m_nextChapterLoaded = false;
+    void preloadNextChapter();
+
     // Image caching (preloaded pages)
     std::map<int, std::string> m_cachedImages;
+
+    // Dark mode support
+    bool m_isDarkMode = true;
+    void updateMarginColors();
 
     // Touch gesture tracking
     bool m_isPanning = false;
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
 
-    // NOBORU-style swipe animation (partial page preview)
+    // NOBORU-style swipe animation (shows margins during swipe)
     bool m_isSwipeAnimating = false;
     float m_swipeOffset = 0.0f;           // Current swipe offset in pixels
-    int m_previewPageIndex = -1;          // Index of page being previewed (-1 = none)
-    bool m_previewIsNext = true;          // true = previewing next page, false = previous
-    void updateSwipePreview(float offset);
-    void loadPreviewPage(int index);
+    int m_targetPageIndex = -1;           // Index of page to navigate to (-1 = none)
+    bool m_swipingToNext = true;          // true = swiping to next page, false = previous
+    void updateSwipeMargins(float offset);
     void completeSwipeAnimation(bool turnPage);
     void resetSwipeState();
 

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -65,6 +65,7 @@ struct AppSettings {
     ReadingMode readingMode = ReadingMode::RIGHT_TO_LEFT;
     PageScaleMode pageScaleMode = PageScaleMode::FIT_SCREEN;
     ReaderBackground readerBackground = ReaderBackground::BLACK;
+    int imageRotation = 0;  // 0, 90, 180, or 270 degrees
     bool keepScreenOn = true;
     bool showPageNumber = true;
     bool tapToNavigate = true;

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -22,11 +22,17 @@ public:
     // Set authentication credentials for image loading
     static void setAuthCredentials(const std::string& username, const std::string& password);
 
-    // Load image asynchronously from URL
+    // Load image asynchronously from URL (with thumbnail downscaling)
     static void loadAsync(const std::string& url, LoadCallback callback, brls::Image* target);
+
+    // Load full-size image asynchronously (no downscaling - for manga reader)
+    static void loadAsyncFullSize(const std::string& url, LoadCallback callback, brls::Image* target);
 
     // Preload image to cache without displaying
     static void preload(const std::string& url);
+
+    // Preload full-size image to cache (for manga reader)
+    static void preloadFullSize(const std::string& url);
 
     // Clear image cache
     static void clearCache();
@@ -46,6 +52,7 @@ private:
         std::string url;
         LoadCallback callback;
         brls::Image* target;
+        bool fullSize;  // true = no downscaling
     };
 
     static void processQueue();

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <borealis.hpp>
+#include "view/rotatable_image.hpp"
 #include <string>
 #include <functional>
 #include <map>
@@ -18,15 +19,19 @@ namespace vitasuwayomi {
 class ImageLoader {
 public:
     using LoadCallback = std::function<void(brls::Image*)>;
+    using RotatableLoadCallback = std::function<void(RotatableImage*)>;
 
     // Set authentication credentials for image loading
     static void setAuthCredentials(const std::string& username, const std::string& password);
 
-    // Load image asynchronously from URL (with thumbnail downscaling)
+    // Load image asynchronously from URL (with thumbnail downscaling) - for brls::Image
     static void loadAsync(const std::string& url, LoadCallback callback, brls::Image* target);
 
-    // Load full-size image asynchronously (no downscaling - for manga reader)
+    // Load full-size image asynchronously (no downscaling - for manga reader) - for brls::Image
     static void loadAsyncFullSize(const std::string& url, LoadCallback callback, brls::Image* target);
+
+    // Load full-size image asynchronously for RotatableImage (custom rendering)
+    static void loadAsyncFullSize(const std::string& url, RotatableLoadCallback callback, RotatableImage* target);
 
     // Preload image to cache without displaying
     static void preload(const std::string& url);
@@ -47,7 +52,7 @@ public:
     static void setMaxThumbnailSize(int maxSize);
 
 private:
-    // Pending load request
+    // Pending load request for brls::Image
     struct LoadRequest {
         std::string url;
         LoadCallback callback;
@@ -55,8 +60,16 @@ private:
         bool fullSize;  // true = no downscaling
     };
 
+    // Pending load request for RotatableImage
+    struct RotatableLoadRequest {
+        std::string url;
+        RotatableLoadCallback callback;
+        RotatableImage* target;
+    };
+
     static void processQueue();
     static void executeLoad(const LoadRequest& request);
+    static void executeRotatableLoad(const RotatableLoadRequest& request);
 
     static std::map<std::string, std::vector<uint8_t>> s_cache;
     static std::mutex s_cacheMutex;
@@ -65,6 +78,7 @@ private:
 
     // Concurrent load limiting
     static std::queue<LoadRequest> s_loadQueue;
+    static std::queue<RotatableLoadRequest> s_rotatableLoadQueue;
     static std::mutex s_queueMutex;
     static std::atomic<int> s_activeLoads;
     static int s_maxConcurrentLoads;

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -32,11 +32,17 @@ public:
      */
     void cycleRotation();
 
+    /**
+     * Set background color (shown in margins when image doesn't fill view)
+     */
+    void setBackgroundFillColor(NVGcolor color) { m_bgColor = color; }
+
     static brls::View* create();
 
 private:
     float m_rotationDegrees = 0.0f;
     float m_rotationRadians = 0.0f;
+    NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Default dark mode color
 };
 
 } // namespace vitasuwayomi

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -1,21 +1,37 @@
 /**
- * RotatableImage - Image view with rotation support
- * Extends brls::Image to add rotation capability (0, 90, 180, 270 degrees)
+ * RotatableImage - Custom image view with rotation support and no edge artifacts
+ * Uses direct NanoVG rendering to avoid borealis Image edge clamping issues
  */
 
 #pragma once
 
 #include <borealis.hpp>
+#include <string>
 
 namespace vitasuwayomi {
 
-class RotatableImage : public brls::Image {
+class RotatableImage : public brls::Box {
 public:
     RotatableImage();
-    ~RotatableImage() = default;
+    ~RotatableImage();
 
     void draw(NVGcontext* vg, float x, float y, float width, float height,
               brls::Style style, brls::FrameContext* ctx) override;
+
+    /**
+     * Set image from memory buffer (TGA, PNG, JPG data)
+     */
+    void setImageFromMem(const unsigned char* data, size_t size);
+
+    /**
+     * Set image from file path
+     */
+    void setImageFromFile(const std::string& path);
+
+    /**
+     * Clear the current image
+     */
+    void clearImage();
 
     /**
      * Set rotation in degrees (0, 90, 180, 270)
@@ -33,16 +49,40 @@ public:
     void cycleRotation();
 
     /**
+     * Set scaling type (FIT maintains aspect ratio)
+     */
+    void setScalingType(brls::ImageScalingType type) { m_scalingType = type; }
+
+    /**
      * Set background color (shown in margins when image doesn't fill view)
      */
     void setBackgroundFillColor(NVGcolor color) { m_bgColor = color; }
 
+    /**
+     * Get image dimensions
+     */
+    int getImageWidth() const { return m_imageWidth; }
+    int getImageHeight() const { return m_imageHeight; }
+
+    /**
+     * Check if image is loaded
+     */
+    bool hasImage() const { return m_nvgImage != 0; }
+
     static brls::View* create();
 
 private:
+    int m_nvgImage = 0;           // NanoVG image handle
+    int m_imageWidth = 0;
+    int m_imageHeight = 0;
     float m_rotationDegrees = 0.0f;
     float m_rotationRadians = 0.0f;
+    brls::ImageScalingType m_scalingType = brls::ImageScalingType::FIT;
     NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Default dark mode color
+
+    // Calculate image bounds for current scaling type
+    void calculateImageBounds(float viewX, float viewY, float viewW, float viewH,
+                              float& imgX, float& imgY, float& imgW, float& imgH);
 };
 
 } // namespace vitasuwayomi

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -9,6 +9,17 @@
     alignItems="center"
     backgroundColor="#1a1a2e">
 
+    <!-- Preview page (slides in during swipe) - hidden by default, positioned off-screen -->
+    <RotatableImage
+        id="reader/preview_image"
+        width="100%"
+        height="100%"
+        scalingType="fit"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="gone"/>
+
     <!-- Main page display area - fills entire screen (960x544) -->
     <!-- Background shows through when page doesn't fill screen (dark/light mode aware) -->
     <RotatableImage

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -14,7 +14,6 @@
         id="reader/preview_image"
         width="100%"
         height="100%"
-        scalingType="fit"
         positionType="absolute"
         positionTop="0"
         positionLeft="0"
@@ -25,7 +24,6 @@
         id="reader/page_image"
         width="100%"
         height="100%"
-        scalingType="fit"
         grow="1"/>
 
     <!-- Page counter overlay (top-right, auto-hides) -->

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -9,7 +9,7 @@
     alignItems="center"
     backgroundColor="#1a1a2e">
 
-    <!-- Preview page (slides in during swipe) - hidden by default, positioned off-screen -->
+    <!-- Preview page (slides in during swipe) - hidden by default -->
     <RotatableImage
         id="reader/preview_image"
         width="100%"
@@ -20,8 +20,7 @@
         positionLeft="0"
         visibility="gone"/>
 
-    <!-- Main page display area - fills entire screen (960x544) -->
-    <!-- Background shows through when page doesn't fill screen (dark/light mode aware) -->
+    <!-- Main page display area -->
     <RotatableImage
         id="reader/page_image"
         width="100%"

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -9,18 +9,8 @@
     alignItems="center"
     backgroundColor="#1a1a2e">
 
-    <!-- Preview page (for NOBORU-style swipe animation) - hidden by default -->
-    <RotatableImage
-        id="reader/preview_image"
-        width="100%"
-        height="100%"
-        scalingType="fit"
-        positionType="absolute"
-        positionTop="0"
-        positionLeft="960"
-        visibility="gone"/>
-
     <!-- Main page display area - fills entire screen (960x544) -->
+    <!-- Background shows through when page doesn't fill screen (dark/light mode aware) -->
     <RotatableImage
         id="reader/page_image"
         width="100%"

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -9,6 +9,17 @@
     alignItems="center"
     backgroundColor="#1a1a2e">
 
+    <!-- Preview page (for NOBORU-style swipe animation) - hidden by default -->
+    <RotatableImage
+        id="reader/preview_image"
+        width="100%"
+        height="100%"
+        scalingType="fit"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="960"
+        visibility="gone"/>
+
     <!-- Main page display area - fills entire screen (960x544) -->
     <RotatableImage
         id="reader/page_image"

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -398,10 +398,10 @@ void ReaderActivity::loadPage(int index) {
     showPageCounter();
     schedulePageCounterHide();
 
-    // Load image
+    // Load image using RotatableImage (with scissor clipping to prevent edge artifacts)
     if (pageImage) {
         int currentPageAtLoad = m_currentPage;
-        ImageLoader::loadAsyncFullSize(imageUrl, [this, index, currentPageAtLoad](brls::Image* img) {
+        ImageLoader::loadAsyncFullSize(imageUrl, [this, index, currentPageAtLoad](RotatableImage* img) {
             if (index == currentPageAtLoad) {
                 brls::Logger::debug("ReaderActivity: Page {} loaded", index);
             }
@@ -877,7 +877,7 @@ void ReaderActivity::loadPreviewPage(int index) {
     brls::Logger::debug("Loading preview page {}", index);
 
     // Load the preview image (full size for manga reader)
-    ImageLoader::loadAsyncFullSize(imageUrl, [this, index](brls::Image* img) {
+    ImageLoader::loadAsyncFullSize(imageUrl, [this, index](RotatableImage* img) {
         brls::Logger::debug("Preview page {} loaded", index);
     }, previewImage);
 }

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -918,16 +918,28 @@ void ReaderActivity::resetSwipeState() {
 }
 
 void ReaderActivity::updateMarginColors() {
-    // Set container background based on dark/light mode
+    // Set background color based on dark/light mode
     // This shows when the manga page doesn't fill the screen
+    NVGcolor bgColor;
+    if (m_isDarkMode) {
+        // Dark mode - dark gray background
+        bgColor = nvgRGBA(26, 26, 46, 255);  // #1a1a2e
+    } else {
+        // Light mode - light gray/white background
+        bgColor = nvgRGBA(240, 240, 245, 255);  // #f0f0f5
+    }
+
+    // Set container background
     if (container) {
-        if (m_isDarkMode) {
-            // Dark mode - dark gray background
-            container->setBackgroundColor(nvgRGBA(26, 26, 46, 255));  // #1a1a2e
-        } else {
-            // Light mode - light gray/white background
-            container->setBackgroundColor(nvgRGBA(240, 240, 245, 255));  // #f0f0f5
-        }
+        container->setBackgroundColor(bgColor);
+    }
+
+    // Set image background colors (prevents edge artifacts)
+    if (pageImage) {
+        pageImage->setBackgroundFillColor(bgColor);
+    }
+    if (previewImage) {
+        previewImage->setBackgroundFillColor(bgColor);
     }
 }
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -138,7 +138,7 @@ void ReaderActivity::onContentAvailable() {
                     m_touchCurrent = status.position;
                     m_swipeOffset = 0.0f;
                     m_previewPageIndex = -1;
-                } else if (status.state == brls::GestureState::CHANGED) {
+                } else if (status.state == brls::GestureState::UPDATE) {
                     // Real-time swipe tracking for preview
                     m_touchCurrent = status.position;
                     float dx = m_touchCurrent.x - m_touchStart.x;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -727,18 +727,17 @@ void ReaderActivity::showSettings() {
 void ReaderActivity::applySettings() {
     if (!pageImage) return;
 
-    // Apply scaling mode
+    // Apply scaling mode - always use FIT to maintain aspect ratio
+    // This ensures the manga page is never stretched/distorted
+    // Margins will show when page doesn't fill screen (dark/light mode aware)
     switch (m_settings.scaleMode) {
         case ReaderScaleMode::FIT_SCREEN:
-            pageImage->setScalingType(brls::ImageScalingType::FIT);
-            break;
         case ReaderScaleMode::FIT_WIDTH:
-            pageImage->setScalingType(brls::ImageScalingType::STRETCH);
-            break;
         case ReaderScaleMode::FIT_HEIGHT:
             pageImage->setScalingType(brls::ImageScalingType::FIT);
             break;
         case ReaderScaleMode::ORIGINAL:
+            // FILL maintains aspect ratio but may crop - closest to original
             pageImage->setScalingType(brls::ImageScalingType::FILL);
             break;
     }
@@ -779,9 +778,8 @@ void ReaderActivity::resetZoom() {
     m_zoomOffset = {0, 0};
 
     if (pageImage) {
-        // Reset to fit scaling
+        // Reset to fit scaling - maintains aspect ratio, shows margins
         pageImage->setScalingType(brls::ImageScalingType::FIT);
-        brls::Application::notify("Zoom: Fit");
     }
 }
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -105,8 +105,9 @@ void ReaderActivity::onContentAvailable() {
         return true;
     });
 
-    // NOBORU-style touch handling with swipe controls
+    // NOBORU-style touch handling with swipe controls and real-time preview
     // Features:
+    // - Real-time swipe preview (shows next/prev page while swiping)
     // - Responsive swipe detection with lower thresholds
     // - Double-tap to zoom in/out
     // - Tap to toggle UI controls
@@ -118,16 +119,53 @@ void ReaderActivity::onContentAvailable() {
         m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
         m_lastTapPosition = {0, 0};
 
-        // Pan gesture for swipe detection (NOBORU style)
+        // Hide preview image initially
+        if (previewImage) {
+            previewImage->setVisibility(brls::Visibility::GONE);
+        }
+
+        // Pan gesture for swipe detection (NOBORU style with real-time preview)
         pageImage->addGestureRecognizer(new brls::PanGestureRecognizer(
             [this](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
                 const float TAP_THRESHOLD = 15.0f;       // Max movement for tap
-                const float PAGE_TURN_THRESHOLD = 50.0f; // Threshold to complete page turn
+                const float PAGE_TURN_THRESHOLD = 80.0f; // Threshold to complete page turn
+                const float SWIPE_START_THRESHOLD = 20.0f; // When to start showing preview
 
                 if (status.state == brls::GestureState::START) {
                     m_isPanning = false;
+                    m_isSwipeAnimating = false;
                     m_touchStart = status.position;
                     m_touchCurrent = status.position;
+                    m_swipeOffset = 0.0f;
+                    m_previewPageIndex = -1;
+                } else if (status.state == brls::GestureState::STAY) {
+                    // Real-time swipe tracking for preview (STAY = finger still on screen)
+                    m_touchCurrent = status.position;
+                    float dx = m_touchCurrent.x - m_touchStart.x;
+                    float dy = m_touchCurrent.y - m_touchStart.y;
+
+                    // Only track horizontal swipes for preview
+                    if (std::abs(dx) > std::abs(dy) && std::abs(dx) > SWIPE_START_THRESHOLD) {
+                        m_isSwipeAnimating = true;
+                        m_swipeOffset = dx;
+
+                        // Determine which page to preview based on swipe direction
+                        bool swipingRight = dx > 0;
+                        bool wantNextPage = (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) ? swipingRight : !swipingRight;
+
+                        int previewIndex = wantNextPage ? m_currentPage + 1 : m_currentPage - 1;
+
+                        // Load preview if not already loaded
+                        if (previewIndex != m_previewPageIndex && previewIndex >= 0 &&
+                            previewIndex < static_cast<int>(m_pages.size())) {
+                            m_previewPageIndex = previewIndex;
+                            m_previewIsNext = wantNextPage;
+                            loadPreviewPage(previewIndex);
+                        }
+
+                        // Update visual positions
+                        updateSwipePreview(dx);
+                    }
                 } else if (status.state == brls::GestureState::END) {
                     m_touchCurrent = status.position;
 
@@ -157,30 +195,24 @@ void ReaderActivity::onContentAvailable() {
                             m_lastTapPosition = status.position;
                             toggleControls();
                         }
+                        resetSwipeState();
+                    } else if (m_isSwipeAnimating) {
+                        // Complete swipe animation
+                        float absX = std::abs(dx);
+
+                        if (absX >= PAGE_TURN_THRESHOLD && m_previewPageIndex >= 0) {
+                            // Swipe was long enough - turn the page
+                            completeSwipeAnimation(true);
+                        } else {
+                            // Swipe too short - snap back
+                            completeSwipeAnimation(false);
+                        }
                     } else {
-                        // It's a swipe - check direction and turn page
-                        m_isPanning = true;
+                        // Vertical swipe or short horizontal swipe
                         float absX = std::abs(dx);
                         float absY = std::abs(dy);
 
-                        if (absX > absY && absX >= PAGE_TURN_THRESHOLD) {
-                            // Horizontal swipe
-                            if (dx > 0) {
-                                // Swipe right
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
-                                    nextPage();
-                                } else {
-                                    previousPage();
-                                }
-                            } else {
-                                // Swipe left
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
-                                    previousPage();
-                                } else {
-                                    nextPage();
-                                }
-                            }
-                        } else if (absY > absX && absY >= PAGE_TURN_THRESHOLD) {
+                        if (absY > absX && absY >= PAGE_TURN_THRESHOLD) {
                             // Vertical swipe
                             if (dy > 0) {
                                 previousPage();
@@ -188,6 +220,7 @@ void ReaderActivity::onContentAvailable() {
                                 nextPage();
                             }
                         }
+                        resetSwipeState();
                     }
 
                     m_isPanning = false;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -287,6 +287,12 @@ bool Application::loadSettings() {
     m_settings.readingMode = static_cast<ReadingMode>(extractInt("readingMode"));
     m_settings.pageScaleMode = static_cast<PageScaleMode>(extractInt("pageScaleMode"));
     m_settings.readerBackground = static_cast<ReaderBackground>(extractInt("readerBackground"));
+    m_settings.imageRotation = extractInt("imageRotation");
+    // Validate rotation (must be 0, 90, 180, or 270)
+    if (m_settings.imageRotation != 0 && m_settings.imageRotation != 90 &&
+        m_settings.imageRotation != 180 && m_settings.imageRotation != 270) {
+        m_settings.imageRotation = 0;
+    }
     m_settings.keepScreenOn = extractBool("keepScreenOn", true);
     m_settings.showPageNumber = extractBool("showPageNumber", true);
     m_settings.tapToNavigate = extractBool("tapToNavigate", true);
@@ -367,6 +373,7 @@ bool Application::saveSettings() {
     json += "  \"readingMode\": " + std::to_string(static_cast<int>(m_settings.readingMode)) + ",\n";
     json += "  \"pageScaleMode\": " + std::to_string(static_cast<int>(m_settings.pageScaleMode)) + ",\n";
     json += "  \"readerBackground\": " + std::to_string(static_cast<int>(m_settings.readerBackground)) + ",\n";
+    json += "  \"imageRotation\": " + std::to_string(m_settings.imageRotation) + ",\n";
     json += "  \"keepScreenOn\": " + std::string(m_settings.keepScreenOn ? "true" : "false") + ",\n";
     json += "  \"showPageNumber\": " + std::string(m_settings.showPageNumber ? "true" : "false") + ",\n";
     json += "  \"tapToNavigate\": " + std::string(m_settings.tapToNavigate ? "true" : "false") + ",\n";

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -19,6 +19,7 @@ std::mutex ImageLoader::s_cacheMutex;
 std::string ImageLoader::s_authUsername;
 std::string ImageLoader::s_authPassword;
 std::queue<ImageLoader::LoadRequest> ImageLoader::s_loadQueue;
+std::queue<ImageLoader::RotatableLoadRequest> ImageLoader::s_rotatableLoadQueue;
 std::mutex ImageLoader::s_queueMutex;
 std::atomic<int> ImageLoader::s_activeLoads{0};
 int ImageLoader::s_maxConcurrentLoads = 4;  // Limit concurrent loads for Vita
@@ -50,7 +51,6 @@ static void downscaleRGBA(const uint8_t* src, int srcW, int srcH,
 }
 
 // Helper function to convert WebP to TGA format with optional downscaling
-// Adds a 1-pixel transparent border to prevent GPU edge clamping artifacts
 static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t webpSize, int maxSize) {
     std::vector<uint8_t> tgaData;
 
@@ -95,59 +95,38 @@ static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t web
         finalRgba = scaledRgba.data();
     }
 
-    // Add 1-pixel border by duplicating edge pixels to prevent GPU edge clamping artifacts
-    // When GPU samples at texture edges during scaling, it clamps to edge pixels.
-    // By duplicating edge pixels outward, the clamping uses the correct edge color.
-    const int BORDER = 1;
-    int paddedW = targetW + (BORDER * 2);
-    int paddedH = targetH + (BORDER * 2);
-
-    // Create TGA file in memory with padded dimensions
-    size_t imageSize = paddedW * paddedH * 4;
+    // Create TGA file in memory
+    size_t imageSize = targetW * targetH * 4;
     tgaData.resize(18 + imageSize);
 
     // TGA header
     uint8_t* header = tgaData.data();
     memset(header, 0, 18);
     header[2] = 2;          // Uncompressed true-color image
-    header[12] = paddedW & 0xFF;
-    header[13] = (paddedW >> 8) & 0xFF;
-    header[14] = paddedH & 0xFF;
-    header[15] = (paddedH >> 8) & 0xFF;
+    header[12] = targetW & 0xFF;
+    header[13] = (targetW >> 8) & 0xFF;
+    header[14] = targetH & 0xFF;
+    header[15] = (targetH >> 8) & 0xFF;
     header[16] = 32;        // 32 bits per pixel (RGBA)
     header[17] = 0x28;      // Image descriptor: top-left origin + 8 alpha bits
 
+    // Convert RGBA to BGRA for TGA
     uint8_t* pixels = tgaData.data() + 18;
-
-    // Helper lambda to copy a pixel from source RGBA to dest BGRA
-    auto copyPixel = [&](int srcX, int srcY, int dstX, int dstY) {
-        // Clamp source coordinates to valid range
-        srcX = std::max(0, std::min(srcX, targetW - 1));
-        srcY = std::max(0, std::min(srcY, targetH - 1));
-
-        int srcIdx = (srcY * targetW + srcX) * 4;
-        int dstIdx = (dstY * paddedW + dstX) * 4;
-        pixels[dstIdx + 0] = finalRgba[srcIdx + 2];  // B
-        pixels[dstIdx + 1] = finalRgba[srcIdx + 1];  // G
-        pixels[dstIdx + 2] = finalRgba[srcIdx + 0];  // R
-        pixels[dstIdx + 3] = finalRgba[srcIdx + 3];  // A
-    };
-
-    // Copy entire padded area, clamping source coordinates to duplicate edges
-    for (int dstY = 0; dstY < paddedH; dstY++) {
-        for (int dstX = 0; dstX < paddedW; dstX++) {
-            // Map destination to source (offset by border, then clamp)
-            int srcX = dstX - BORDER;
-            int srcY = dstY - BORDER;
-            copyPixel(srcX, srcY, dstX, dstY);
+    for (int y = 0; y < targetH; y++) {
+        for (int x = 0; x < targetW; x++) {
+            int srcIdx = (y * targetW + x) * 4;
+            int dstIdx = (y * targetW + x) * 4;
+            pixels[dstIdx + 0] = finalRgba[srcIdx + 2];  // B
+            pixels[dstIdx + 1] = finalRgba[srcIdx + 1];  // G
+            pixels[dstIdx + 2] = finalRgba[srcIdx + 0];  // R
+            pixels[dstIdx + 3] = finalRgba[srcIdx + 3];  // A
         }
     }
 
     // Free WebP decoded data
     WebPFree(rgba);
 
-    brls::Logger::debug("ImageLoader: Converted WebP to TGA {}x{} (padded to {}x{}, {} bytes)",
-                        targetW, targetH, paddedW, paddedH, tgaData.size());
+    brls::Logger::debug("ImageLoader: Converted WebP to TGA {}x{} ({} bytes)", targetW, targetH, tgaData.size());
     return tgaData;
 }
 
@@ -167,17 +146,28 @@ void ImageLoader::setMaxThumbnailSize(int maxSize) {
 void ImageLoader::processQueue() {
     std::lock_guard<std::mutex> lock(s_queueMutex);
 
-    // Process queue while we have capacity
+    // Process brls::Image queue while we have capacity
     while (!s_loadQueue.empty() && s_activeLoads < s_maxConcurrentLoads) {
         LoadRequest request = s_loadQueue.front();
         s_loadQueue.pop();
         s_activeLoads++;
 
-        // Execute load asynchronously
         brls::async([request]() {
             executeLoad(request);
             s_activeLoads--;
-            // Try to process more from queue
+            processQueue();
+        });
+    }
+
+    // Process RotatableImage queue while we have capacity
+    while (!s_rotatableLoadQueue.empty() && s_activeLoads < s_maxConcurrentLoads) {
+        RotatableLoadRequest request = s_rotatableLoadQueue.front();
+        s_rotatableLoadQueue.pop();
+        s_activeLoads++;
+
+        brls::async([request]() {
+            executeRotatableLoad(request);
+            s_activeLoads--;
             processQueue();
         });
     }
@@ -336,6 +326,125 @@ void ImageLoader::loadAsyncFullSize(const std::string& url, LoadCallback callbac
     }
 
     // Try to process queue
+    processQueue();
+}
+
+void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
+    const std::string& url = request.url;
+    RotatableLoadCallback callback = request.callback;
+    RotatableImage* target = request.target;
+
+    HttpClient client;
+
+    // Add authentication if credentials are set
+    if (!s_authUsername.empty() && !s_authPassword.empty()) {
+        std::string credentials = s_authUsername + ":" + s_authPassword;
+        static const char* b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::string encoded;
+        int val = 0, valb = -6;
+        for (unsigned char c : credentials) {
+            val = (val << 8) + c;
+            valb += 8;
+            while (valb >= 0) {
+                encoded.push_back(b64chars[(val >> valb) & 0x3F]);
+                valb -= 6;
+            }
+        }
+        if (valb > -6) encoded.push_back(b64chars[((val << 8) >> (valb + 8)) & 0x3F]);
+        while (encoded.size() % 4) encoded.push_back('=');
+        client.setDefaultHeader("Authorization", "Basic " + encoded);
+    }
+
+    HttpResponse resp = client.get(url);
+
+    if (resp.success && !resp.body.empty()) {
+        brls::Logger::debug("ImageLoader: Loaded {} bytes from {} for RotatableImage", resp.body.size(), url);
+
+        // Check image format
+        bool isWebP = false;
+        bool isValidImage = false;
+
+        if (resp.body.size() > 12) {
+            unsigned char* data = reinterpret_cast<unsigned char*>(resp.body.data());
+
+            // JPEG, PNG, GIF
+            if ((data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) ||
+                (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47) ||
+                (data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46)) {
+                isValidImage = true;
+            }
+            // WebP
+            else if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 &&
+                     data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50) {
+                isWebP = true;
+                isValidImage = true;
+            }
+        }
+
+        if (!isValidImage) {
+            brls::Logger::warning("ImageLoader: Invalid image format for {}", url);
+            return;
+        }
+
+        // Convert WebP to TGA if needed (no downscaling for manga pages)
+        std::vector<uint8_t> imageData;
+        if (isWebP) {
+            imageData = convertWebPtoTGA(
+                reinterpret_cast<const uint8_t*>(resp.body.data()),
+                resp.body.size(),
+                0  // No downscaling
+            );
+            if (imageData.empty()) {
+                brls::Logger::error("ImageLoader: WebP conversion failed for {}", url);
+                return;
+            }
+        } else {
+            imageData.assign(resp.body.begin(), resp.body.end());
+        }
+
+        // Cache the image
+        std::string cacheKey = url + "_full";
+        {
+            std::lock_guard<std::mutex> lock(s_cacheMutex);
+            if (s_cache.size() > 50) {
+                s_cache.clear();
+            }
+            s_cache[cacheKey] = imageData;
+        }
+
+        // Update UI on main thread
+        brls::sync([imageData, callback, target]() {
+            if (target) {
+                target->setImageFromMem(imageData.data(), imageData.size());
+                if (callback) callback(target);
+            }
+        });
+    } else {
+        brls::Logger::error("ImageLoader: Failed to load {}: {}", url, resp.error);
+    }
+}
+
+void ImageLoader::loadAsyncFullSize(const std::string& url, RotatableLoadCallback callback, RotatableImage* target) {
+    if (url.empty() || !target) return;
+
+    // Check cache first
+    std::string cacheKey = url + "_full";
+    {
+        std::lock_guard<std::mutex> lock(s_cacheMutex);
+        auto it = s_cache.find(cacheKey);
+        if (it != s_cache.end()) {
+            target->setImageFromMem(it->second.data(), it->second.size());
+            if (callback) callback(target);
+            return;
+        }
+    }
+
+    // Add to rotatable queue
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        s_rotatableLoadQueue.push({url, callback, target});
+    }
+
     processQueue();
 }
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -410,12 +410,11 @@ void MangaDetailView::populateChaptersList() {
         }
 
         // Download button - shows state based on local download state
-        // Material Design icon codepoints (UTF-8):
-        // file_download: U+E2C4, check_circle: U+E86C, hourglass: U+E88B, error: U+E000
-        static const std::string ICON_DOWNLOAD = "\xEE\x8B\x84";      // file_download
-        static const std::string ICON_CHECK = "\xEE\xA1\xAC";         // check_circle
-        static const std::string ICON_HOURGLASS = "\xEE\xA2\x8B";     // hourglass_empty
-        static const std::string ICON_ERROR = "\xEE\x80\x80";         // error
+        // Using Unicode characters supported by DejaVuSans font
+        static const std::string ICON_DOWNLOAD = "\xE2\xAC\x87";      // ⬇ U+2B07 downwards arrow
+        static const std::string ICON_CHECK = "\xE2\x9C\x94";         // ✔ U+2714 heavy check mark
+        static const std::string ICON_HOURGLASS = "\xE2\x8F\xB3";     // ⏳ U+23F3 hourglass
+        static const std::string ICON_ERROR = "\xE2\x9C\x95";         // ✕ U+2715 multiplication x
 
         Chapter capturedChapter = chapter;
         auto* dlBtn = new brls::Button();

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -166,7 +166,7 @@ void MangaItemCell::setManga(const Manga& manga) {
 
     // Show download badge if any chapters are downloaded locally
     if (m_downloadBadge) {
-        static const std::string ICON_CHECK = "\xEE\xA1\xAC";  // check_circle
+        static const std::string ICON_CHECK = "\xE2\x9C\x94";  // ✔ U+2714 heavy check mark
         DownloadsManager& dm = DownloadsManager::getInstance();
         DownloadItem* download = dm.getMangaDownload(manga.id);
         if (download != nullptr) {

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -17,8 +17,8 @@ RotatableImage::RotatableImage() {
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // First, clear the area with background color to prevent edge artifacts
-    // This fixes the issue where edge pixels get stretched/clamped
+    // STEP 1: Always draw background first to fill the entire area
+    // This ensures margins have the correct color even before image loads
     nvgSave(vg);
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
@@ -26,29 +26,69 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     nvgFill(vg);
     nvgRestore(vg);
 
-    if (m_rotationDegrees == 0.0f) {
-        // No rotation, draw normally
-        brls::Image::draw(vg, x, y, width, height, style, ctx);
+    // STEP 2: Get image dimensions to calculate actual rendered bounds
+    int imgW = 0, imgH = 0;
+    NVGLUimage* texture = this->getTexture();
+    if (texture) {
+        nvgluImageSize(texture, &imgW, &imgH);
+    }
+
+    // If no image loaded yet, just show background
+    if (imgW <= 0 || imgH <= 0) {
         return;
     }
 
-    // Calculate center of the view
-    float centerX = x + width / 2.0f;
-    float centerY = y + height / 2.0f;
+    // STEP 3: Calculate the actual image bounds for FIT scaling
+    float imgX = x, imgY = y, imgWidth = width, imgHeight = height;
+    float viewAspect = width / height;
+    float imgAspect = (float)imgW / (float)imgH;
 
-    // Save NanoVG state
+    if (viewAspect > imgAspect) {
+        // View is wider than image - image fills height, has margins on sides
+        imgHeight = height;
+        imgWidth = height * imgAspect;
+        imgX = x + (width - imgWidth) / 2.0f;
+    } else {
+        // View is taller than image - image fills width, has margins on top/bottom
+        imgWidth = width;
+        imgHeight = width / imgAspect;
+        imgY = y + (height - imgHeight) / 2.0f;
+    }
+
+    // STEP 4: Use scissor to clip rendering to calculated image bounds
+    // This prevents any edge sampling artifacts from bleeding into margins
+    // Add small inset (1 pixel) to ensure we clip any edge interpolation artifacts
+    const float EDGE_INSET = 1.0f;
+    float scissorX = imgX + EDGE_INSET;
+    float scissorY = imgY + EDGE_INSET;
+    float scissorW = imgWidth - (2.0f * EDGE_INSET);
+    float scissorH = imgHeight - (2.0f * EDGE_INSET);
+
+    // Only apply inset if image is large enough (inset shouldn't take more than 5%)
+    if (imgWidth < 40.0f || imgHeight < 40.0f) {
+        // Image too small for inset, use original bounds
+        scissorX = imgX;
+        scissorY = imgY;
+        scissorW = imgWidth;
+        scissorH = imgHeight;
+    }
+
     nvgSave(vg);
+    nvgScissor(vg, scissorX, scissorY, scissorW, scissorH);
 
-    // Move to center, rotate, then draw centered
-    nvgTranslate(vg, centerX, centerY);
-    nvgRotate(vg, m_rotationRadians);
-    nvgTranslate(vg, -centerX, -centerY);
+    // STEP 5: Draw the image with rotation if needed
+    if (m_rotationDegrees == 0.0f) {
+        brls::Image::draw(vg, x, y, width, height, style, ctx);
+    } else {
+        float centerX = x + width / 2.0f;
+        float centerY = y + height / 2.0f;
+        nvgTranslate(vg, centerX, centerY);
+        nvgRotate(vg, m_rotationRadians);
+        nvgTranslate(vg, -centerX, -centerY);
+        brls::Image::draw(vg, x, y, width, height, style, ctx);
+    }
 
-    // Draw the image at original position (transforms will apply)
-    brls::Image::draw(vg, x, y, width, height, style, ctx);
-
-    // Restore NanoVG state
-    nvgRestore(vg);
+    nvgRestore(vg);  // Restores scissor and any transforms
 }
 
 void RotatableImage::setRotation(float degrees) {

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -1,5 +1,6 @@
 /**
  * RotatableImage implementation
+ * Uses direct NanoVG rendering to avoid edge clamping artifacts
  */
 
 #include "view/rotatable_image.hpp"
@@ -12,38 +13,175 @@
 namespace vitasuwayomi {
 
 RotatableImage::RotatableImage() {
-    // Register as a Borealis view
+    // Set default properties
+    this->setFocusable(false);
+}
+
+RotatableImage::~RotatableImage() {
+    clearImage();
+}
+
+void RotatableImage::clearImage() {
+    if (m_nvgImage != 0) {
+        NVGcontext* vg = brls::Application::getNVGContext();
+        if (vg) {
+            nvgDeleteImage(vg, m_nvgImage);
+        }
+        m_nvgImage = 0;
+        m_imageWidth = 0;
+        m_imageHeight = 0;
+    }
+}
+
+void RotatableImage::setImageFromMem(const unsigned char* data, size_t size) {
+    NVGcontext* vg = brls::Application::getNVGContext();
+    if (!vg || !data || size == 0) {
+        return;
+    }
+
+    // Clear existing image
+    clearImage();
+
+    // Create NVG image from memory
+    m_nvgImage = nvgCreateImageMem(vg, 0, const_cast<unsigned char*>(data), size);
+
+    if (m_nvgImage != 0) {
+        // Get image dimensions
+        nvgImageSize(vg, m_nvgImage, &m_imageWidth, &m_imageHeight);
+        brls::Logger::debug("RotatableImage: Loaded image {}x{}", m_imageWidth, m_imageHeight);
+    } else {
+        brls::Logger::error("RotatableImage: Failed to create NVG image");
+    }
+
+    this->invalidate();
+}
+
+void RotatableImage::setImageFromFile(const std::string& path) {
+    NVGcontext* vg = brls::Application::getNVGContext();
+    if (!vg || path.empty()) {
+        return;
+    }
+
+    // Clear existing image
+    clearImage();
+
+    // Create NVG image from file
+    m_nvgImage = nvgCreateImage(vg, path.c_str(), 0);
+
+    if (m_nvgImage != 0) {
+        nvgImageSize(vg, m_nvgImage, &m_imageWidth, &m_imageHeight);
+        brls::Logger::debug("RotatableImage: Loaded image from file {}x{}", m_imageWidth, m_imageHeight);
+    } else {
+        brls::Logger::error("RotatableImage: Failed to load image from {}", path);
+    }
+
+    this->invalidate();
+}
+
+void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW, float viewH,
+                                          float& imgX, float& imgY, float& imgW, float& imgH) {
+    if (m_imageWidth <= 0 || m_imageHeight <= 0) {
+        imgX = viewX;
+        imgY = viewY;
+        imgW = viewW;
+        imgH = viewH;
+        return;
+    }
+
+    float imageAspect = (float)m_imageWidth / (float)m_imageHeight;
+    float viewAspect = viewW / viewH;
+
+    switch (m_scalingType) {
+        case brls::ImageScalingType::FIT:
+            // Fit entire image within view, maintaining aspect ratio
+            if (viewAspect > imageAspect) {
+                // View is wider - fit to height
+                imgH = viewH;
+                imgW = viewH * imageAspect;
+                imgX = viewX + (viewW - imgW) / 2.0f;
+                imgY = viewY;
+            } else {
+                // View is taller - fit to width
+                imgW = viewW;
+                imgH = viewW / imageAspect;
+                imgX = viewX;
+                imgY = viewY + (viewH - imgH) / 2.0f;
+            }
+            break;
+
+        case brls::ImageScalingType::FILL:
+            // Fill view, cropping if necessary
+            if (viewAspect > imageAspect) {
+                // View is wider - fill width, crop top/bottom
+                imgW = viewW;
+                imgH = viewW / imageAspect;
+                imgX = viewX;
+                imgY = viewY + (viewH - imgH) / 2.0f;
+            } else {
+                // View is taller - fill height, crop left/right
+                imgH = viewH;
+                imgW = viewH * imageAspect;
+                imgX = viewX + (viewW - imgW) / 2.0f;
+                imgY = viewY;
+            }
+            break;
+
+        case brls::ImageScalingType::STRETCH:
+        default:
+            // Stretch to fill (distorts aspect ratio)
+            imgX = viewX;
+            imgY = viewY;
+            imgW = viewW;
+            imgH = viewH;
+            break;
+    }
 }
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // STEP 1: Draw background first to fill the entire area
-    // This ensures margins have the correct color before the image is drawn
-    nvgSave(vg);
+    // First draw the background to fill margins
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
     nvgFillColor(vg, m_bgColor);
     nvgFill(vg);
-    nvgRestore(vg);
 
-    // STEP 2: Draw the image with rotation if needed
-    // The image has a 1-pixel transparent border added during loading to prevent
-    // GPU edge clamping artifacts (edge pixels being stretched into margins)
-    if (m_rotationDegrees == 0.0f) {
-        // No rotation - draw normally
-        brls::Image::draw(vg, x, y, width, height, style, ctx);
-    } else {
-        // Apply rotation around center
+    // If no image, just show background
+    if (m_nvgImage == 0 || m_imageWidth <= 0 || m_imageHeight <= 0) {
+        return;
+    }
+
+    // Calculate where the image should be drawn
+    float imgX, imgY, imgW, imgH;
+    calculateImageBounds(x, y, width, height, imgX, imgY, imgW, imgH);
+
+    // Save state
+    nvgSave(vg);
+
+    // Apply rotation if needed
+    if (m_rotationDegrees != 0.0f) {
         float centerX = x + width / 2.0f;
         float centerY = y + height / 2.0f;
-
-        nvgSave(vg);
         nvgTranslate(vg, centerX, centerY);
         nvgRotate(vg, m_rotationRadians);
         nvgTranslate(vg, -centerX, -centerY);
-        brls::Image::draw(vg, x, y, width, height, style, ctx);
-        nvgRestore(vg);
     }
+
+    // CRITICAL: Use scissor to clip rendering to ONLY the image bounds
+    // This prevents any edge artifacts from appearing in the margins
+    nvgScissor(vg, imgX, imgY, imgW, imgH);
+
+    // Create image pattern - sized exactly to the image bounds
+    // The pattern maps the full texture (0,0 to imageWidth,imageHeight) to the draw bounds
+    NVGpaint imgPaint = nvgImagePattern(vg, imgX, imgY, imgW, imgH, 0, m_nvgImage, 1.0f);
+
+    // Draw the image as a filled rectangle
+    nvgBeginPath(vg);
+    nvgRect(vg, imgX, imgY, imgW, imgH);
+    nvgFillPaint(vg, imgPaint);
+    nvgFill(vg);
+
+    // Restore state (removes scissor and rotation)
+    nvgRestore(vg);
 }
 
 void RotatableImage::setRotation(float degrees) {
@@ -67,10 +205,7 @@ void RotatableImage::setRotation(float degrees) {
     // Convert to radians
     m_rotationRadians = m_rotationDegrees * NVG_PI / 180.0f;
 
-    brls::Logger::info("RotatableImage: setRotation({}) -> {} degrees, {} radians",
-                       degrees, m_rotationDegrees, m_rotationRadians);
-
-    // Force redraw
+    brls::Logger::debug("RotatableImage: setRotation({}) -> {} degrees", degrees, m_rotationDegrees);
     this->invalidate();
 }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -17,6 +17,15 @@ RotatableImage::RotatableImage() {
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
+    // First, clear the area with background color to prevent edge artifacts
+    // This fixes the issue where edge pixels get stretched/clamped
+    nvgSave(vg);
+    nvgBeginPath(vg);
+    nvgRect(vg, x, y, width, height);
+    nvgFillColor(vg, m_bgColor);
+    nvgFill(vg);
+    nvgRestore(vg);
+
     if (m_rotationDegrees == 0.0f) {
         // No rotation, draw normally
         brls::Image::draw(vg, x, y, width, height, style, ctx);

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -17,8 +17,8 @@ RotatableImage::RotatableImage() {
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // STEP 1: Always draw background first to fill the entire area
-    // This ensures margins have the correct color even before image loads
+    // STEP 1: Draw background first to fill the entire area
+    // This ensures margins have the correct color before the image is drawn
     nvgSave(vg);
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
@@ -26,69 +26,24 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     nvgFill(vg);
     nvgRestore(vg);
 
-    // STEP 2: Get image dimensions to calculate actual rendered bounds
-    int imgW = 0, imgH = 0;
-    NVGLUimage* texture = this->getTexture();
-    if (texture) {
-        nvgluImageSize(texture, &imgW, &imgH);
-    }
-
-    // If no image loaded yet, just show background
-    if (imgW <= 0 || imgH <= 0) {
-        return;
-    }
-
-    // STEP 3: Calculate the actual image bounds for FIT scaling
-    float imgX = x, imgY = y, imgWidth = width, imgHeight = height;
-    float viewAspect = width / height;
-    float imgAspect = (float)imgW / (float)imgH;
-
-    if (viewAspect > imgAspect) {
-        // View is wider than image - image fills height, has margins on sides
-        imgHeight = height;
-        imgWidth = height * imgAspect;
-        imgX = x + (width - imgWidth) / 2.0f;
-    } else {
-        // View is taller than image - image fills width, has margins on top/bottom
-        imgWidth = width;
-        imgHeight = width / imgAspect;
-        imgY = y + (height - imgHeight) / 2.0f;
-    }
-
-    // STEP 4: Use scissor to clip rendering to calculated image bounds
-    // This prevents any edge sampling artifacts from bleeding into margins
-    // Add small inset (1 pixel) to ensure we clip any edge interpolation artifacts
-    const float EDGE_INSET = 1.0f;
-    float scissorX = imgX + EDGE_INSET;
-    float scissorY = imgY + EDGE_INSET;
-    float scissorW = imgWidth - (2.0f * EDGE_INSET);
-    float scissorH = imgHeight - (2.0f * EDGE_INSET);
-
-    // Only apply inset if image is large enough (inset shouldn't take more than 5%)
-    if (imgWidth < 40.0f || imgHeight < 40.0f) {
-        // Image too small for inset, use original bounds
-        scissorX = imgX;
-        scissorY = imgY;
-        scissorW = imgWidth;
-        scissorH = imgHeight;
-    }
-
-    nvgSave(vg);
-    nvgScissor(vg, scissorX, scissorY, scissorW, scissorH);
-
-    // STEP 5: Draw the image with rotation if needed
+    // STEP 2: Draw the image with rotation if needed
+    // The image has a 1-pixel transparent border added during loading to prevent
+    // GPU edge clamping artifacts (edge pixels being stretched into margins)
     if (m_rotationDegrees == 0.0f) {
+        // No rotation - draw normally
         brls::Image::draw(vg, x, y, width, height, style, ctx);
     } else {
+        // Apply rotation around center
         float centerX = x + width / 2.0f;
         float centerY = y + height / 2.0f;
+
+        nvgSave(vg);
         nvgTranslate(vg, centerX, centerY);
         nvgRotate(vg, m_rotationRadians);
         nvgTranslate(vg, -centerX, -centerY);
         brls::Image::draw(vg, x, y, width, height, style, ctx);
+        nvgRestore(vg);
     }
-
-    nvgRestore(vg);  // Restores scissor and any transforms
 }
 
 void RotatableImage::setRotation(float degrees) {


### PR DESCRIPTION
Reworks the reader with NOBORU-style touch controls and a live swipe preview, and resolves a long run of image-rendering problems: edge and scaling artifacts, WebP transparent borders, 90/270° rotation scaling, aspect-ratio handling, next-chapter preloading, and persisting reader settings across sessions.

---
_Generated by [Claude Code](https://claude.ai/code)_