### PR TITLE
Fix local downloads not allowing d-pad navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(APP_SOURCES
     src/view/downloads_tab.cpp
     src/view/extensions_tab.cpp
     src/view/source_browse_tab.cpp
+    src/view/horizontal_scroll_row.cpp
 
     # Utils
     src/utils/http_client.cpp

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <map>
+#include <set>
 #include "utils/http_client.hpp"
 
 namespace vitasuwayomi {
@@ -303,6 +304,8 @@ public:
 
     // Extension Management
     bool fetchExtensionList(std::vector<Extension>& extensions);
+    bool fetchInstalledExtensions(std::vector<Extension>& extensions);  // Server-side filtered: installed only
+    bool fetchUninstalledExtensions(std::vector<Extension>& extensions, const std::set<std::string>& languages);  // Server-side filtered by languages
     bool installExtension(const std::string& pkgName);
     bool updateExtension(const std::string& pkgName);
     bool uninstallExtension(const std::string& pkgName);
@@ -456,6 +459,8 @@ private:
 
     // Extension GraphQL methods
     bool fetchExtensionListGraphQL(std::vector<Extension>& extensions);
+    bool fetchInstalledExtensionsGraphQL(std::vector<Extension>& extensions);  // Server-side filtered
+    bool fetchUninstalledExtensionsGraphQL(std::vector<Extension>& extensions, const std::set<std::string>& languages);  // Server-side filtered
     bool installExtensionGraphQL(const std::string& pkgName);
     bool updateExtensionGraphQL(const std::string& pkgName);
     bool uninstallExtensionGraphQL(const std::string& pkgName);

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -38,6 +38,11 @@ private:
 
     // Track currently focused X button icon (like book detail view)
     brls::Image* m_currentFocusedIcon = nullptr;
+
+    // Top action icons
+    brls::Box* m_actionsRow = nullptr;
+    brls::Image* m_hideIcon = nullptr;
+    brls::Image* m_showIcon = nullptr;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -1,7 +1,7 @@
 /**
  * VitaSuwayomi - Extensions Tab
  * Manage Suwayomi extensions (install, update, uninstall)
- * Extensions are grouped by language for better organization
+ * Shows unified list: updates first, then installed, then uninstalled (sorted by language)
  */
 
 #pragma once
@@ -19,40 +19,27 @@ public:
     void onFocusGained() override;
 
 private:
-    enum class ViewMode {
-        INSTALLED,
-        AVAILABLE,
-        UPDATES
-    };
-
     void loadExtensions();
-    void showInstalled();
-    void showAvailable();
-    void showUpdates();
-    void updateButtonStyles();
-    void populateList(const std::vector<Extension>& extensions);
-    void populateListGroupedByLanguage(const std::vector<Extension>& extensions);
+    void populateUnifiedList();
+    brls::Box* createSectionHeader(const std::string& title, int count);
     brls::Box* createLanguageHeader(const std::string& langCode, int extensionCount);
-    brls::Box* createExtensionItem(const Extension& ext, bool clickToInstall = false);
+    brls::Box* createExtensionItem(const Extension& ext);
     void installExtension(const Extension& ext);
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
     void showError(const std::string& message);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions);
     std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);
+    std::vector<std::string> getSortedLanguages(const std::map<std::string, std::vector<Extension>>& grouped);
     std::string getLanguageDisplayName(const std::string& langCode);
 
     brls::Label* m_titleLabel = nullptr;
-    brls::Button* m_installedBtn = nullptr;
-    brls::Button* m_availableBtn = nullptr;
-    brls::Button* m_updatesBtn = nullptr;
     brls::Box* m_listBox = nullptr;
 
-    ViewMode m_currentView = ViewMode::INSTALLED;
     std::vector<Extension> m_extensions;
-    std::vector<Extension> m_installed;
-    std::vector<Extension> m_available;
     std::vector<Extension> m_updates;
+    std::vector<Extension> m_installed;
+    std::vector<Extension> m_uninstalled;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -44,6 +44,7 @@ private:
     brls::Box* m_listBox = nullptr;
     brls::Box* m_buttonBox = nullptr;
     brls::Button* m_refreshBtn = nullptr;
+    brls::ScrollingFrame* m_scrollFrame = nullptr;
 
     std::vector<Extension> m_extensions;
     std::vector<Extension> m_updates;
@@ -53,6 +54,36 @@ private:
     // Cache for fast mode
     std::vector<Extension> m_cachedExtensions;
     bool m_cacheLoaded = false;
+
+    // Performance: Batched rendering
+    static const int BATCH_SIZE = 8;          // Items per batch
+    static const int BATCH_DELAY_MS = 16;     // ~60fps frame time
+    int m_currentBatchIndex = 0;
+    bool m_isPopulating = false;
+
+    // Performance: Track extension items for incremental updates
+    struct ExtensionItemInfo {
+        brls::Box* container = nullptr;
+        brls::Image* icon = nullptr;
+        std::string pkgName;
+        std::string iconUrl;
+        bool iconLoaded = false;
+    };
+    std::vector<ExtensionItemInfo> m_extensionItems;
+
+    // Performance: Cached grouped data
+    std::map<std::string, std::vector<Extension>> m_cachedGrouped;
+    std::vector<std::string> m_cachedSortedLanguages;
+    bool m_groupingCacheValid = false;
+
+    // Performance: Deferred icon loading
+    void loadVisibleIcons();
+    void scheduleNextBatch();
+    void populateBatch();
+
+    // Performance: Incremental updates
+    void updateExtensionItemStatus(const std::string& pkgName, bool installed, bool hasUpdate);
+    ExtensionItemInfo* findExtensionItem(const std::string& pkgName);
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -19,7 +19,13 @@ public:
     void onFocusGained() override;
 
 private:
+    // Fast mode: single query, client-side filtering (like Kodi addon)
+    void loadExtensionsFast();
+    // Standard mode: two queries with server-side filtering
     void loadExtensions();
+    // Refresh from server (clears cache and reloads)
+    void refreshExtensions();
+
     void populateUnifiedList();
     brls::Box* createSectionHeader(const std::string& title, int count);
     brls::Box* createLanguageHeader(const std::string& langCode, int extensionCount);
@@ -28,6 +34,7 @@ private:
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
     void showError(const std::string& message);
+    void showLoading(const std::string& message);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions, bool forceLanguageFilter = false);
     std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);
     std::vector<std::string> getSortedLanguages(const std::map<std::string, std::vector<Extension>>& grouped);
@@ -35,11 +42,17 @@ private:
 
     brls::Label* m_titleLabel = nullptr;
     brls::Box* m_listBox = nullptr;
