### PR TITLE
Add language grouping and click-to-install for Extensions tab

### DIFF
--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -1,6 +1,7 @@
 /**
  * VitaSuwayomi - Extensions Tab
  * Manage Suwayomi extensions (install, update, uninstall)
+ * Extensions are grouped by language for better organization
  */
 
 #pragma once
@@ -8,6 +9,7 @@
 #include <borealis.hpp>
 #include "app/suwayomi_client.hpp"
 #include <set>
+#include <map>
 
 namespace vitasuwayomi {
 
@@ -30,7 +32,9 @@ private:
     void showUpdates();
     void updateButtonStyles();
     void populateList(const std::vector<Extension>& extensions);
-    brls::Box* createExtensionItem(const Extension& ext);
+    void populateListGroupedByLanguage(const std::vector<Extension>& extensions);
+    brls::Box* createLanguageHeader(const std::string& langCode, int extensionCount);
+    brls::Box* createExtensionItem(const Extension& ext, bool clickToInstall = false);
     void installExtension(const Extension& ext);
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
@@ -38,6 +42,8 @@ private:
     void updateLanguageFilter();
     void filterByLanguage(const std::string& lang);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions);
+    std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);
+    std::string getLanguageDisplayName(const std::string& langCode);
 
     brls::Label* m_titleLabel = nullptr;
     brls::Button* m_installedBtn = nullptr;
@@ -54,6 +60,9 @@ private:
 
     std::set<std::string> m_availableLanguages;
     std::string m_selectedLanguage = "all";  // "all" means no filter
+
+    // Track collapsed language sections
+    std::set<std::string> m_collapsedLanguages;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -8,7 +8,6 @@
 
 #include <borealis.hpp>
 #include "app/suwayomi_client.hpp"
-#include <set>
 #include <map>
 
 namespace vitasuwayomi {
@@ -39,9 +38,6 @@ private:
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
     void showError(const std::string& message);
-    void updateLanguageFilter();
-    void updateLanguageButtonText();
-    void filterByLanguage(const std::string& lang);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions);
     std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);
     std::string getLanguageDisplayName(const std::string& langCode);
@@ -50,7 +46,6 @@ private:
     brls::Button* m_installedBtn = nullptr;
     brls::Button* m_availableBtn = nullptr;
     brls::Button* m_updatesBtn = nullptr;
-    brls::Button* m_langFilterBtn = nullptr;
     brls::Box* m_listBox = nullptr;
 
     ViewMode m_currentView = ViewMode::INSTALLED;
@@ -58,12 +53,6 @@ private:
     std::vector<Extension> m_installed;
     std::vector<Extension> m_available;
     std::vector<Extension> m_updates;
-
-    std::set<std::string> m_availableLanguages;
-    std::string m_selectedLanguage = "all";  // "all" means no filter
-
-    // Track collapsed language sections
-    std::set<std::string> m_collapsedLanguages;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -40,6 +40,7 @@ private:
     void uninstallExtension(const Extension& ext);
     void showError(const std::string& message);
     void updateLanguageFilter();
+    void updateLanguageButtonText();
     void filterByLanguage(const std::string& lang);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions);
     std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);

--- a/resources/xml/tabs/extensions.xml
+++ b/resources/xml/tabs/extensions.xml
@@ -43,14 +43,6 @@
             style="bordered"
             text="Updates"
             width="120"
-            height="35"
-            marginRight="10"/>
-
-        <brls:Button
-            id="extensions/lang_filter_btn"
-            style="bordered"
-            text="All Languages"
-            width="140"
             height="35"/>
 
     </brls:Box>


### PR DESCRIPTION
Adds language grouping and click-to-install to the Extensions tab, integrates it with the global language settings, and removes the now-redundant per-tab Language filter button.

---
_Generated by [Claude Code](https://claude.ai/code)_