### PR TITLE
Add horizontal layout for 90/270 degree rotation in WebtoonScrollView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(APP_SOURCES
     src/view/media_item_cell.cpp
     src/view/recycling_grid.cpp
     src/view/rotatable_image.cpp
+    src/view/rotatable_label.cpp
     src/view/webtoon_scroll_view.cpp
     src/view/downloads_tab.cpp
     src/view/extensions_tab.cpp

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -11,6 +11,7 @@
 #include "app/suwayomi_client.hpp"
 #include "app/application.hpp"
 #include "view/rotatable_image.hpp"
+#include "view/rotatable_label.hpp"
 #include "view/webtoon_scroll_view.hpp"
 
 namespace vitasuwayomi {
@@ -102,14 +103,16 @@ private:
     void hidePageCounter();
     void schedulePageCounterHide();
 
+    // Update page counter rotation/position
+    void updatePageCounterRotation();
+
     // UI components - NOBORU style
     BRLS_BIND(brls::Box, container, "reader/container");
     BRLS_BIND(RotatableImage, pageImage, "reader/page_image");
     BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");  // Preview page for swipe
     BRLS_BIND(brls::Box, topBar, "reader/top_bar");
     BRLS_BIND(brls::Box, bottomBar, "reader/bottom_bar");
-    BRLS_BIND(brls::Box, pageCounter, "reader/page_counter");
-    BRLS_BIND(brls::Label, pageLabel, "reader/page_label");
+    BRLS_BIND(RotatableLabel, pageCounter, "reader/page_counter");
     BRLS_BIND(brls::Label, mangaLabel, "reader/manga_label");
     BRLS_BIND(brls::Label, chapterLabel, "reader/chapter_label");
     BRLS_BIND(brls::Label, chapterProgress, "reader/chapter_progress");

--- a/include/view/rotatable_label.hpp
+++ b/include/view/rotatable_label.hpp
@@ -1,0 +1,82 @@
+/**
+ * RotatableLabel - Label with rotation support for display at 0/90/180/270 degrees
+ * Uses NanoVG text rendering with rotation transforms
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include <string>
+
+namespace vitasuwayomi {
+
+class RotatableLabel : public brls::Box {
+public:
+    RotatableLabel();
+    ~RotatableLabel() = default;
+
+    void draw(NVGcontext* vg, float x, float y, float width, float height,
+              brls::Style style, brls::FrameContext* ctx) override;
+
+    /**
+     * Set the text to display
+     */
+    void setText(const std::string& text);
+
+    /**
+     * Get current text
+     */
+    const std::string& getText() const { return m_text; }
+
+    /**
+     * Set rotation in degrees (0, 90, 180, 270)
+     */
+    void setRotation(float degrees);
+
+    /**
+     * Get current rotation in degrees
+     */
+    float getRotation() const { return m_rotationDegrees; }
+
+    /**
+     * Set text color
+     */
+    void setTextColor(NVGcolor color) { m_textColor = color; }
+
+    /**
+     * Set font size
+     */
+    void setFontSize(float size) { m_fontSize = size; }
+
+    /**
+     * Set background color (for the rounded rect behind text)
+     */
+    void setBackgroundColor(NVGcolor color) { m_bgColor = color; }
+
+    /**
+     * Set corner radius
+     */
+    void setCornerRadius(float radius) { m_cornerRadius = radius; }
+
+    /**
+     * Set padding
+     */
+    void setPadding(float horizontal, float vertical) {
+        m_paddingH = horizontal;
+        m_paddingV = vertical;
+    }
+
+    static brls::View* create();
+
+private:
+    std::string m_text = "";
+    float m_rotationDegrees = 0.0f;
+    float m_fontSize = 14.0f;
+    float m_cornerRadius = 4.0f;
+    float m_paddingH = 12.0f;
+    float m_paddingV = 6.0f;
+    NVGcolor m_textColor = nvgRGBA(255, 255, 255, 255);
+    NVGcolor m_bgColor = nvgRGBA(0, 0, 0, 170);  // Semi-transparent black
+};
+
+} // namespace vitasuwayomi

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -102,8 +102,11 @@ private:
     // Check if a page is in the visible range
     bool isPageVisible(int pageIndex) const;
 