+    brls::Box* m_buttonBox = nullptr;
+    brls::Button* m_refreshBtn = nullptr;
 
     std::vector<Extension> m_extensions;
     std::vector<Extension> m_updates;
     std::vector<Extension> m_installed;
     std::vector<Extension> m_uninstalled;
+
+    // Cache for fast mode
+    std::vector<Extension> m_cachedExtensions;
+    bool m_cacheLoaded = false;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -28,7 +28,7 @@ private:
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
     void showError(const std::string& message);
-    std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions);
+    std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions, bool forceLanguageFilter = false);
     std::map<std::string, std::vector<Extension>> groupExtensionsByLanguage(const std::vector<Extension>& extensions);
     std::vector<std::string> getSortedLanguages(const std::map<std::string, std::vector<Extension>>& grouped);
     std::string getLanguageDisplayName(const std::string& langCode);

--- a/include/view/horizontal_scroll_row.hpp
+++ b/include/view/horizontal_scroll_row.hpp
@@ -1,0 +1,36 @@
+/**
+ * VitaSuwayomi - Horizontal Scroll Row
+ * A horizontal scrollable row for touch and d-pad navigation
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+
+namespace vitasuwayomi {
+
+class HorizontalScrollRow : public brls::Box {
+public:
+    HorizontalScrollRow();
+
+    void onLayout() override;
+    brls::View* getNextFocus(brls::FocusDirection direction, brls::View* currentView) override;
+
+    // Set scroll offset
+    void setScrollOffset(float offset);
+    float getScrollOffset() const { return m_scrollOffset; }
+
+    // Scroll to make a child view visible
+    void scrollToView(brls::View* view);
+
+private:
+    void onPan(brls::PanGestureStatus status, brls::Sound* sound);
+    void updateScroll();
+
+    float m_scrollOffset = 0.0f;
+    float m_contentWidth = 0.0f;
+    float m_visibleWidth = 0.0f;
+    float m_panStartOffset = 0.0f;
+};
+
+} // namespace vitasuwayomi

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <borealis.hpp>
+#include <map>
 #include "app/suwayomi_client.hpp"
 #include "view/recycling_grid.hpp"
 
@@ -64,8 +65,15 @@ private:
     void showGlobalSearchDialog();
     void showFilterDialog();
 
-    // Main content grid
+    // Main content grid (for single source browsing)
     RecyclingGrid* m_contentGrid = nullptr;
+
+    // Search results by source (grouped horizontal rows)
+    brls::ScrollingFrame* m_searchResultsScrollView = nullptr;
+    brls::Box* m_searchResultsBox = nullptr;
+    std::map<std::string, std::vector<Manga>> m_resultsBySource;
+    void populateSearchResultsBySource();
+    void createSourceRow(const std::string& sourceName, const std::vector<Manga>& manga);
 
     // State
     BrowseMode m_browseMode = BrowseMode::SOURCES;

--- a/resources/xml/tabs/extensions.xml
+++ b/resources/xml/tabs/extensions.xml
@@ -13,39 +13,7 @@
         id="extensions/title"
         text="Extensions"
         fontSize="24"
-        marginBottom="20"/>
-
-    <!-- Tab buttons -->
-    <brls:Box
-        id="extensions/tabs"
-        width="100%"
-        axis="row"
-        marginBottom="15">
-
-        <brls:Button
-            id="extensions/installed_btn"
-            style="primary"
-            text="Installed"
-            width="120"
-            height="35"
-            marginRight="10"/>
-
-        <brls:Button
-            id="extensions/available_btn"
-            style="bordered"
-            text="Available"
-            width="120"
-            height="35"
-            marginRight="10"/>
-
-        <brls:Button
-            id="extensions/updates_btn"
-            style="bordered"
-            text="Updates"
-            width="120"
-            height="35"/>
-
-    </brls:Box>
+        marginBottom="15"/>
 
     <!-- Extensions list -->
     <brls:ScrollingFrame

--- a/resources/xml/tabs/extensions.xml
+++ b/resources/xml/tabs/extensions.xml
@@ -8,12 +8,28 @@
     paddingLeft="30"
     paddingRight="30">
 
-    <!-- Title -->
-    <brls:Label
-        id="extensions/title"
-        text="Extensions"
-        fontSize="24"
-        marginBottom="15"/>
+    <!-- Title row with refresh button -->
+    <brls:Box
+        id="extensions/titleRow"
+        width="100%"
+        height="40"
+        axis="row"
+        justifyContent="spaceBetween"
+        alignItems="center"
+        marginBottom="15">
+
+        <brls:Label
+            id="extensions/title"
+            text="Extensions"
+            fontSize="24"/>
+
+        <!-- Refresh button placeholder - created programmatically -->
+        <brls:Box
+            id="extensions/buttonBox"
+            axis="row"
+            alignItems="center"/>
+
+    </brls:Box>
 
     <!-- Extensions list -->
     <brls:ScrollingFrame

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1682,51 +1682,99 @@ bool SuwayomiClient::fetchExtensionList(std::vector<Extension>& extensions) {
 }
 
 bool SuwayomiClient::installExtension(const std::string& pkgName) {
-    // Try GraphQL first (primary API)
-    if (installExtensionGraphQL(pkgName)) {
-        return true;
+    const int maxRetries = 3;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        brls::Logger::info("Installing extension {} (attempt {}/{})", pkgName, attempt, maxRetries);
+
+        // Try GraphQL first (primary API)
+        if (installExtensionGraphQL(pkgName)) {
+            return true;
+        }
+
+        // REST fallback
+        brls::Logger::info("GraphQL failed for install extension, falling back to REST...");
+        vitasuwayomi::HttpClient http = createHttpClient();
+        http.setTimeout(60);  // Extended timeout for extensions
+
+        std::string url = buildApiUrl("/extension/install/" + pkgName);
+        vitasuwayomi::HttpResponse response = http.get(url);
+
+        if (response.success && response.statusCode == 200) {
+            return true;
+        }
+
+        if (attempt < maxRetries) {
+            brls::Logger::warning("Extension install failed (attempt {}/{}), retrying...", attempt, maxRetries);
+        }
     }
 
-    // REST fallback
-    brls::Logger::info("GraphQL failed for install extension, falling back to REST...");
-    vitasuwayomi::HttpClient http = createHttpClient();
-
-    std::string url = buildApiUrl("/extension/install/" + pkgName);
-    vitasuwayomi::HttpResponse response = http.get(url);
-
-    return response.success && response.statusCode == 200;
+    brls::Logger::error("Extension install failed after {} attempts", maxRetries);
+    return false;
 }
 
 bool SuwayomiClient::updateExtension(const std::string& pkgName) {
-    // Try GraphQL first (primary API)
-    if (updateExtensionGraphQL(pkgName)) {
-        return true;
+    const int maxRetries = 3;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        brls::Logger::info("Updating extension {} (attempt {}/{})", pkgName, attempt, maxRetries);
+
+        // Try GraphQL first (primary API)
+        if (updateExtensionGraphQL(pkgName)) {
+            return true;
+        }
+
+        // REST fallback
+        brls::Logger::info("GraphQL failed for update extension, falling back to REST...");
+        vitasuwayomi::HttpClient http = createHttpClient();
+        http.setTimeout(60);  // Extended timeout for extensions
+
+        std::string url = buildApiUrl("/extension/update/" + pkgName);
+        vitasuwayomi::HttpResponse response = http.get(url);
+
+        if (response.success && response.statusCode == 200) {
+            return true;
+        }
+
+        if (attempt < maxRetries) {
+            brls::Logger::warning("Extension update failed (attempt {}/{}), retrying...", attempt, maxRetries);
+        }
     }
 
-    // REST fallback
-    brls::Logger::info("GraphQL failed for update extension, falling back to REST...");
-    vitasuwayomi::HttpClient http = createHttpClient();
-
-    std::string url = buildApiUrl("/extension/update/" + pkgName);
-    vitasuwayomi::HttpResponse response = http.get(url);
-
-    return response.success && response.statusCode == 200;
+    brls::Logger::error("Extension update failed after {} attempts", maxRetries);
+    return false;
 }
 
 bool SuwayomiClient::uninstallExtension(const std::string& pkgName) {
-    // Try GraphQL first (primary API)
-    if (uninstallExtensionGraphQL(pkgName)) {
-        return true;
+    const int maxRetries = 3;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        brls::Logger::info("Uninstalling extension {} (attempt {}/{})", pkgName, attempt, maxRetries);
+
+        // Try GraphQL first (primary API)
+        if (uninstallExtensionGraphQL(pkgName)) {
+            return true;
+        }
+
+        // REST fallback
+        brls::Logger::info("GraphQL failed for uninstall extension, falling back to REST...");
+        vitasuwayomi::HttpClient http = createHttpClient();
+        http.setTimeout(60);  // Extended timeout for extensions
+
+        std::string url = buildApiUrl("/extension/uninstall/" + pkgName);
+        vitasuwayomi::HttpResponse response = http.get(url);
+
+        if (response.success && response.statusCode == 200) {
+            return true;
+        }
+
+        if (attempt < maxRetries) {
+            brls::Logger::warning("Extension uninstall failed (attempt {}/{}), retrying...", attempt, maxRetries);
+        }
     }
 
-    // REST fallback
-    brls::Logger::info("GraphQL failed for uninstall extension, falling back to REST...");
-    vitasuwayomi::HttpClient http = createHttpClient();
-
-    std::string url = buildApiUrl("/extension/uninstall/" + pkgName);
-    vitasuwayomi::HttpResponse response = http.get(url);
-
-    return response.success && response.statusCode == 200;
+    brls::Logger::error("Extension uninstall failed after {} attempts", maxRetries);
+    return false;
 }
 
 std::string SuwayomiClient::getExtensionIconUrl(const std::string& apkName) {

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1700,7 +1700,8 @@ bool SuwayomiClient::installExtension(const std::string& pkgName) {
         std::string url = buildApiUrl("/extension/install/" + pkgName);
         vitasuwayomi::HttpResponse response = http.get(url);
 
-        if (response.success && response.statusCode == 200) {
+        // REST API returns 201 (Created), 302 (Redirect), or 200 on success
+        if (response.success && (response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 302)) {
             return true;
         }
 
@@ -1732,7 +1733,8 @@ bool SuwayomiClient::updateExtension(const std::string& pkgName) {
         std::string url = buildApiUrl("/extension/update/" + pkgName);
         vitasuwayomi::HttpResponse response = http.get(url);
 
-        if (response.success && response.statusCode == 200) {
+        // REST API returns 201 (Created), 302 (Redirect), or 200 on success
+        if (response.success && (response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 302)) {
             return true;
         }
 
@@ -1764,7 +1766,8 @@ bool SuwayomiClient::uninstallExtension(const std::string& pkgName) {
         std::string url = buildApiUrl("/extension/uninstall/" + pkgName);
         vitasuwayomi::HttpResponse response = http.get(url);
 
-        if (response.success && response.statusCode == 200) {
+        // REST API returns 201 (Created), 302 (Redirect), or 200 on success
+        if (response.success && (response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 302)) {
             return true;
         }
 
@@ -3308,8 +3311,8 @@ bool SuwayomiClient::fetchUninstalledExtensions(std::vector<Extension>& extensio
 
 bool SuwayomiClient::installExtensionGraphQL(const std::string& pkgName) {
     const char* query = R"(
-        mutation InstallExtension($pkgName: String!) {
-            updateExtension(input: { pkgName: $pkgName, install: true }) {
+        mutation InstallExtension($id: String!, $install: Boolean) {
+            updateExtension(input: { id: $id, patch: { install: $install } }) {
                 extension {
                     pkgName
                     isInstalled
@@ -3328,7 +3331,7 @@ bool SuwayomiClient::installExtensionGraphQL(const std::string& pkgName) {
         }
     }
 
-    std::string variables = "{\"pkgName\":\"" + escapedPkg + "\"}";
+    std::string variables = "{\"id\":\"" + escapedPkg + "\",\"install\":true}";
     std::string response = executeGraphQL(query, variables);
     if (response.empty()) return false;
 
@@ -3352,8 +3355,8 @@ bool SuwayomiClient::installExtensionGraphQL(const std::string& pkgName) {
 
 bool SuwayomiClient::updateExtensionGraphQL(const std::string& pkgName) {
     const char* query = R"(
-        mutation UpdateExtension($pkgName: String!) {
-            updateExtension(input: { pkgName: $pkgName, update: true }) {
+        mutation UpdateExtension($id: String!, $update: Boolean) {
+            updateExtension(input: { id: $id, patch: { update: $update } }) {
                 extension {
                     pkgName
                     isInstalled
@@ -3372,7 +3375,7 @@ bool SuwayomiClient::updateExtensionGraphQL(const std::string& pkgName) {
         }
     }
 
-    std::string variables = "{\"pkgName\":\"" + escapedPkg + "\"}";
+    std::string variables = "{\"id\":\"" + escapedPkg + "\",\"update\":true}";
     std::string response = executeGraphQL(query, variables);
     if (response.empty()) return false;
 
@@ -3401,8 +3404,8 @@ bool SuwayomiClient::updateExtensionGraphQL(const std::string& pkgName) {
 
 bool SuwayomiClient::uninstallExtensionGraphQL(const std::string& pkgName) {
     const char* query = R"(
-        mutation UninstallExtension($pkgName: String!) {
-            updateExtension(input: { pkgName: $pkgName, uninstall: true }) {
+        mutation UninstallExtension($id: String!, $uninstall: Boolean) {
+            updateExtension(input: { id: $id, patch: { uninstall: $uninstall } }) {
                 extension {
                     pkgName
                     isInstalled
@@ -3420,7 +3423,7 @@ bool SuwayomiClient::uninstallExtensionGraphQL(const std::string& pkgName) {
         }
     }
 
-    std::string variables = "{\"pkgName\":\"" + escapedPkg + "\"}";
+    std::string variables = "{\"id\":\"" + escapedPkg + "\",\"uninstall\":true}";
     std::string response = executeGraphQL(query, variables);
     if (response.empty()) return false;
 

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -57,12 +57,89 @@ DownloadsTab::DownloadsTab() {
     this->setPadding(20);
     this->setGrow(1.0f);
 
-    // Header
+    // Header row with title and action icons
+    auto headerRow = new brls::Box();
+    headerRow->setAxis(brls::Axis::ROW);
+    headerRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    headerRow->setAlignItems(brls::AlignItems::CENTER);
+    headerRow->setMargins(0, 0, 15, 0);
+    this->addView(headerRow);
+
     auto header = new brls::Label();
     header->setText("Downloads");
     header->setFontSize(24);
-    header->setMargins(0, 0, 15, 0);
-    this->addView(header);
+    headerRow->addView(header);
+
+    // Actions row with Hide (L) and Show (R) icons
+    m_actionsRow = new brls::Box();
+    m_actionsRow->setAxis(brls::Axis::ROW);
+    m_actionsRow->setAlignItems(brls::AlignItems::CENTER);
+    headerRow->addView(m_actionsRow);
+
+    // Hide button with L icon above
+    auto* hideContainer = new brls::Box();
+    hideContainer->setAxis(brls::Axis::COLUMN);
+    hideContainer->setAlignItems(brls::AlignItems::CENTER);
+    hideContainer->setMarginRight(15);
+
+    // L button icon
+    auto* lButtonIcon = new brls::Image();
+    lButtonIcon->setWidth(36);
+    lButtonIcon->setHeight(24);
+    lButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    lButtonIcon->setImageFromFile("app0:resources/images/l_button.png");
+    lButtonIcon->setMarginBottom(2);
+    hideContainer->addView(lButtonIcon);
+
+    auto* hideBtn = new brls::Button();
+    hideBtn->setWidth(44);
+    hideBtn->setHeight(40);
+    hideBtn->setCornerRadius(8);
+    hideBtn->setJustifyContent(brls::JustifyContent::CENTER);
+    hideBtn->setAlignItems(brls::AlignItems::CENTER);
+
+    m_hideIcon = new brls::Image();
+    m_hideIcon->setWidth(24);
+    m_hideIcon->setHeight(24);
+    m_hideIcon->setScalingType(brls::ImageScalingType::FIT);
+    m_hideIcon->setImageFromFile("app0:resources/icons/hide.png");
+    hideBtn->addView(m_hideIcon);
+
+    hideBtn->addGestureRecognizer(new brls::TapGestureRecognizer(hideBtn));
+    hideContainer->addView(hideBtn);
+    m_actionsRow->addView(hideContainer);
+
+    // Show button with R icon above
+    auto* showContainer = new brls::Box();
+    showContainer->setAxis(brls::Axis::COLUMN);
+    showContainer->setAlignItems(brls::AlignItems::CENTER);
+
+    // R button icon
+    auto* rButtonIcon = new brls::Image();
+    rButtonIcon->setWidth(36);
+    rButtonIcon->setHeight(24);
+    rButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    rButtonIcon->setImageFromFile("app0:resources/images/r_button.png");
+    rButtonIcon->setMarginBottom(2);
+    showContainer->addView(rButtonIcon);
+
+    auto* showBtn = new brls::Button();
+    showBtn->setWidth(44);
+    showBtn->setHeight(40);
+    showBtn->setCornerRadius(8);
+    showBtn->setJustifyContent(brls::JustifyContent::CENTER);
+    showBtn->setAlignItems(brls::AlignItems::CENTER);
+
+    m_showIcon = new brls::Image();
+    m_showIcon->setWidth(24);
+    m_showIcon->setHeight(24);
+    m_showIcon->setScalingType(brls::ImageScalingType::FIT);
+    m_showIcon->setImageFromFile("app0:resources/icons/show.png");
+    showBtn->addView(m_showIcon);
+
+    showBtn->addGestureRecognizer(new brls::TapGestureRecognizer(showBtn));
+    showContainer->addView(showBtn);
+    m_actionsRow->addView(showContainer);
 
     // === Download Queue Section (server downloads) ===
     m_queueSection = new brls::Box();

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -516,13 +516,12 @@ void DownloadsTab::refreshLocalDownloads() {
                     return true;
                 });
 
-            // Add swipe gesture for removal and reordering
+            // Add swipe gesture for removal (horizontal only, like server downloads)
             row->addGestureRecognizer(new brls::PanGestureRecognizer(
                 [this, row, mangaId, chapterIndex, originalBgColor](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
                     static brls::Point touchStart;
                     static bool isValidSwipe = false;
                     const float SWIPE_THRESHOLD = 60.0f;
-                    const float VERTICAL_THRESHOLD = 40.0f;
                     const float TAP_THRESHOLD = 15.0f;
 
                     if (status.state == brls::GestureState::START) {
@@ -541,47 +540,19 @@ void DownloadsTab::refreshLocalDownloads() {
                             } else {
                                 row->setBackgroundColor(originalBgColor);
                             }
-                        } else if (std::abs(dy) > std::abs(dx) * 1.5f && std::abs(dy) > TAP_THRESHOLD) {
-                            isValidSwipe = true;
-                            if (dy < -VERTICAL_THRESHOLD * 0.5f) {
-                                // Up swipe - blue tint for move up
-                                row->setBackgroundColor(nvgRGBA(52, 152, 219, 100));
-                            } else if (dy > VERTICAL_THRESHOLD * 0.5f) {
-                                // Down swipe - blue tint for move down
-                                row->setBackgroundColor(nvgRGBA(52, 152, 219, 100));
-                            } else {
-                                row->setBackgroundColor(originalBgColor);
-                            }
                         }
                     } else if (status.state == brls::GestureState::END) {
                         row->setBackgroundColor(originalBgColor);
 
                         float dx = status.position.x - touchStart.x;
-                        float dy = status.position.y - touchStart.y;
-
-                        if (isValidSwipe) {
-                            if (std::abs(dx) > std::abs(dy) * 1.5f && dx < -SWIPE_THRESHOLD) {
-                                // Left swipe confirmed - remove from queue
-                                DownloadsManager& mgr = DownloadsManager::getInstance();
-                                mgr.cancelChapterDownload(mangaId, chapterIndex);
-                                refresh();
-                            } else if (std::abs(dy) > std::abs(dx) * 1.5f) {
-                                DownloadsManager& mgr = DownloadsManager::getInstance();
-                                if (dy < -VERTICAL_THRESHOLD) {
-                                    // Up swipe confirmed - move up in queue
-                                    if (mgr.moveChapterInQueue(mangaId, chapterIndex, -1)) {
-                                        refresh();
-                                    }
-                                } else if (dy > VERTICAL_THRESHOLD) {
-                                    // Down swipe confirmed - move down in queue
-                                    if (mgr.moveChapterInQueue(mangaId, chapterIndex, 1)) {
-                                        refresh();
-                                    }
-                                }
-                            }
+                        if (isValidSwipe && dx < -SWIPE_THRESHOLD) {
+                            // Left swipe confirmed - remove from queue
+                            DownloadsManager& mgr = DownloadsManager::getInstance();
+                            mgr.cancelChapterDownload(mangaId, chapterIndex);
+                            refresh();
                         }
                     }
-                }, brls::PanAxis::ANY));
+                }, brls::PanAxis::HORIZONTAL));
 
             // Add row
             m_localContainer->addView(row);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1,8 +1,8 @@
 /**
  * VitaSuwayomi - Extensions Tab
  * Manage Suwayomi extensions (install, update, uninstall)
- * Extensions are grouped by language for better organization
- * Language filtering follows global settings from Settings tab
+ * Shows unified list: updates first, then installed, then uninstalled (sorted by language)
+ * Language filtering and sorting follows global settings from Settings tab
  */
 
 #include "view/extensions_tab.hpp"
