### PR TITLE
Add continuous scrolling support for Webtoon reading mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(APP_SOURCES
     src/view/media_item_cell.cpp
     src/view/recycling_grid.cpp
     src/view/rotatable_image.cpp
+    src/view/webtoon_scroll_view.cpp
     src/view/downloads_tab.cpp
     src/view/extensions_tab.cpp
     src/view/source_browse_tab.cpp

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -11,6 +11,7 @@
 #include "app/suwayomi_client.hpp"
 #include "app/application.hpp"
 #include "view/rotatable_image.hpp"
+#include "view/webtoon_scroll_view.hpp"
 
 namespace vitasuwayomi {
 
@@ -130,6 +131,9 @@ private:
     BRLS_BIND(brls::Label, settingsDirLabel, "reader/settings_dir_label");
     BRLS_BIND(brls::Label, settingsRotLabel, "reader/settings_rot_label");
 
+    // Webtoon continuous scroll view
+    BRLS_BIND(WebtoonScrollView, webtoonScroll, "reader/webtoon_scroll");
+
     // Manga/Chapter info
     int m_mangaId = 0;
     int m_chapterIndex = 0;
@@ -145,6 +149,10 @@ private:
     ReaderSettings m_settings;
     bool m_controlsVisible = false;
     bool m_settingsVisible = false;
+    bool m_continuousScrollMode = false;  // True when using WebtoonScrollView
+
+    // Switch between single-page and continuous scroll modes
+    void updateReaderMode();
 
     // Chapter navigation
     std::vector<Chapter> m_chapters;

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -1,0 +1,152 @@
+/**
+ * WebtoonScrollView - Continuous vertical scrolling view for webtoon reading
+ * Displays all pages as one long continuous strip with smooth scrolling
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include <vector>
+#include <set>
+#include <functional>
+#include "view/rotatable_image.hpp"
+#include "app/suwayomi_client.hpp"
+
+namespace vitasuwayomi {
+
+// Callback when scroll position changes (for progress tracking)
+using ScrollProgressCallback = std::function<void(int currentPage, int totalPages, float scrollPercent)>;
+
+// Callback when user taps (for toggling controls)
+using TapCallback = std::function<void()>;
+
+class WebtoonScrollView : public brls::Box {
+public:
+    WebtoonScrollView();
+    ~WebtoonScrollView();
+
+    /**
+     * Set the pages to display
+     * @param pages Vector of page data with image URLs
+     * @param screenWidth Width available for pages
+     */
+    void setPages(const std::vector<Page>& pages, float screenWidth);
+
+    /**
+     * Clear all pages and reset scroll
+     */
+    void clearPages();
+
+    /**
+     * Scroll to a specific page index
+     */
+    void scrollToPage(int pageIndex);
+
+    /**
+     * Get the currently visible page (topmost page in view)
+     */
+    int getCurrentPage() const { return m_currentPage; }
+
+    /**
+     * Get total page count
+     */
+    int getPageCount() const { return static_cast<int>(m_pages.size()); }
+
+    /**
+     * Get current scroll position (0.0 to 1.0)
+     */
+    float getScrollProgress() const;
+
+    /**
+     * Set callback for scroll progress updates
+     */
+    void setProgressCallback(ScrollProgressCallback callback) { m_progressCallback = callback; }
+
+    /**
+     * Set callback for tap gesture (to toggle controls)
+     */
+    void setTapCallback(TapCallback callback) { m_tapCallback = callback; }
+
+    /**
+     * Set side padding percentage (0-20)
+     */
+    void setSidePadding(int percent);
+
+    /**
+     * Handle frame update for progressive loading
+     */
+    void onFrame();
+
+    void draw(NVGcontext* vg, float x, float y, float width, float height,
+              brls::Style style, brls::FrameContext* ctx) override;
+
+    static brls::View* create();
+
+private:
+    // Setup touch gestures for scrolling
+    void setupGestures();
+
+    // Load images that are visible or near visible
+    void updateVisibleImages();
+
+    // Check if a page is in the visible range
+    bool isPageVisible(int pageIndex) const;
+
+    // Calculate the Y offset for a page
+    float getPageOffset(int pageIndex) const;
+
+    // Update current page based on scroll position
+    void updateCurrentPage();
+
+    // Apply momentum scrolling
+    void applyMomentum();
+
+    // Pages data
+    std::vector<Page> m_pages;
+
+    // Image containers for each page
+    std::vector<RotatableImage*> m_pageImages;
+
+    // Content box that holds all images
+    brls::Box* m_contentBox = nullptr;
+
+    // Scroll state
+    float m_scrollY = 0.0f;           // Current scroll position (negative = scrolled down)
+    float m_scrollVelocity = 0.0f;    // Current scroll velocity for momentum
+    float m_totalHeight = 0.0f;       // Total content height
+    float m_viewHeight = 0.0f;        // Visible area height
+    float m_viewWidth = 0.0f;         // Visible area width
+
+    // Touch tracking
+    bool m_isTouching = false;
+    brls::Point m_touchStart;
+    brls::Point m_touchLast;
+    float m_scrollAtTouchStart = 0.0f;
+    std::chrono::steady_clock::time_point m_lastTouchTime;
+
+    // Page tracking
+    int m_currentPage = 0;
+    std::set<int> m_loadedPages;      // Pages that have been loaded
+    std::set<int> m_loadingPages;     // Pages currently being loaded
+
+    // Layout
+    float m_sidePadding = 0.0f;       // Padding on each side
+    float m_pageGap = 0.0f;           // Gap between pages (0 for seamless webtoon)
+    std::vector<float> m_pageHeights; // Height of each page
+
+    // Callbacks
+    ScrollProgressCallback m_progressCallback;
+    TapCallback m_tapCallback;
+
+    // Preload buffer - how many pages ahead/behind to load
+    static constexpr int PRELOAD_PAGES = 3;
+
+    // Momentum friction
+    static constexpr float MOMENTUM_FRICTION = 0.95f;
+    static constexpr float MOMENTUM_MIN_VELOCITY = 0.5f;
+
+    // Touch thresholds
+    static constexpr float TAP_THRESHOLD = 15.0f;
+};
+
+} // namespace vitasuwayomi

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -73,6 +73,16 @@ public:
     void setSidePadding(int percent);
 
     /**
+     * Set rotation for all page images (0, 90, 180, 270 degrees)
+     */
+    void setRotation(float degrees);
+
+    /**
+     * Get current rotation
+     */
+    float getRotation() const { return m_rotationDegrees; }
+
+    /**
      * Handle frame update for progressive loading
      */
     void onFrame();