-    // Calculate the Y offset for a page
+    // Calculate the offset for a page (Y for vertical, X for horizontal)
     float getPageOffset(int pageIndex) const;
+
+    // Check if layout should be horizontal (at 90 or 270 rotation)
+    bool isHorizontalLayout() const;
 
     // Update current page based on scroll position
     void updateCurrentPage();

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -108,6 +108,12 @@ private:
     // Check if layout should be horizontal (at 90 or 270 rotation)
     bool isHorizontalLayout() const;
 
+    // Get effective page size for current layout mode (width for horizontal, height for vertical)
+    float getEffectivePageSize(int pageIndex) const;
+
+    // Get total content size for current layout mode
+    float getTotalContentSize() const;
+
     // Update current page based on scroll position
     void updateCurrentPage();
 

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -36,30 +36,15 @@
         positionLeft="0"
         visibility="gone"/>
 
-    <!-- Page counter overlay (top-right, auto-hides) -->
-    <brls:Box
+    <!-- Page counter overlay (top-right, auto-hides, rotates with content) -->
+    <RotatableLabel
         id="reader/page_counter"
-        width="auto"
-        height="32"
-        axis="row"
-        justifyContent="center"
-        alignItems="center"
-        paddingLeft="12"
-        paddingRight="12"
-        backgroundColor="#000000AA"
+        width="80"
+        height="40"
         positionType="absolute"
         positionTop="10"
         positionRight="10"
-        cornerRadius="4"
-        visibility="visible">
-
-        <brls:Label
-            id="reader/page_label"
-            text="1/20"
-            fontSize="14"
-            textColor="#ffffff"
-            horizontalAlign="center"/>
-    </brls:Box>
+        visibility="visible"/>
 
     <!-- Top bar overlay (80px, NOBORU style) -->
     <brls:Box

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1091,55 +1091,16 @@ void ReaderActivity::updatePageCounterRotation() {
     // Get rotation in degrees
     float rotation = static_cast<float>(m_settings.rotation);
 
-    // Screen dimensions (PS Vita)
-    const float SCREEN_WIDTH = 960.0f;
-    const float SCREEN_HEIGHT = 544.0f;
-    const float COUNTER_MARGIN = 10.0f;
-
-    // Counter dimensions from XML
-    float counterWidth = 80.0f;
-    float counterHeight = 40.0f;
-
     // Apply rotation to the RotatableLabel (text will rotate with it)
     pageCounter->setRotation(rotation);
 
-    // Reset any previous transform
+    // Keep counter fixed at physical top-right corner of screen
+    // Position is set in XML (positionTop=10, positionRight=10)
+    // No translation needed - counter stays in place, only text rotates
     pageCounter->setTranslationX(0.0f);
     pageCounter->setTranslationY(0.0f);
 
-    // Position the counter to stay in a logical position for the user
-    // When content is rotated, we move the counter so it appears in the
-    // "top-right" from the user's perspective in the rotated view
-    int rot = static_cast<int>(rotation);
-    switch (rot) {
-        case 0:
-            // Normal: top-right, no translation needed
-            // Position is already set in XML (positionTop=10, positionRight=10)
-            break;
-
-        case 90:
-            // Content rotated 90° clockwise
-            // Counter needs to move to bottom-right to appear at "top-right" for user
-            pageCounter->setTranslationX(0.0f);
-            pageCounter->setTranslationY(SCREEN_HEIGHT - counterHeight - 2 * COUNTER_MARGIN);
-            break;
-
-        case 180:
-            // Content rotated 180° (upside down)
-            // Counter needs to move to bottom-left to appear at "top-right" for user
-            pageCounter->setTranslationX(-(SCREEN_WIDTH - counterWidth - 2 * COUNTER_MARGIN));
-            pageCounter->setTranslationY(SCREEN_HEIGHT - counterHeight - 2 * COUNTER_MARGIN);
-            break;
-
-        case 270:
-            // Content rotated 270° clockwise (90° counter-clockwise)
-            // Counter needs to move to top-left to appear at "top-right" for user
-            pageCounter->setTranslationX(-(SCREEN_WIDTH - counterWidth - 2 * COUNTER_MARGIN));
-            pageCounter->setTranslationY(0.0f);
-            break;
-    }
-
-    brls::Logger::debug("ReaderActivity: Page counter rotation set to {}°", rot);
+    brls::Logger::debug("ReaderActivity: Page counter rotation set to {}°", static_cast<int>(rotation));
 }
 
 void ReaderActivity::showSettings() {

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -992,8 +992,16 @@ void ReaderActivity::nextChapter() {
                                          " of " + std::to_string(m_totalChapters));
             }
 