@@ -79,32 +79,7 @@ ExtensionsTab::ExtensionsTab() {
 
     // Get references to UI elements
     m_titleLabel = dynamic_cast<brls::Label*>(this->getView("extensions/title"));
-    m_installedBtn = dynamic_cast<brls::Button*>(this->getView("extensions/installed_btn"));
-    m_availableBtn = dynamic_cast<brls::Button*>(this->getView("extensions/available_btn"));
-    m_updatesBtn = dynamic_cast<brls::Button*>(this->getView("extensions/updates_btn"));
     m_listBox = dynamic_cast<brls::Box*>(this->getView("extensions/list"));
-
-    // Set up button handlers
-    if (m_installedBtn) {
-        m_installedBtn->registerClickAction([this](brls::View*) {
-            showInstalled();
-            return true;
-        });
-    }
-
-    if (m_availableBtn) {
-        m_availableBtn->registerClickAction([this](brls::View*) {
-            showAvailable();
-            return true;
-        });
-    }
-
-    if (m_updatesBtn) {
-        m_updatesBtn->registerClickAction([this](brls::View*) {
-            showUpdates();
-            return true;
-        });
-    }
 
     // Load extensions list
     loadExtensions();
@@ -125,23 +100,24 @@ void ExtensionsTab::loadExtensions() {
             m_extensions = extensions;
 
             // Categorize extensions
-            m_installed.clear();
-            m_available.clear();
             m_updates.clear();
+            m_installed.clear();
+            m_uninstalled.clear();
 
             for (const auto& ext : m_extensions) {
                 if (ext.installed) {
-                    m_installed.push_back(ext);
                     if (ext.hasUpdate) {
                         m_updates.push_back(ext);
+                    } else {
+                        m_installed.push_back(ext);
                     }
                 } else {
-                    m_available.push_back(ext);
+                    m_uninstalled.push_back(ext);
                 }
             }
 
             brls::sync([this]() {
-                showInstalled();
+                populateUnifiedList();
             });
         } else {
             brls::sync([this]() {
@@ -149,27 +125,6 @@ void ExtensionsTab::loadExtensions() {
             });
         }
     });