@@ -133,6 +143,7 @@ private:
     float m_sidePadding = 0.0f;       // Padding on each side
     float m_pageGap = 0.0f;           // Gap between pages (0 for seamless webtoon)
     std::vector<float> m_pageHeights; // Height of each page
+    float m_rotationDegrees = 0.0f;   // Image rotation (0, 90, 180, 270)
 
     // Callbacks
     ScrollProgressCallback m_progressCallback;

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -9,7 +9,7 @@
     alignItems="center"
     backgroundColor="#1a1a2e">
 
-    <!-- Main page display area -->
+    <!-- Main page display area (single page mode) -->
     <RotatableImage
         id="reader/page_image"
         width="100%"
@@ -19,6 +19,16 @@
     <!-- Preview page (slides in during swipe) - hidden by default, AFTER main page for z-order -->
     <RotatableImage
         id="reader/preview_image"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="gone"/>
+
+    <!-- Webtoon continuous scroll view - hidden by default, shown in webtoon mode -->
+    <WebtoonScrollView
+        id="reader/webtoon_scroll"
         width="100%"
         height="100%"
         positionType="absolute"

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -768,6 +768,7 @@ void ReaderActivity::loadPages() {
             if (webtoonScroll) {
                 webtoonScroll->setVisibility(brls::Visibility::VISIBLE);
                 webtoonScroll->setSidePadding(m_settings.webtoonSidePadding);
+                webtoonScroll->setRotation(static_cast<float>(m_settings.rotation));
 
                 // Set up progress callback
                 webtoonScroll->setProgressCallback([this](int currentPage, int totalPages, float scrollPercent) {
@@ -1175,6 +1176,11 @@ void ReaderActivity::applySettings() {
     if (previewImage) {
         previewImage->setRotation(rotation);
     }
+
+    // Apply rotation to webtoon scroll view if in continuous mode
+    if (webtoonScroll) {
+        webtoonScroll->setRotation(rotation);
+    }
 }
 
 void ReaderActivity::saveSettingsToApp() {
@@ -1549,6 +1555,7 @@ void ReaderActivity::updateReaderMode() {
         if (webtoonScroll) {
             webtoonScroll->setVisibility(brls::Visibility::VISIBLE);
             webtoonScroll->setSidePadding(m_settings.webtoonSidePadding);
+            webtoonScroll->setRotation(static_cast<float>(m_settings.rotation));
 
             // Set up progress callback
             webtoonScroll->setProgressCallback([this](int currentPage, int totalPages, float scrollPercent) {

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -366,7 +366,8 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext, bool clickTo
     icon->setSize(brls::Size(40, 40));
     icon->setMarginRight(15);
     if (!ext.iconUrl.empty()) {
-        ImageLoader::loadAsync(ext.iconUrl, [](brls::Image* img) {
+        std::string fullIconUrl = Application::getInstance().getServerUrl() + ext.iconUrl;
+        ImageLoader::loadAsync(fullIconUrl, [](brls::Image* img) {
             brls::Logger::debug("ExtensionsTab: Extension icon loaded");
         }, icon);
     }

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -110,6 +110,7 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
         pageImg->setHeight(defaultHeight);  // Will be adjusted when image loads
         pageImg->setScalingType(brls::ImageScalingType::FIT);
         pageImg->setBackgroundFillColor(nvgRGBA(26, 26, 46, 255));
+        pageImg->setRotation(m_rotationDegrees);  // Apply current rotation
 
         m_pageImages.push_back(pageImg);
         m_pageHeights.push_back(defaultHeight);
@@ -183,6 +184,34 @@ void WebtoonScrollView::setSidePadding(int percent) {
     }
     float paddingRatio = percent / 100.0f;
     m_sidePadding = m_viewWidth * paddingRatio;
+}
+
+void WebtoonScrollView::setRotation(float degrees) {
+    // Normalize to 0, 90, 180, 270
+    int normalized = static_cast<int>(degrees) % 360;
+    if (normalized < 0) normalized += 360;
+
+    // Snap to nearest 90 degree increment
+    if (normalized < 45) {
+        m_rotationDegrees = 0.0f;
+    } else if (normalized < 135) {
+        m_rotationDegrees = 90.0f;
+    } else if (normalized < 225) {
+        m_rotationDegrees = 180.0f;
+    } else if (normalized < 315) {
+        m_rotationDegrees = 270.0f;
+    } else {
+        m_rotationDegrees = 0.0f;
+    }
+
+    // Apply rotation to all existing page images
+    for (auto* img : m_pageImages) {
+        if (img) {
+            img->setRotation(m_rotationDegrees);
+        }
+    }
+
+    brls::Logger::debug("WebtoonScrollView: setRotation({}) -> {} degrees", degrees, m_rotationDegrees);
 }
 
 void WebtoonScrollView::onFrame() {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -1,0 +1,415 @@
+/**
+ * WebtoonScrollView implementation
+ * Continuous vertical scrolling for webtoon reading
+ */
+
+#include "view/webtoon_scroll_view.hpp"
+#include "utils/image_loader.hpp"
+#include <cmath>
+
+namespace vitasuwayomi {
+
+WebtoonScrollView::WebtoonScrollView() {
+    // Set up as a full-size container
+    this->setAxis(brls::Axis::COLUMN);
+    this->setJustifyContent(brls::JustifyContent::FLEX_START);
+    this->setAlignItems(brls::AlignItems::CENTER);
+    this->setGrow(1.0f);
+
+    // Setup touch gestures
+    setupGestures();
+}
+
+WebtoonScrollView::~WebtoonScrollView() {
+    clearPages();
+}
+
+void WebtoonScrollView::setupGestures() {
+    this->setFocusable(true);
+
+    // Pan gesture for scrolling
+    this->addGestureRecognizer(new brls::PanGestureRecognizer(
+        [this](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            if (status.state == brls::GestureState::START) {
+                m_isTouching = true;
+                m_touchStart = status.position;
+                m_touchLast = status.position;
+                m_scrollAtTouchStart = m_scrollY;
+                m_scrollVelocity = 0.0f;
+                m_lastTouchTime = std::chrono::steady_clock::now();
+            } else if (status.state == brls::GestureState::STAY) {
+                // Calculate scroll delta
+                float dy = status.position.y - m_touchLast.y;
+
+                // Update scroll position (inverted - drag down = scroll up)
+                m_scrollY += dy;
+
+                // Clamp scroll position
+                float maxScroll = 0.0f;
+                float minScroll = -(m_totalHeight - m_viewHeight);
+                if (minScroll > maxScroll) minScroll = maxScroll;
+
+                m_scrollY = std::max(minScroll, std::min(maxScroll, m_scrollY));
+
+                // Calculate velocity for momentum
+                auto now = std::chrono::steady_clock::now();
+                auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastTouchTime).count();
+                if (dt > 0) {
+                    m_scrollVelocity = dy / (dt / 16.67f);  // Normalize to ~60fps
+                }
+
+                m_touchLast = status.position;
+                m_lastTouchTime = now;
+
+                // Update visible images and current page
+                updateVisibleImages();
+                updateCurrentPage();
+            } else if (status.state == brls::GestureState::END) {
+                m_isTouching = false;
+
+                // Check if it was a tap (minimal movement)
+                float dx = status.position.x - m_touchStart.x;
+                float dy = status.position.y - m_touchStart.y;
+                float distance = std::sqrt(dx * dx + dy * dy);
+
+                if (distance < TAP_THRESHOLD) {
+                    // It's a tap - toggle controls via callback
+                    m_scrollVelocity = 0.0f;
+                    if (m_tapCallback) {
+                        m_tapCallback();
+                    }
+                }
+                // Otherwise, momentum will be applied in onFrame()
+            }
+        }, brls::PanAxis::VERTICAL));
+}
+
+void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWidth) {
+    clearPages();
+
+    m_pages = pages;
+    m_viewWidth = screenWidth;
+    m_viewHeight = 544.0f;  // PS Vita screen height
+
+    // Calculate available width after padding
+    float availableWidth = screenWidth - (m_sidePadding * 2);
+
+    // For webtoons, we'll estimate heights based on typical aspect ratios
+    // Images will be FIT_WIDTH, so height depends on aspect ratio
+    // Default to 2:3 aspect ratio if unknown (will adjust when images load)
+    float defaultHeight = availableWidth * 1.5f;  // 2:3 aspect ratio
+
+    m_totalHeight = 0.0f;
+    m_pageHeights.clear();
+    m_pageHeights.reserve(pages.size());
+
+    // Create image containers for each page
+    for (size_t i = 0; i < pages.size(); i++) {
+        auto* pageImg = new RotatableImage();
+        pageImg->setWidth(availableWidth);
+        pageImg->setHeight(defaultHeight);  // Will be adjusted when image loads
+        pageImg->setScalingType(brls::ImageScalingType::FIT);
+        pageImg->setBackgroundFillColor(nvgRGBA(26, 26, 46, 255));
+
+        m_pageImages.push_back(pageImg);
+        m_pageHeights.push_back(defaultHeight);
+        m_totalHeight += defaultHeight + m_pageGap;
+    }
+
+    // Remove trailing gap
+    if (!pages.empty() && m_pageGap > 0) {
+        m_totalHeight -= m_pageGap;
+    }
+
+    // Reset scroll
+    m_scrollY = 0.0f;
+    m_scrollVelocity = 0.0f;
+    m_currentPage = 0;
+    m_loadedPages.clear();
+    m_loadingPages.clear();
+
+    // Load initial visible images
+    updateVisibleImages();
+
+    brls::Logger::info("WebtoonScrollView: Set {} pages, totalHeight={}", pages.size(), m_totalHeight);
+}
+
+void WebtoonScrollView::clearPages() {
+    for (auto* img : m_pageImages) {
+        delete img;
+    }
+    m_pageImages.clear();
+    m_pageHeights.clear();
+    m_pages.clear();
+    m_loadedPages.clear();
+    m_loadingPages.clear();
+    m_totalHeight = 0.0f;
+    m_scrollY = 0.0f;
+    m_scrollVelocity = 0.0f;
+    m_currentPage = 0;
+}
+
+void WebtoonScrollView::scrollToPage(int pageIndex) {
+    if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pages.size())) {
+        return;
+    }
+
+    // Calculate scroll position for this page
+    float targetY = -getPageOffset(pageIndex);
+
+    // Clamp scroll position
+    float maxScroll = 0.0f;
+    float minScroll = -(m_totalHeight - m_viewHeight);
+    if (minScroll > maxScroll) minScroll = maxScroll;
+
+    m_scrollY = std::max(minScroll, std::min(maxScroll, targetY));
+    m_scrollVelocity = 0.0f;
+
+    updateVisibleImages();
+    updateCurrentPage();
+}
+
+float WebtoonScrollView::getScrollProgress() const {
+    if (m_totalHeight <= m_viewHeight) {
+        return 0.0f;
+    }
+    float scrollable = m_totalHeight - m_viewHeight;
+    return std::min(1.0f, std::max(0.0f, -m_scrollY / scrollable));
+}
+
+void WebtoonScrollView::setSidePadding(int percent) {
+    if (percent < 0 || percent > 20) {
+        percent = 0;
+    }
+    float paddingRatio = percent / 100.0f;
+    m_sidePadding = m_viewWidth * paddingRatio;
+}
+
+void WebtoonScrollView::onFrame() {
+    // Apply momentum scrolling when not touching
+    if (!m_isTouching && std::abs(m_scrollVelocity) > MOMENTUM_MIN_VELOCITY) {
+        m_scrollY += m_scrollVelocity;
+        m_scrollVelocity *= MOMENTUM_FRICTION;
+
+        // Clamp scroll position
+        float maxScroll = 0.0f;
+        float minScroll = -(m_totalHeight - m_viewHeight);
+        if (minScroll > maxScroll) minScroll = maxScroll;
+
+        // Bounce back if out of bounds
+        if (m_scrollY > maxScroll) {
+            m_scrollY = maxScroll;
+            m_scrollVelocity = 0.0f;
+        } else if (m_scrollY < minScroll) {
+            m_scrollY = minScroll;
+            m_scrollVelocity = 0.0f;
+        }
+
+        updateVisibleImages();
+        updateCurrentPage();
+    }
+}
+
+float WebtoonScrollView::getPageOffset(int pageIndex) const {
+    if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pageHeights.size())) {
+        return 0.0f;
+    }
+
+    float offset = 0.0f;
+    for (int i = 0; i < pageIndex; i++) {
+        offset += m_pageHeights[i] + m_pageGap;
+    }
+    return offset;
+}
+
+bool WebtoonScrollView::isPageVisible(int pageIndex) const {
+    if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pageHeights.size())) {
+        return false;
+    }
+
+    float pageTop = getPageOffset(pageIndex);
+    float pageBottom = pageTop + m_pageHeights[pageIndex];
+
+    // Current visible range (scrollY is negative when scrolled down)
+    float visibleTop = -m_scrollY;
+    float visibleBottom = visibleTop + m_viewHeight;
+
+    // Check if page overlaps with visible area
+    return (pageBottom > visibleTop && pageTop < visibleBottom);
+}
+
+void WebtoonScrollView::updateVisibleImages() {
+    // Find visible pages and preload nearby pages
+    int firstVisible = -1;
+    int lastVisible = -1;
+
+    for (int i = 0; i < static_cast<int>(m_pages.size()); i++) {
+        if (isPageVisible(i)) {
+            if (firstVisible < 0) firstVisible = i;
+            lastVisible = i;
+        }
+    }
+
+    if (firstVisible < 0) {
+        return;  // No visible pages
+    }
+
+    // Expand range for preloading
+    int loadStart = std::max(0, firstVisible - PRELOAD_PAGES);
+    int loadEnd = std::min(static_cast<int>(m_pages.size()) - 1, lastVisible + PRELOAD_PAGES);
+
+    // Load pages in range
+    for (int i = loadStart; i <= loadEnd; i++) {
+        if (m_loadedPages.count(i) > 0 || m_loadingPages.count(i) > 0) {
+            continue;  // Already loaded or loading
+        }
+
+        m_loadingPages.insert(i);
+
+        const Page& page = m_pages[i];
+        RotatableImage* img = m_pageImages[i];
+        int pageIndex = i;
+
+        // Load the image
+        if (page.totalSegments > 1) {
+            // Segmented webtoon page
+            ImageLoader::loadAsyncFullSizeSegment(
+                page.imageUrl, page.segment, page.totalSegments,
+                [this, pageIndex, img](RotatableImage* loadedImg) {
+                    m_loadingPages.erase(pageIndex);
+                    m_loadedPages.insert(pageIndex);
+
+                    // Update page height based on actual image dimensions
+                    if (img->hasImage()) {
+                        float imageWidth = static_cast<float>(img->getImageWidth());
+                        float imageHeight = static_cast<float>(img->getImageHeight());
+
+                        if (imageWidth > 0 && imageHeight > 0) {
+                            float availableWidth = m_viewWidth - (m_sidePadding * 2);
+                            float aspectRatio = imageHeight / imageWidth;
+                            float newHeight = availableWidth * aspectRatio;
+
+                            // Update total height
+                            float oldHeight = m_pageHeights[pageIndex];
+                            m_totalHeight += (newHeight - oldHeight);
+                            m_pageHeights[pageIndex] = newHeight;
+                            img->setHeight(newHeight);
+                        }
+                    }
+
+                    brls::Logger::debug("WebtoonScrollView: Loaded segment page {}", pageIndex);
+                }, img);
+        } else {
+            // Regular page
+            ImageLoader::loadAsyncFullSize(page.imageUrl,
+                [this, pageIndex, img](RotatableImage* loadedImg) {
+                    m_loadingPages.erase(pageIndex);
+                    m_loadedPages.insert(pageIndex);
+
+                    // Update page height based on actual image dimensions
+                    if (img->hasImage()) {
+                        float imageWidth = static_cast<float>(img->getImageWidth());
+                        float imageHeight = static_cast<float>(img->getImageHeight());
+
+                        if (imageWidth > 0 && imageHeight > 0) {
+                            float availableWidth = m_viewWidth - (m_sidePadding * 2);
+                            float aspectRatio = imageHeight / imageWidth;
+                            float newHeight = availableWidth * aspectRatio;
+
+                            // Update total height
+                            float oldHeight = m_pageHeights[pageIndex];
+                            m_totalHeight += (newHeight - oldHeight);
+                            m_pageHeights[pageIndex] = newHeight;
+                            img->setHeight(newHeight);
+                        }
+                    }
+
+                    brls::Logger::debug("WebtoonScrollView: Loaded page {}", pageIndex);
+                }, img);
+        }
+    }
+}
+
+void WebtoonScrollView::updateCurrentPage() {
+    // Find the page at the top of the visible area
+    float visibleTop = -m_scrollY;
+
+    int newCurrentPage = 0;
+    float offset = 0.0f;
+
+    for (int i = 0; i < static_cast<int>(m_pageHeights.size()); i++) {
+        float pageBottom = offset + m_pageHeights[i];
+
+        if (pageBottom > visibleTop) {
+            newCurrentPage = i;
+            break;
+        }
+
+        offset = pageBottom + m_pageGap;
+    }
+
+    if (newCurrentPage != m_currentPage) {
+        m_currentPage = newCurrentPage;
+
+        // Notify progress callback
+        if (m_progressCallback) {
+            m_progressCallback(m_currentPage, static_cast<int>(m_pages.size()), getScrollProgress());
+        }
+    }
+}
+
+void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, float height,
+                              brls::Style style, brls::FrameContext* ctx) {
+    // Update view dimensions
+    m_viewWidth = width;
+    m_viewHeight = height;
+
+    // Draw background
+    nvgBeginPath(vg);
+    nvgRect(vg, x, y, width, height);
+    nvgFillColor(vg, nvgRGBA(26, 26, 46, 255));
+    nvgFill(vg);
+
+    // Save state and set scissor for clipping
+    nvgSave(vg);
+    nvgScissor(vg, x, y, width, height);
+
+    // Calculate the X position for centered pages
+    float availableWidth = width - (m_sidePadding * 2);
+    float pageX = x + m_sidePadding;
+
+    // Draw visible pages
+    float currentY = y + m_scrollY;  // Start position adjusted by scroll
+
+    for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
+        float pageHeight = m_pageHeights[i];
+        float pageBottom = currentY + pageHeight;
+
+        // Check if page is in visible area (with some margin for smooth scrolling)
+        if (pageBottom >= y - 100 && currentY <= y + height + 100) {
+            // Draw this page
+            RotatableImage* img = m_pageImages[i];
+            if (img) {
+                // Update image width in case view resized
+                img->setWidth(availableWidth);
+
+                // Draw the image
+                img->draw(vg, pageX, currentY, availableWidth, pageHeight, style, ctx);
+            }
+        }
+
+        currentY = pageBottom + m_pageGap;
+    }
+
+    // Restore state
+    nvgRestore(vg);
+
+    // Call onFrame for momentum updates
+    onFrame();
+}
+
+brls::View* WebtoonScrollView::create() {
+    return new WebtoonScrollView();
+}
+
+} // namespace vitasuwayomi


### PR DESCRIPTION
Adds continuous scrolling to Webtoon reading mode, with image-rotation support in WebtoonScrollView, rotation-aware scrolling, and a fix for extension icon URLs missing the server prefix.

---
_Generated by [Claude Code](https://claude.ai/code)_