+            // Handle webtoon mode vs single-page mode
+            if (m_continuousScrollMode && webtoonScroll) {
+                // Update webtoon scroll view with new pages and scroll to beginning
+                webtoonScroll->setPages(m_pages, 960.0f);  // PS Vita screen width
+                webtoonScroll->scrollToPage(0);
+            } else {
+                loadPage(m_currentPage);
+            }
+
             updatePageDisplay();
-            loadPage(m_currentPage);
 
             // Start preloading next chapter
             preloadNextChapter();
@@ -1013,6 +1021,11 @@ void ReaderActivity::previousChapter() {
         m_currentPage = 0;
         m_pages.clear();
         m_cachedImages.clear();
+
+        // Clear webtoon scroll view to reset scroll position for new chapter
+        if (m_continuousScrollMode && webtoonScroll) {
+            webtoonScroll->clearPages();
+        }
 
         loadPages();
     }

--- a/src/view/rotatable_label.cpp
+++ b/src/view/rotatable_label.cpp
@@ -1,0 +1,101 @@
+/**
+ * RotatableLabel implementation
+ * Uses NanoVG for rotated text rendering
+ */
+
+#include "view/rotatable_label.hpp"
+#include <cmath>
+
+#ifndef NVG_PI
+#define NVG_PI 3.14159265358979323846264338327f
+#endif
+
+namespace vitasuwayomi {
+
+RotatableLabel::RotatableLabel() {
+    this->setFocusable(false);
+}
+
+void RotatableLabel::setText(const std::string& text) {
+    m_text = text;
+    this->invalidate();
+}
+
+void RotatableLabel::setRotation(float degrees) {
+    // Normalize to 0, 90, 180, 270
+    int normalized = static_cast<int>(degrees) % 360;
+    if (normalized < 0) normalized += 360;
+
+    // Snap to nearest 90 degree increment
+    if (normalized < 45) {
+        m_rotationDegrees = 0.0f;
+    } else if (normalized < 135) {
+        m_rotationDegrees = 90.0f;
+    } else if (normalized < 225) {
+        m_rotationDegrees = 180.0f;
+    } else if (normalized < 315) {
+        m_rotationDegrees = 270.0f;
+    } else {
+        m_rotationDegrees = 0.0f;
+    }
+
+    this->invalidate();
+}
+
+void RotatableLabel::draw(NVGcontext* vg, float x, float y, float width, float height,
+                           brls::Style style, brls::FrameContext* ctx) {
+    if (m_text.empty()) return;
+
+    // Calculate text bounds to determine actual size needed
+    nvgFontSize(vg, m_fontSize);
+    nvgFontFace(vg, "regular");
+    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+
+    float bounds[4];
+    nvgTextBounds(vg, 0, 0, m_text.c_str(), nullptr, bounds);
+    float textWidth = bounds[2] - bounds[0];
+    float textHeight = bounds[3] - bounds[1];
+
+    // Box dimensions with padding
+    float boxWidth = textWidth + m_paddingH * 2;
+    float boxHeight = textHeight + m_paddingV * 2;
+
+    // For 90/270 rotation, swap effective dimensions for positioning
+    bool isRotated90or270 = (m_rotationDegrees == 90.0f || m_rotationDegrees == 270.0f);
+    float effectiveBoxWidth = isRotated90or270 ? boxHeight : boxWidth;
+    float effectiveBoxHeight = isRotated90or270 ? boxWidth : boxHeight;
+
+    // Center of the view
+    float viewCenterX = x + width / 2.0f;
+    float viewCenterY = y + height / 2.0f;
+
+    // Save NVG state
+    nvgSave(vg);
+
+    // Apply rotation around the view center
+    nvgTranslate(vg, viewCenterX, viewCenterY);
+    nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
+    nvgTranslate(vg, -viewCenterX, -viewCenterY);
+
+    // Draw background box (centered in the view)
+    float boxX = viewCenterX - boxWidth / 2.0f;
+    float boxY = viewCenterY - boxHeight / 2.0f;
+
+    nvgBeginPath(vg);
+    nvgRoundedRect(vg, boxX, boxY, boxWidth, boxHeight, m_cornerRadius);
+    nvgFillColor(vg, m_bgColor);
+    nvgFill(vg);
+
+    // Draw text
+    nvgFillColor(vg, m_textColor);
+    nvgText(vg, viewCenterX, viewCenterY, m_text.c_str(), nullptr);
+
+    // Restore NVG state
+    nvgRestore(vg);
+}
+
+brls::View* RotatableLabel::create() {
+    return new RotatableLabel();
+}
+
+} // namespace vitasuwayomi

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -43,21 +43,24 @@ void WebtoonScrollView::setupGestures() {
                 float rawDy = status.position.y - m_touchLast.y;
 
                 // Calculate scroll delta based on rotation
-                // 0°: Normal vertical scrolling (dy)
-                // 90°: Horizontal scrolling, swipe left = scroll down (-dx)
-                // 180°: Inverted vertical scrolling (-dy)
-                // 270°: Horizontal scrolling, swipe right = scroll down (dx)
+                // scrollY: 0 = beginning (top/left), negative = scrolled towards end
+                // 0°: Normal vertical scrolling - swipe up (negative dy) to scroll down
+                // 90°: Horizontal scrolling - swipe left (negative dx) to scroll down (forward)
+                // 180°: Inverted vertical scrolling - swipe down (positive dy) to scroll down
+                // 270°: Horizontal scrolling - swipe right (positive dx) to scroll down (forward)
                 float scrollDelta = 0.0f;
                 int rotation = static_cast<int>(m_rotationDegrees);
 
                 if (rotation == 0) {
                     scrollDelta = rawDy;
                 } else if (rotation == 90) {
-                    scrollDelta = -rawDx;
+                    // Swipe left (negative dx) should scroll forward (decrease scrollY)
+                    scrollDelta = rawDx;
                 } else if (rotation == 180) {
                     scrollDelta = -rawDy;
                 } else if (rotation == 270) {
-                    scrollDelta = rawDx;
+                    // Swipe right (positive dx) should scroll forward (decrease scrollY)
+                    scrollDelta = -rawDx;
                 }
 
                 // Update scroll position

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -63,9 +63,11 @@ void WebtoonScrollView::setupGestures() {
                 // Update scroll position
                 m_scrollY += scrollDelta;
 
-                // Clamp scroll position
+                // Clamp scroll position based on layout direction
                 float maxScroll = 0.0f;
-                float minScroll = -(m_totalHeight - m_viewHeight);
+                bool horizontal = (rotation == 90 || rotation == 270);
+                float viewSize = horizontal ? m_viewWidth : m_viewHeight;
+                float minScroll = -(m_totalHeight - viewSize);
                 if (minScroll > maxScroll) minScroll = maxScroll;
 
                 m_scrollY = std::max(minScroll, std::min(maxScroll, m_scrollY));
@@ -175,14 +177,15 @@ void WebtoonScrollView::scrollToPage(int pageIndex) {
     }
 
     // Calculate scroll position for this page
-    float targetY = -getPageOffset(pageIndex);
+    float targetScroll = -getPageOffset(pageIndex);
 
-    // Clamp scroll position
+    // Clamp scroll position based on layout direction
     float maxScroll = 0.0f;
-    float minScroll = -(m_totalHeight - m_viewHeight);
+    float viewSize = isHorizontalLayout() ? m_viewWidth : m_viewHeight;
+    float minScroll = -(m_totalHeight - viewSize);
     if (minScroll > maxScroll) minScroll = maxScroll;
 
-    m_scrollY = std::max(minScroll, std::min(maxScroll, targetY));
+    m_scrollY = std::max(minScroll, std::min(maxScroll, targetScroll));
     m_scrollVelocity = 0.0f;
 
     updateVisibleImages();
@@ -190,10 +193,11 @@ void WebtoonScrollView::scrollToPage(int pageIndex) {
 }
 
 float WebtoonScrollView::getScrollProgress() const {
-    if (m_totalHeight <= m_viewHeight) {
+    float viewSize = isHorizontalLayout() ? m_viewWidth : m_viewHeight;
+    if (m_totalHeight <= viewSize) {
         return 0.0f;
     }
-    float scrollable = m_totalHeight - m_viewHeight;
+    float scrollable = m_totalHeight - viewSize;
     return std::min(1.0f, std::max(0.0f, -m_scrollY / scrollable));
 }
 
@@ -233,15 +237,21 @@ void WebtoonScrollView::setRotation(float degrees) {
     brls::Logger::debug("WebtoonScrollView: setRotation({}) -> {} degrees", degrees, m_rotationDegrees);
 }
 
+bool WebtoonScrollView::isHorizontalLayout() const {
+    int rotation = static_cast<int>(m_rotationDegrees);
+    return (rotation == 90 || rotation == 270);
+}
+
 void WebtoonScrollView::onFrame() {
     // Apply momentum scrolling when not touching
     if (!m_isTouching && std::abs(m_scrollVelocity) > MOMENTUM_MIN_VELOCITY) {
         m_scrollY += m_scrollVelocity;
         m_scrollVelocity *= MOMENTUM_FRICTION;
 
-        // Clamp scroll position
+        // Clamp scroll position based on layout direction
         float maxScroll = 0.0f;
-        float minScroll = -(m_totalHeight - m_viewHeight);
+        float viewSize = isHorizontalLayout() ? m_viewWidth : m_viewHeight;
+        float minScroll = -(m_totalHeight - viewSize);
         if (minScroll > maxScroll) minScroll = maxScroll;
 
         // Bounce back if out of bounds
@@ -275,15 +285,25 @@ bool WebtoonScrollView::isPageVisible(int pageIndex) const {
         return false;
     }
 
-    float pageTop = getPageOffset(pageIndex);
-    float pageBottom = pageTop + m_pageHeights[pageIndex];
+    float pageStart = getPageOffset(pageIndex);
+    float pageSize = m_pageHeights[pageIndex];
+    float pageEnd = pageStart + pageSize;
 
-    // Current visible range (scrollY is negative when scrolled down)
-    float visibleTop = -m_scrollY;
-    float visibleBottom = visibleTop + m_viewHeight;
+    if (isHorizontalLayout()) {
+        // Horizontal layout: check X position
+        float visibleLeft = -m_scrollY;  // scrollY acts as scrollX
+        float visibleRight = visibleLeft + m_viewWidth;
 
-    // Check if page overlaps with visible area
-    return (pageBottom > visibleTop && pageTop < visibleBottom);
+        // Check if page overlaps with visible area
+        return (pageEnd > visibleLeft && pageStart < visibleRight);
+    } else {
+        // Vertical layout: check Y position
+        float visibleTop = -m_scrollY;
+        float visibleBottom = visibleTop + m_viewHeight;
+
+        // Check if page overlaps with visible area
+        return (pageEnd > visibleTop && pageStart < visibleBottom);
+    }
 }
 
 void WebtoonScrollView::updateVisibleImages() {
@@ -379,21 +399,22 @@ void WebtoonScrollView::updateVisibleImages() {
 }
 
 void WebtoonScrollView::updateCurrentPage() {
-    // Find the page at the top of the visible area
-    float visibleTop = -m_scrollY;
+    // Find the page at the start of the visible area
+    // (top for vertical layout, left for horizontal layout)
+    float visibleStart = -m_scrollY;
 
     int newCurrentPage = 0;
     float offset = 0.0f;
 
     for (int i = 0; i < static_cast<int>(m_pageHeights.size()); i++) {
-        float pageBottom = offset + m_pageHeights[i];
+        float pageEnd = offset + m_pageHeights[i];
 
-        if (pageBottom > visibleTop) {
+        if (pageEnd > visibleStart) {
             newCurrentPage = i;
             break;
         }
 
-        offset = pageBottom + m_pageGap;
+        offset = pageEnd + m_pageGap;
     }
 
     if (newCurrentPage != m_currentPage) {
@@ -422,31 +443,65 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
     nvgSave(vg);
     nvgScissor(vg, x, y, width, height);
 
-    // Calculate the X position for centered pages
-    float availableWidth = width - (m_sidePadding * 2);
-    float pageX = x + m_sidePadding;
+    bool horizontal = isHorizontalLayout();
 
-    // Draw visible pages
-    float currentY = y + m_scrollY;  // Start position adjusted by scroll
+    if (horizontal) {
+        // Horizontal layout (for 90/270 rotation)
+        // Pages are laid out left to right, scrollY acts as scrollX
+        float availableHeight = height - (m_sidePadding * 2);
+        float pageY = y + m_sidePadding;
 
-    for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
-        float pageHeight = m_pageHeights[i];
-        float pageBottom = currentY + pageHeight;
+        // Draw visible pages horizontally
+        float currentX = x + m_scrollY;  // scrollY is used as horizontal offset
 
-        // Check if page is in visible area (with some margin for smooth scrolling)
-        if (pageBottom >= y - 100 && currentY <= y + height + 100) {
-            // Draw this page
-            RotatableImage* img = m_pageImages[i];
-            if (img) {
-                // Update image width in case view resized
-                img->setWidth(availableWidth);
+        for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
+            float pageWidth = m_pageHeights[i];  // In horizontal mode, "height" becomes width
+            float pageRight = currentX + pageWidth;
 
-                // Draw the image
-                img->draw(vg, pageX, currentY, availableWidth, pageHeight, style, ctx);
+            // Check if page is in visible area (with some margin for smooth scrolling)
+            if (pageRight >= x - 100 && currentX <= x + width + 100) {
+                // Draw this page
+                RotatableImage* img = m_pageImages[i];
+                if (img) {
+                    // Update image size for horizontal layout
+                    img->setWidth(pageWidth);
+                    img->setHeight(availableHeight);
+
+                    // Draw the image
+                    img->draw(vg, currentX, pageY, pageWidth, availableHeight, style, ctx);
+                }
             }
-        }
 
-        currentY = pageBottom + m_pageGap;
+            currentX = pageRight + m_pageGap;
+        }
+    } else {
+        // Vertical layout (for 0/180 rotation)
+        // Calculate the X position for centered pages
+        float availableWidth = width - (m_sidePadding * 2);
+        float pageX = x + m_sidePadding;
+
+        // Draw visible pages vertically
+        float currentY = y + m_scrollY;  // Start position adjusted by scroll
+
+        for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
+            float pageHeight = m_pageHeights[i];
+            float pageBottom = currentY + pageHeight;
+
+            // Check if page is in visible area (with some margin for smooth scrolling)
+            if (pageBottom >= y - 100 && currentY <= y + height + 100) {
+                // Draw this page
+                RotatableImage* img = m_pageImages[i];
+                if (img) {
+                    // Update image width in case view resized
+                    img->setWidth(availableWidth);
+
+                    // Draw the image
+                    img->draw(vg, pageX, currentY, availableWidth, pageHeight, style, ctx);
+                }
+            }
+
+            currentY = pageBottom + m_pageGap;
+        }
     }
 
     // Restore state


### PR DESCRIPTION
Adds a horizontal layout for 90/270° rotation in WebtoonScrollView and fixes the associated issues: blank space between pages, scroll direction and chapter transitions, a fixed top-right page counter, and page rotation direction.

---
_Generated by [Claude Code](https://claude.ai/code)_