-}
-
-void ExtensionsTab::showInstalled() {
-    m_currentView = ViewMode::INSTALLED;
-    updateButtonStyles();
-    auto filtered = getFilteredExtensions(m_installed);
-    populateListGroupedByLanguage(filtered);
-}
-
-void ExtensionsTab::showAvailable() {
-    m_currentView = ViewMode::AVAILABLE;
-    updateButtonStyles();
-    auto filtered = getFilteredExtensions(m_available);
-    populateListGroupedByLanguage(filtered);
-}
-
-void ExtensionsTab::showUpdates() {
-    m_currentView = ViewMode::UPDATES;
-    updateButtonStyles();
-    auto filtered = getFilteredExtensions(m_updates);
-    populateListGroupedByLanguage(filtered);
 }
 
 std::vector<Extension> ExtensionsTab::getFilteredExtensions(const std::vector<Extension>& extensions) {
@@ -233,50 +188,59 @@ std::map<std::string, std::vector<Extension>> ExtensionsTab::groupExtensionsByLa
     return grouped;
 }
 
-void ExtensionsTab::updateButtonStyles() {
-    // Update button styles to show active state
-    // Selected: teal accent, Unselected: dark gray
-    NVGcolor selectedColor = nvgRGBA(0, 150, 136, 255);
-    NVGcolor normalColor = nvgRGBA(50, 50, 50, 255);
+std::vector<std::string> ExtensionsTab::getSortedLanguages(const std::map<std::string, std::vector<Extension>>& grouped) {
+    const AppSettings& settings = Application::getInstance().getSettings();
+    std::vector<std::string> languages;
 
-    if (m_installedBtn) {
-        m_installedBtn->setBackgroundColor(m_currentView == ViewMode::INSTALLED ?
-            selectedColor : normalColor);
+    for (const auto& pair : grouped) {
+        languages.push_back(pair.first);
     }
-    if (m_availableBtn) {
-        m_availableBtn->setBackgroundColor(m_currentView == ViewMode::AVAILABLE ?
-            selectedColor : normalColor);
-    }
-    if (m_updatesBtn) {
-        m_updatesBtn->setBackgroundColor(m_currentView == ViewMode::UPDATES ?
-            selectedColor : normalColor);
-    }
+
+    // Sort languages: enabled languages first (in order), then others alphabetically
+    std::sort(languages.begin(), languages.end(),
+        [this, &settings](const std::string& a, const std::string& b) {
+            bool aEnabled = settings.enabledSourceLanguages.count(a) > 0;
+            bool bEnabled = settings.enabledSourceLanguages.count(b) > 0;
+
+            // If both are enabled or both are not enabled, sort by display name
+            if (aEnabled == bEnabled) {
+                // English first within enabled or non-enabled groups
+                if (a == "en" && b != "en") return true;
+                if (a != "en" && b == "en") return false;
+                return getLanguageDisplayName(a) < getLanguageDisplayName(b);
+            }
+
+            // Enabled languages come first
+            return aEnabled > bEnabled;
+        });
+
+    return languages;
 }
 
-brls::Box* ExtensionsTab::createLanguageHeader(const std::string& langCode, int extensionCount) {
+brls::Box* ExtensionsTab::createSectionHeader(const std::string& title, int count) {
     auto* header = new brls::Box();
     header->setAxis(brls::Axis::ROW);
     header->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
     header->setAlignItems(brls::AlignItems::CENTER);
-    header->setPadding(8, 15, 8, 15);
-    header->setMarginTop(10);
+    header->setPadding(10, 15, 10, 15);
+    header->setMarginTop(5);
     header->setMarginBottom(5);
-    header->setBackgroundColor(nvgRGBA(40, 40, 40, 255));
-    header->setCornerRadius(4);
+    header->setBackgroundColor(nvgRGBA(0, 100, 80, 255));  // Teal section header
+    header->setCornerRadius(6);
     header->setFocusable(true);
 
-    // Language name label
-    auto* langLabel = new brls::Label();
-    langLabel->setText(getLanguageDisplayName(langCode));
-    langLabel->setFontSize(16);
-    langLabel->setTextColor(nvgRGB(200, 200, 200));
-    header->addView(langLabel);
+    // Section title label
+    auto* titleLabel = new brls::Label();
+    titleLabel->setText(title);
+    titleLabel->setFontSize(18);
+    titleLabel->setTextColor(nvgRGB(255, 255, 255));
+    header->addView(titleLabel);
 
     // Count label
     auto* countLabel = new brls::Label();
-    countLabel->setText(std::to_string(extensionCount) + " extension" + (extensionCount != 1 ? "s" : ""));
-    countLabel->setFontSize(12);
-    countLabel->setTextColor(nvgRGB(140, 140, 140));
+    countLabel->setText(std::to_string(count));
+    countLabel->setFontSize(14);
+    countLabel->setTextColor(nvgRGB(200, 255, 200));
     header->addView(countLabel);
 
     // Add touch gesture support
@@ -285,74 +249,128 @@ brls::Box* ExtensionsTab::createLanguageHeader(const std::string& langCode, int 
     return header;
 }
 
-void ExtensionsTab::populateListGroupedByLanguage(const std::vector<Extension>& extensions) {
+brls::Box* ExtensionsTab::createLanguageHeader(const std::string& langCode, int extensionCount) {
+    auto* header = new brls::Box();
+    header->setAxis(brls::Axis::ROW);
+    header->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    header->setAlignItems(brls::AlignItems::CENTER);
+    header->setPadding(6, 12, 6, 12);
+    header->setMarginTop(8);
+    header->setMarginBottom(3);
+    header->setMarginLeft(10);
+    header->setBackgroundColor(nvgRGBA(50, 50, 50, 255));
+    header->setCornerRadius(4);
+    header->setFocusable(true);
+
+    // Language name label
+    auto* langLabel = new brls::Label();
+    langLabel->setText(getLanguageDisplayName(langCode));
+    langLabel->setFontSize(14);
+    langLabel->setTextColor(nvgRGB(180, 180, 180));
+    header->addView(langLabel);
+
+    // Count label
+    auto* countLabel = new brls::Label();
+    countLabel->setText(std::to_string(extensionCount));
+    countLabel->setFontSize(11);
+    countLabel->setTextColor(nvgRGB(120, 120, 120));
+    header->addView(countLabel);
+
+    // Add touch gesture support
+    header->addGestureRecognizer(new brls::TapGestureRecognizer(header));
+
+    return header;
+}
+
+void ExtensionsTab::populateUnifiedList() {
     if (!m_listBox) return;
 
     m_listBox->clearViews();
 
-    if (extensions.empty()) {
-        auto* emptyLabel = new brls::Label();
-        if (m_currentView == ViewMode::AVAILABLE) {
-            emptyLabel->setText("No available extensions to install");
-        } else if (m_currentView == ViewMode::UPDATES) {
-            emptyLabel->setText("All extensions are up to date");
-        } else {
-            emptyLabel->setText("No extensions installed");
-        }
-        emptyLabel->setFontSize(16);
-        emptyLabel->setMargins(20, 20, 20, 20);
-        m_listBox->addView(emptyLabel);
-        return;
-    }
+    // Filter extensions based on language settings
+    auto filteredUpdates = getFilteredExtensions(m_updates);
+    auto filteredInstalled = getFilteredExtensions(m_installed);
+    auto filteredUninstalled = getFilteredExtensions(m_uninstalled);
 
-    // Group extensions by language
-    auto grouped = groupExtensionsByLanguage(extensions);
+    // Sort installed and updates alphabetically by name
+    std::sort(filteredUpdates.begin(), filteredUpdates.end(),
+        [](const Extension& a, const Extension& b) { return a.name < b.name; });
+    std::sort(filteredInstalled.begin(), filteredInstalled.end(),
+        [](const Extension& a, const Extension& b) { return a.name < b.name; });
 
-    // Sort languages: "en" first, then alphabetically by display name
-    std::vector<std::pair<std::string, std::vector<Extension>>> sortedGroups(grouped.begin(), grouped.end());
-    std::sort(sortedGroups.begin(), sortedGroups.end(),
-        [this](const auto& a, const auto& b) {
-            // English first
-            if (a.first == "en" && b.first != "en") return true;
-            if (a.first != "en" && b.first == "en") return false;
-            // Then by display name
-            return getLanguageDisplayName(a.first) < getLanguageDisplayName(b.first);
-        });
+    // Section 1: Updates (if any)
+    if (!filteredUpdates.empty()) {
+        auto* updateHeader = createSectionHeader("Updates Available", filteredUpdates.size());
+        m_listBox->addView(updateHeader);
 
-    // Determine if this is the Available tab (for click-to-install)
-    bool clickToInstall = (m_currentView == ViewMode::AVAILABLE);
-
-    // Add each language group
-    for (const auto& pair : sortedGroups) {
-        const std::string& langCode = pair.first;
-        const std::vector<Extension>& langExtensions = pair.second;
-
-        // Add language header
-        auto* header = createLanguageHeader(langCode, langExtensions.size());
-        m_listBox->addView(header);
-
-        // Add extensions for this language
-        for (const auto& ext : langExtensions) {
-            auto* item = createExtensionItem(ext, clickToInstall);
+        for (const auto& ext : filteredUpdates) {
+            auto* item = createExtensionItem(ext);
             if (item) {
                 m_listBox->addView(item);
             }
         }
     }
+
+    // Section 2: Installed extensions
+    if (!filteredInstalled.empty()) {
+        auto* installedHeader = createSectionHeader("Installed", filteredInstalled.size());
+        m_listBox->addView(installedHeader);
+
+        for (const auto& ext : filteredInstalled) {
+            auto* item = createExtensionItem(ext);
+            if (item) {
+                m_listBox->addView(item);
+            }
+        }
+    }
+
+    // Section 3: Uninstalled extensions (grouped by language, sorted by settings)
+    if (!filteredUninstalled.empty()) {
+        auto* uninstalledHeader = createSectionHeader("Available to Install", filteredUninstalled.size());
+        m_listBox->addView(uninstalledHeader);
+
+        // Group by language
+        auto grouped = groupExtensionsByLanguage(filteredUninstalled);
+
+        // Get sorted language list based on settings
+        auto sortedLanguages = getSortedLanguages(grouped);
+
+        // Add each language group
+        for (const auto& langCode : sortedLanguages) {
+            const auto& langExtensions = grouped[langCode];
+
+            // Add language header
+            auto* langHeader = createLanguageHeader(langCode, langExtensions.size());
+            m_listBox->addView(langHeader);
+
+            // Add extensions for this language
+            for (const auto& ext : langExtensions) {
+                auto* item = createExtensionItem(ext);
+                if (item) {
+                    m_listBox->addView(item);
+                }
+            }
+        }
+    }
+
+    // Show message if everything is empty
+    if (filteredUpdates.empty() && filteredInstalled.empty() && filteredUninstalled.empty()) {
+        auto* emptyLabel = new brls::Label();
+        emptyLabel->setText("No extensions available");
+        emptyLabel->setFontSize(16);
+        emptyLabel->setMargins(20, 20, 20, 20);
+        m_listBox->addView(emptyLabel);
+    }
 }
 
-void ExtensionsTab::populateList(const std::vector<Extension>& extensions) {
-    // Redirect to grouped version
-    populateListGroupedByLanguage(extensions);
-}
-
-brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext, bool clickToInstall) {
+brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     auto* container = new brls::Box();
     container->setAxis(brls::Axis::ROW);
     container->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
     container->setAlignItems(brls::AlignItems::CENTER);
-    container->setPadding(10, 15, 10, 15);
-    container->setMarginBottom(5);
+    container->setPadding(8, 12, 8, 12);
+    container->setMarginBottom(3);
+    container->setMarginLeft(ext.installed ? 0 : 20);  // Indent uninstalled items under language headers
     container->setFocusable(true);
 
     // Left side: icon and info
@@ -363,8 +381,8 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext, bool clickTo
 
     // Extension icon
     auto* icon = new brls::Image();
-    icon->setSize(brls::Size(40, 40));
-    icon->setMarginRight(15);
+    icon->setSize(brls::Size(36, 36));
+    icon->setMarginRight(12);
     if (!ext.iconUrl.empty()) {
         std::string fullIconUrl = Application::getInstance().getServerUrl() + ext.iconUrl;
         ImageLoader::loadAsync(fullIconUrl, [](brls::Image* img) {
@@ -383,19 +401,23 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext, bool clickTo
     infoBox->addView(nameLabel);
 
     auto* detailLabel = new brls::Label();
-    std::string detailText = getLanguageDisplayName(ext.lang) + " • v" + ext.versionName;
+    std::string detailText = "v" + ext.versionName;
+    if (!ext.installed) {
+        // Don't show language for installed extensions (they're not grouped by language)
+        detailText = getLanguageDisplayName(ext.lang) + " • " + detailText;
+    }
     if (ext.isNsfw) {
         detailText += " • 18+";
     }
     detailLabel->setText(detailText);
-    detailLabel->setFontSize(11);
-    detailLabel->setTextColor(nvgRGB(160, 160, 160));
+    detailLabel->setFontSize(10);
+    detailLabel->setTextColor(nvgRGB(140, 140, 140));
     infoBox->addView(detailLabel);
 
     leftBox->addView(infoBox);
     container->addView(leftBox);
 
-    // Right side: action button or status
+    // Right side: action button
     auto* actionBtn = new brls::Button();
 
     if (ext.installed) {
@@ -421,20 +443,18 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext, bool clickTo
             installExtension(ext);
             return true;
         });
+
+        // Make whole row clickable to install for uninstalled extensions
+        container->registerClickAction([this, ext](brls::View*) {
+            installExtension(ext);
+            return true;
+        });
     }
 
     container->addView(actionBtn);
 
     // Add touch gesture support
     container->addGestureRecognizer(new brls::TapGestureRecognizer(container));
-
-    // If click-to-install is enabled (Available tab), make the whole row clickable to install
-    if (clickToInstall && !ext.installed) {
-        container->registerClickAction([this, ext](brls::View*) {
-            installExtension(ext);
-            return true;
-        });
-    }
 
     return container;
 }

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -297,12 +297,10 @@ void ExtensionsTab::populateUnifiedList() {
 
     m_listBox->clearViews();
 
-    // Filter extensions based on language settings
-    // For installed/updates: show all (user already has them installed)
-    // For uninstalled: force language filter (default to "en" if none set)
-    auto filteredUpdates = getFilteredExtensions(m_updates, false);
-    auto filteredInstalled = getFilteredExtensions(m_installed, false);
-    auto filteredUninstalled = getFilteredExtensions(m_uninstalled, true);  // Force language filter for browsing
+    // Filter all extensions by language settings (default to "en" if none set)
+    auto filteredUpdates = getFilteredExtensions(m_updates, true);
+    auto filteredInstalled = getFilteredExtensions(m_installed, true);
+    auto filteredUninstalled = getFilteredExtensions(m_uninstalled, true);
 
     // Sort installed and updates alphabetically by name
     std::sort(filteredUpdates.begin(), filteredUpdates.end(),

--- a/src/view/horizontal_scroll_row.cpp
+++ b/src/view/horizontal_scroll_row.cpp
@@ -1,0 +1,118 @@
+/**
+ * VitaSuwayomi - Horizontal Scroll Row implementation
+ */
+
+#include "view/horizontal_scroll_row.hpp"
+
+namespace vitasuwayomi {
+
+HorizontalScrollRow::HorizontalScrollRow() {
+    this->setAxis(brls::Axis::ROW);
+    this->setJustifyContent(brls::JustifyContent::FLEX_START);
+    this->setAlignItems(brls::AlignItems::CENTER);
+    this->setClipsToBounds(true);
+
+    // Add pan gesture for touch scrolling
+    this->addGestureRecognizer(new brls::PanGestureRecognizer(
+        [this](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            onPan(status, soundToPlay);
+        }, brls::PanAxis::HORIZONTAL));
+}
+
+void HorizontalScrollRow::onLayout() {
+    brls::Box::onLayout();
+
+    // Calculate content width from children
+    m_contentWidth = 0.0f;
+    for (auto* child : this->getChildren()) {
+        m_contentWidth += child->getWidth() + child->getMarginLeft() + child->getMarginRight();
+    }
+
+    m_visibleWidth = this->getWidth();
+
+    // Ensure scroll offset is valid
+    float maxOffset = std::max(0.0f, m_contentWidth - m_visibleWidth);
+    m_scrollOffset = std::max(0.0f, std::min(m_scrollOffset, maxOffset));
+
+    updateScroll();
+}
+
+void HorizontalScrollRow::onPan(brls::PanGestureStatus status, brls::Sound* sound) {
+    if (status.state == brls::GestureState::START) {
+        m_panStartOffset = m_scrollOffset;
+    }
+    else if (status.state == brls::GestureState::STAY || status.state == brls::GestureState::END) {
+        // Calculate new offset based on pan delta
+        float deltaX = status.position.x - status.startPosition.x;
+        float newOffset = m_panStartOffset - deltaX;
+
+        // Clamp to valid range
+        float maxOffset = std::max(0.0f, m_contentWidth - m_visibleWidth);
+        m_scrollOffset = std::max(0.0f, std::min(newOffset, maxOffset));
+
+        updateScroll();
+    }
+}
+
+void HorizontalScrollRow::updateScroll() {
+    // Apply translation to all children
+    for (auto* child : this->getChildren()) {
+        child->setTranslationX(-m_scrollOffset);
+    }
+}
+
+void HorizontalScrollRow::setScrollOffset(float offset) {
+    float maxOffset = std::max(0.0f, m_contentWidth - m_visibleWidth);
+    m_scrollOffset = std::max(0.0f, std::min(offset, maxOffset));
+    updateScroll();
+}
+
+void HorizontalScrollRow::scrollToView(brls::View* targetView) {
+    if (!targetView) return;
+
+    // Find the view's position within the row
+    float viewLeft = 0.0f;
+    bool found = false;
+
+    for (auto* child : this->getChildren()) {
+        if (child == targetView) {
+            found = true;
+            break;
+        }
+        viewLeft += child->getWidth() + child->getMarginLeft() + child->getMarginRight();
+    }
+
+    if (!found) return;
+
+    float viewRight = viewLeft + targetView->getWidth();
+
+    // Check if view is outside visible area
+    float visibleLeft = m_scrollOffset;
+    float visibleRight = m_scrollOffset + m_visibleWidth;
+
+    if (viewLeft < visibleLeft) {
+        // Scroll left to show view
+        setScrollOffset(viewLeft);
+    }
+    else if (viewRight > visibleRight) {
+        // Scroll right to show view
+        setScrollOffset(viewRight - m_visibleWidth);
+    }
+}
+
+brls::View* HorizontalScrollRow::getNextFocus(brls::FocusDirection direction, brls::View* currentView) {
+    // Get the default next focus
+    brls::View* nextFocus = brls::Box::getNextFocus(direction, currentView);
+
+    // If navigating left/right within this row, scroll to keep focused view visible
+    if (nextFocus && (direction == brls::FocusDirection::LEFT || direction == brls::FocusDirection::RIGHT)) {
+        // Schedule scroll after focus is applied
+        brls::sync([this, nextFocus]() {
+            scrollToView(nextFocus);
+        });
+    }
+
+    return nextFocus;
+}
+
+} // namespace vitasuwayomi

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -6,6 +6,7 @@
 #include "view/search_tab.hpp"
 #include "view/manga_item_cell.hpp"
 #include "view/manga_detail_view.hpp"
+#include "view/horizontal_scroll_row.hpp"
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "utils/async.hpp"
@@ -599,6 +600,8 @@ void SearchTab::populateSearchResultsBySource() {
     if (!m_searchResultsScrollView) {
         m_searchResultsScrollView = new brls::ScrollingFrame();
         m_searchResultsScrollView->setGrow(1.0f);
+        // Use centered scrolling to keep focused items visible
+        m_searchResultsScrollView->setScrollingBehavior(brls::ScrollingBehavior::CENTERED);
 
         m_searchResultsBox = new brls::Box();
         m_searchResultsBox->setAxis(brls::Axis::COLUMN);
@@ -640,30 +643,20 @@ void SearchTab::createSourceRow(const std::string& sourceName, const std::vector
     sourceLabel->setTextColor(nvgRGB(100, 180, 255));
     m_searchResultsBox->addView(sourceLabel);
 
-    // Horizontal scroll container for this source's results
-    auto* scrollContainer = new brls::ScrollingFrame();
-    scrollContainer->setHeight(195);
-    scrollContainer->setMarginBottom(10);
-
-    auto* rowBox = new brls::Box();
-    rowBox->setAxis(brls::Axis::ROW);
-    rowBox->setJustifyContent(brls::JustifyContent::FLEX_START);
-    rowBox->setAlignItems(brls::AlignItems::CENTER);
-    rowBox->setHeight(185);
-
-    // Calculate total width for horizontal scrolling
-    float totalWidth = manga.size() * 160.0f;
-    rowBox->setWidth(totalWidth);
+    // Create horizontal scrolling row for cells
+    auto* rowBox = new HorizontalScrollRow();
+    rowBox->setHeight(195);
+    rowBox->setMarginBottom(10);
 
     // Create manga cells for each result
-    for (const auto& item : manga) {
+    for (size_t i = 0; i < manga.size(); i++) {
         auto* cell = new MangaItemCell();
-        cell->setManga(item);
+        cell->setManga(manga[i]);
         cell->setWidth(150);
         cell->setHeight(185);
         cell->setMarginRight(10);
 
-        Manga mangaCopy = item;
+        Manga mangaCopy = manga[i];
         cell->registerClickAction([this, mangaCopy](brls::View* view) {
             onMangaSelected(mangaCopy);
             return true;
@@ -673,8 +666,7 @@ void SearchTab::createSourceRow(const std::string& sourceName, const std::vector
         rowBox->addView(cell);
     }
 
-    scrollContainer->setContentView(rowBox);
-    m_searchResultsBox->addView(scrollContainer);
+    m_searchResultsBox->addView(rowBox);
 }
 
 void SearchTab::loadNextPage() {

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -635,7 +635,6 @@ void SettingsTab::showLanguageFilterDialog() {
         {"hi", "Hindi"},
         {"bn", "Bengali"},
         {"ms", "Malay"},
-        {"tl", "Filipino"},
         {"my", "Burmese"},
         {"bg", "Bulgarian"},
         {"ca", "Catalan"},


### PR DESCRIPTION
Fixes the downloads tab and extensions handling: D-pad navigation for local downloads, hide/show icons with L/R hints, a unified extensions list with server-side language filtering to prevent freezing, retry/timeout logic, install/update/uninstall API fixes, and horizontal/touch global-search results.

---
_Generated by [Claude Code](https://claude.ai/code)_