### PR TITLE
Make download queue scrollable and reduce notifications

### DIFF
--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -98,6 +98,24 @@ public:
     bool cancelDownload(int mangaId);
     bool cancelChapterDownload(int mangaId, int chapterIndex);
 
+    // Reorder queue items (for touch-based queue management)
+    // direction: -1 for up (earlier in queue), +1 for down (later in queue)
+    bool moveChapterInQueue(int mangaId, int chapterIndex, int direction);
+
+    // Get flat list of all queued/downloading chapters for display
+    struct QueuedChapterInfo {
+        int mangaId;
+        int chapterId;
+        int chapterIndex;
+        std::string mangaTitle;
+        std::string chapterName;
+        float chapterNumber;
+        int pageCount;
+        int downloadedPages;
+        LocalDownloadState state;
+    };
+    std::vector<QueuedChapterInfo> getQueuedChapters() const;
+
     // Delete downloaded manga/chapters
     bool deleteMangaDownload(int mangaId);
     bool deleteChapterDownload(int mangaId, int chapterIndex);

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -156,6 +156,9 @@ public:
     // Check if there are any incomplete downloads
     bool hasIncompleteDownloads() const;
 
+    // Count incomplete downloads (returns number of chapters to resume)
+    int countIncompleteDownloads() const;
+
     // Set progress callback for UI updates
     void setProgressCallback(DownloadProgressCallback callback);
 

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -22,8 +22,17 @@ private:
     void refreshLocalDownloads();
     void showDownloadOptions(const std::string& ratingKey, const std::string& title);
 
+    // Queue section (server downloads)
+    brls::Box* m_queueSection = nullptr;
+    brls::Label* m_queueHeader = nullptr;
+    brls::ScrollingFrame* m_queueScroll = nullptr;
     brls::Box* m_queueContainer = nullptr;
     brls::Label* m_queueEmptyLabel = nullptr;
+
+    // Local downloads section
+    brls::Box* m_localSection = nullptr;
+    brls::Label* m_localHeader = nullptr;
+    brls::ScrollingFrame* m_localScroll = nullptr;
     brls::Box* m_localContainer = nullptr;
     brls::Label* m_localEmptyLabel = nullptr;
 };

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -35,6 +35,9 @@ private:
     brls::ScrollingFrame* m_localScroll = nullptr;
     brls::Box* m_localContainer = nullptr;
     brls::Label* m_localEmptyLabel = nullptr;
+
+    // Track currently focused X button icon (like book detail view)
+    brls::Image* m_currentFocusedIcon = nullptr;
 };
 
 } // namespace vitasuwayomi

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -127,6 +127,7 @@ bool DownloadsManager::init() {
     // Auto-resume downloads if setting is enabled and there are incomplete downloads
     if (Application::getInstance().getSettings().autoResumeDownloads && hasIncompleteDownloads()) {
         brls::Logger::info("DownloadsManager: Auto-resuming incomplete downloads");
+        brls::Application::notify("Resuming downloads...");
         startDownloads();
     }
 

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -129,9 +129,9 @@ bool DownloadsManager::init() {
         int chapterCount = countIncompleteDownloads();
         brls::Logger::info("DownloadsManager: Auto-resuming {} incomplete downloads", chapterCount);
         if (chapterCount == 1) {
-            brls::Application::notify("Resuming 1 chapter...");
+            brls::Application::notify("Resuming 1 download...");
         } else {
-            brls::Application::notify("Resuming " + std::to_string(chapterCount) + " chapters...");
+            brls::Application::notify("Resuming " + std::to_string(chapterCount) + " downloads...");
         }
         startDownloads();
     }

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -107,9 +107,9 @@ DownloadsTab::DownloadsTab() {
     m_localHeader->setMargins(0, 0, 10, 0);
     m_localSection->addView(m_localHeader);
 
-    // Scrollable local container with max height
+    // Scrollable local container
     m_localScroll = new brls::ScrollingFrame();
-    m_localScroll->setMaxHeight(300);  // Limit height to make it scrollable
+    m_localScroll->setGrow(1.0f);
     m_localSection->addView(m_localScroll);
 
     m_localContainer = new brls::Box();

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -278,15 +278,13 @@ void DownloadsTab::refreshQueue() {
                 // X button action - remove from server queue
                 int mangaId = item.mangaId;
                 int chapterId = item.chapterId;
-                int chapterIndex = item.chapterIndex;
                 row->registerAction("Remove", brls::ControllerButton::BUTTON_X,
-                    [this, mangaId, chapterId, chapterIndex](brls::View* view) {
-                        asyncRun([this, mangaId, chapterId, chapterIndex]() {
+                    [this, mangaId, chapterId](brls::View* view) {
+                        asyncRun([this, mangaId, chapterId]() {
                             SuwayomiClient& client = SuwayomiClient::getInstance();
                             // Remove from server queue using existing method
                             std::vector<int> chapterIds = {chapterId};
-                            std::vector<int> chapterIndexes = {chapterIndex};
-                            client.deleteChapterDownloads(chapterIds, mangaId, chapterIndexes);
+                            client.deleteChapterDownloads(chapterIds, mangaId);
                             brls::sync([this]() {
                                 refresh();
                             });
@@ -296,7 +294,7 @@ void DownloadsTab::refreshQueue() {
 
                 // Add swipe gesture for removal
                 row->addGestureRecognizer(new brls::PanGestureRecognizer(
-                    [this, row, mangaId, chapterId, chapterIndex, originalBgColor](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+                    [this, row, mangaId, chapterId, originalBgColor](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
                         static brls::Point touchStart;
                         static bool isValidSwipe = false;
                         const float SWIPE_THRESHOLD = 60.0f;
@@ -325,11 +323,10 @@ void DownloadsTab::refreshQueue() {
                             float dx = status.position.x - touchStart.x;
                             if (isValidSwipe && dx < -SWIPE_THRESHOLD) {
                                 // Left swipe confirmed - remove from queue
-                                asyncRun([this, mangaId, chapterId, chapterIndex]() {
+                                asyncRun([this, mangaId, chapterId]() {
                                     SuwayomiClient& client = SuwayomiClient::getInstance();
                                     std::vector<int> chapterIds = {chapterId};
-                                    std::vector<int> chapterIndexes = {chapterIndex};
-                                    client.deleteChapterDownloads(chapterIds, mangaId, chapterIndexes);
+                                    client.deleteChapterDownloads(chapterIds, mangaId);
                                     brls::sync([this]() {
                                         refresh();
                                     });

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -67,6 +67,7 @@ DownloadsTab::DownloadsTab() {
     // === Download Queue Section (server downloads) ===
     m_queueSection = new brls::Box();
     m_queueSection->setAxis(brls::Axis::COLUMN);
+    m_queueSection->setGrow(1.0f);
     m_queueSection->setMargins(0, 0, 15, 0);
     m_queueSection->setVisibility(brls::Visibility::GONE);  // Hidden by default
     this->addView(m_queueSection);
@@ -77,9 +78,9 @@ DownloadsTab::DownloadsTab() {
     m_queueHeader->setMargins(0, 0, 10, 0);
     m_queueSection->addView(m_queueHeader);
 
-    // Scrollable queue container with max height
+    // Scrollable queue container
     m_queueScroll = new brls::ScrollingFrame();
-    m_queueScroll->setMaxHeight(300);  // Limit height to make it scrollable
+    m_queueScroll->setGrow(1.0f);  // Allow proper scrolling
     m_queueSection->addView(m_queueScroll);
 
     m_queueContainer = new brls::Box();

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -720,15 +720,9 @@ void MangaDetailView::populateChaptersList() {
                                     DownloadsManager& dm = DownloadsManager::getInstance();
                                     dm.init();
                                     if (dm.queueChapterDownload(mangaId, chapterId, chapterIndex, mangaTitle, chapterName)) {
-                                        dm.setProgressCallback([](int downloaded, int total) {
-                                            brls::sync([downloaded, total]() {
-                                                std::string msg = std::to_string(downloaded) + "/" + std::to_string(total) + " pages";
-                                                brls::Application::notify(msg);
-                                            });
-                                        });
                                         dm.startDownloads();
                                         brls::sync([]() {
-                                            brls::Application::notify("Download started");
+                                            brls::Application::notify("Download queued");
                                         });
                                     }
                                 });
@@ -1031,7 +1025,6 @@ void MangaDetailView::showDownloadOptions() {
 
 void MangaDetailView::downloadAllChapters() {
     brls::Logger::info("MangaDetailView: Downloading all chapters");
-    brls::Application::notify("Queueing all chapters for download...");
 
     // Get download mode setting
     DownloadMode downloadMode = Application::getInstance().getSettings().downloadMode;
@@ -1094,14 +1087,6 @@ void MangaDetailView::downloadAllChapters() {
         if (!localChapterPairs.empty()) {
             brls::Logger::info("MangaDetailView: Queueing {} to LOCAL", localChapterPairs.size());
             if (localMgr.queueChaptersDownload(mangaId, localChapterPairs, mangaTitle)) {
-                // Set progress callback for UI updates (doesn't capture 'this')
-                localMgr.setProgressCallback([](int downloaded, int total) {
-                    brls::sync([downloaded, total]() {
-                        std::string msg = std::to_string(downloaded) + "/" + std::to_string(total) + " pages";
-                        brls::Application::notify(msg);
-                    });
-                });
-
                 localMgr.startDownloads();
                 brls::Logger::info("MangaDetailView: Local queue SUCCESS");
             } else {
@@ -1137,7 +1122,6 @@ void MangaDetailView::downloadAllChapters() {
 
 void MangaDetailView::downloadUnreadChapters() {
     brls::Logger::info("MangaDetailView: Downloading unread chapters");
-    brls::Application::notify("Queueing unread chapters for download...");
 
     // Get download mode setting
     DownloadMode downloadMode = Application::getInstance().getSettings().downloadMode;
@@ -1192,14 +1176,6 @@ void MangaDetailView::downloadUnreadChapters() {
 
         if (!localChapterPairs.empty()) {
             if (localMgr.queueChaptersDownload(mangaId, localChapterPairs, mangaTitle)) {
-                // Set progress callback for UI updates (doesn't capture 'this')
-                localMgr.setProgressCallback([](int downloaded, int total) {
-                    brls::sync([downloaded, total]() {
-                        std::string msg = std::to_string(downloaded) + "/" + std::to_string(total) + " pages";
-                        brls::Application::notify(msg);
-                    });
-                });
-
                 localMgr.startDownloads();
             } else {
                 localSuccess = false;
@@ -1410,8 +1386,6 @@ void MangaDetailView::markChapterRead(const Chapter& chapter) {
 }
 
 void MangaDetailView::downloadChapter(const Chapter& chapter) {
-    brls::Application::notify("Downloading to Vita...");
-
     // Collect chapter data before async to avoid accessing view members
     int mangaId = m_manga.id;
     int chapterId = chapter.id;
@@ -1426,19 +1400,9 @@ void MangaDetailView::downloadChapter(const Chapter& chapter) {
 
         // Queue chapter for local download (using chapterId for API calls)
         if (dm.queueChapterDownload(mangaId, chapterId, chapterIndex, mangaTitle, chapterName)) {
-            // Set progress callback for UI updates (doesn't capture 'this')
-            dm.setProgressCallback([](int downloaded, int total) {
-                brls::sync([downloaded, total]() {
-                    std::string msg = std::to_string(downloaded) + "/" + std::to_string(total) + " pages";
-                    brls::Application::notify(msg);
-                });
-            });
-
-            // Start downloading
             dm.startDownloads();
-
             brls::sync([]() {
-                brls::Application::notify("Download started");
+                brls::Application::notify("Download queued");
             });
         } else {
             brls::sync([]() {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -620,7 +620,7 @@ void MangaDetailView::populateChaptersList() {
                 DownloadsManager& dm = DownloadsManager::getInstance();
                 if (dm.cancelChapterDownload(m_manga.id, chapterIdx)) {
                     brls::Application::notify("Removed from queue");
-                    refreshChaptersList();
+                    populateChaptersList();
                 }
             } else if (localDownloaded) {
                 deleteChapterDownload(capturedChapter);
@@ -721,7 +721,7 @@ void MangaDetailView::populateChaptersList() {
                                     if (dm.cancelChapterDownload(mangaId, chapterIndex)) {
                                         brls::sync([this]() {
                                             brls::Application::notify("Removed from queue");
-                                            refreshChaptersList();
+                                            populateChaptersList();
                                         });
                                     }
                                 });


### PR DESCRIPTION
Makes the download queue scrollable and quieter: chapter-by-chapter local queue display, touch controls and an X button for queue management (including on the book detail page), fewer notifications, and several build/display fixes for the queue.

---
_Generated by [Claude Code](https://claude.ai/code)_