### PR TITLE
Add source icon to browse tab header

### DIFF
--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -26,6 +26,8 @@ private:
     void loadExtensions();
     // Refresh from server (clears cache and reloads)
     void refreshExtensions();
+    // Rebuild UI from cached data (safe to call after extension operations)
+    void refreshUIFromCache();
 
     void populateUnifiedList();
     brls::Box* createSectionHeader(const std::string& title, int count);
@@ -58,7 +60,7 @@ private:
     // Performance: Batched rendering
     static const int BATCH_SIZE = 8;          // Items per batch
     static const int BATCH_DELAY_MS = 16;     // ~60fps frame time
-    static const int ITEMS_PER_PAGE = 15;     // Items to show initially per section
+    static const int ITEMS_PER_PAGE = 30;     // Items to show initially per section
     int m_currentBatchIndex = 0;
     bool m_isPopulating = false;
 

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -28,6 +28,12 @@ private:
     void refreshExtensions();
     // Rebuild UI from cached data (safe to call after extension operations)
     void refreshUIFromCache();
+    // Schedule a deferred UI refresh (prevents crash from deleting views during click)
+    void scheduleDeferredUIRefresh();
+    // Show search dialog to filter extensions by name
+    void showSearchDialog();
+    // Clear search and show all extensions
+    void clearSearch();
 
     void populateUnifiedList();
     brls::Box* createSectionHeader(const std::string& title, int count);
@@ -45,8 +51,13 @@ private:
 
     brls::Label* m_titleLabel = nullptr;
     brls::Box* m_listBox = nullptr;
-    brls::Button* m_refreshBtn = nullptr;
+    brls::Image* m_refreshIcon = nullptr;
+    brls::Image* m_searchIcon = nullptr;
     brls::ScrollingFrame* m_scrollFrame = nullptr;
+
+    // Search state
+    std::string m_searchQuery;
+    bool m_isSearchActive = false;
 
     std::vector<Extension> m_extensions;
     std::vector<Extension> m_updates;

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -42,7 +42,6 @@ private:
 
     brls::Label* m_titleLabel = nullptr;
     brls::Box* m_listBox = nullptr;
-    brls::Box* m_buttonBox = nullptr;
     brls::Button* m_refreshBtn = nullptr;
     brls::ScrollingFrame* m_scrollFrame = nullptr;
 

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -28,8 +28,6 @@ private:
     void refreshExtensions();
     // Rebuild UI from cached data (safe to call after extension operations)
     void refreshUIFromCache();
-    // Schedule a deferred UI refresh (prevents crash from deleting views during click)
-    void scheduleDeferredUIRefresh();
     // Show search dialog to filter extensions by name
     void showSearchDialog();
     // Clear search and show all extensions
@@ -67,6 +65,7 @@ private:
     // Cache for fast mode
     std::vector<Extension> m_cachedExtensions;
     bool m_cacheLoaded = false;
+    bool m_needsRefresh = false;  // Set after install/update/uninstall, cleared on focus
 
     // Performance: Batched rendering
     static const int BATCH_SIZE = 8;          // Items per batch

--- a/include/view/source_browse_tab.hpp
+++ b/include/view/source_browse_tab.hpp
@@ -7,6 +7,7 @@
 
 #include <borealis.hpp>
 #include "app/suwayomi_client.hpp"
+#include "app/application.hpp"
 #include "view/recycling_grid.hpp"
 
 namespace vitasuwayomi {
@@ -42,6 +43,8 @@ private:
     bool m_hasNextPage = false;
     std::vector<Manga> m_mangaList;
 
+    brls::Box* m_headerBox = nullptr;
+    brls::Image* m_sourceIcon = nullptr;
     brls::Label* m_titleLabel = nullptr;
     brls::Button* m_popularBtn = nullptr;
     brls::Button* m_latestBtn = nullptr;

--- a/resources/xml/tabs/extensions.xml
+++ b/resources/xml/tabs/extensions.xml
@@ -11,7 +11,6 @@
     <!-- Title row with refresh button -->
     <brls:Box
         id="extensions/titleRow"
-        width="100%"
         height="40"
         axis="row"
         justifyContent="spaceBetween"
@@ -34,12 +33,11 @@
     <!-- Extensions list -->
     <brls:ScrollingFrame
         id="extensions/scroll"
-        width="100%"
         grow="1">
 
         <brls:Box
             id="extensions/list"
-            width="100%"
+            grow="1"
             axis="column"/>
 
     </brls:ScrollingFrame>

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -403,7 +403,7 @@ brls::Box* ExtensionsTab::createSectionHeader(const std::string& title, int coun
     header->setPadding(10, 15, 10, 15);
     header->setMarginTop(5);
     header->setMarginBottom(5);
-    header->setWidthPercentage(100);  // Constrain width to parent
+    header->setGrow(1.0f);  // Fill available space (respects parent padding unlike setWidthPercentage)
     header->setBackgroundColor(nvgRGBA(0, 100, 80, 255));  // Teal section header
     header->setCornerRadius(6);
     header->setFocusable(true);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -15,6 +15,11 @@
 
 namespace vitasuwayomi {
 
+// Static member definitions (required for ODR-use with std::min)
+const int ExtensionsTab::BATCH_SIZE;
+const int ExtensionsTab::BATCH_DELAY_MS;
+const int ExtensionsTab::ITEMS_PER_PAGE;
+
 // Language code to display name mapping
 std::string ExtensionsTab::getLanguageDisplayName(const std::string& langCode) {
     static const std::map<std::string, std::string> languageNames = {

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -74,41 +74,44 @@ std::string ExtensionsTab::getLanguageDisplayName(const std::string& langCode) {
 }
 
 ExtensionsTab::ExtensionsTab() {
-    // Load from XML
-    this->inflateFromXMLRes("xml/tabs/extensions.xml");
+    // Programmatic layout (like SourceBrowseTab)
+    this->setAxis(brls::Axis::COLUMN);
+    this->setPadding(20, 30, 20, 30);
 
-    // Get references to UI elements
-    m_titleLabel = dynamic_cast<brls::Label*>(this->getView("extensions/title"));
-    m_listBox = dynamic_cast<brls::Box*>(this->getView("extensions/list"));
-    m_buttonBox = dynamic_cast<brls::Box*>(this->getView("extensions/buttonBox"));
-    m_scrollFrame = dynamic_cast<brls::ScrollingFrame*>(this->getView("extensions/scroll"));
+    // Header with title and refresh button
+    auto* headerBox = new brls::Box();
+    headerBox->setAxis(brls::Axis::ROW);
+    headerBox->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    headerBox->setAlignItems(brls::AlignItems::CENTER);
+    headerBox->setMarginBottom(15);
 
-    // Create refresh button with icon
-    if (m_buttonBox) {
-        m_refreshBtn = new brls::Button();
-        m_refreshBtn->setWidth(44);
-        m_refreshBtn->setHeight(40);
-        m_refreshBtn->setCornerRadius(8);
-        m_refreshBtn->setJustifyContent(brls::JustifyContent::CENTER);
-        m_refreshBtn->setAlignItems(brls::AlignItems::CENTER);
+    // Title
+    m_titleLabel = new brls::Label();
+    m_titleLabel->setText("Extensions");
+    m_titleLabel->setFontSize(24);
+    headerBox->addView(m_titleLabel);
 
-        auto* refreshIcon = new brls::Image();
-        refreshIcon->setWidth(24);
-        refreshIcon->setHeight(24);
-        refreshIcon->setScalingType(brls::ImageScalingType::FIT);
-        refreshIcon->setImageFromFile("app0:resources/icons/refresh.png");
-        m_refreshBtn->addView(refreshIcon);
+    // Refresh button
+    m_refreshBtn = new brls::Button();
+    m_refreshBtn->setText("Refresh");
+    m_refreshBtn->registerClickAction([this](brls::View*) {
+        refreshExtensions();
+        return true;
+    });
+    headerBox->addView(m_refreshBtn);
 
-        m_refreshBtn->registerClickAction([this](brls::View*) {
-            refreshExtensions();
-            return true;
-        });
+    this->addView(headerBox);
 
-        // Add touch gesture support
-        m_refreshBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_refreshBtn));
+    // Scrolling content area
+    m_scrollFrame = new brls::ScrollingFrame();
+    m_scrollFrame->setGrow(1.0f);
 
-        m_buttonBox->addView(m_refreshBtn);
-    }
+    // Content box inside scroll frame
+    m_listBox = new brls::Box();
+    m_listBox->setAxis(brls::Axis::COLUMN);
+    m_scrollFrame->setContentView(m_listBox);
+
+    this->addView(m_scrollFrame);
 
     // Use fast mode for initial load (single query, client-side filtering)
     loadExtensionsFast();

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1344,7 +1344,7 @@ void ExtensionsTab::showSearchDialog() {
 
         // Rebuild UI with filtered results
         populateUnifiedList();
-    }, "Search Extensions", "", 64, "", "", "");
+    }, "Search Extensions", "", 64, "");
 }
 
 void ExtensionsTab::clearSearch() {

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -437,7 +437,7 @@ brls::Box* ExtensionsTab::createLanguageHeader(const std::string& langCode, int 
     header->setMarginTop(8);
     header->setMarginBottom(3);
     header->setMarginLeft(10);
-    header->setWidthPercentage(100);  // Constrain width to parent
+    header->setGrow(1.0f);  // Fill available space (respects margins unlike setWidthPercentage)
     header->setBackgroundColor(nvgRGBA(50, 50, 50, 255));
     header->setCornerRadius(4);
     header->setFocusable(true);
@@ -607,7 +607,7 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     container->setPadding(8, 12, 8, 12);
     container->setMarginBottom(3);
     container->setMarginLeft(ext.installed ? 0 : 20);  // Indent uninstalled items under language headers
-    container->setWidthPercentage(100);  // Constrain width to parent
+    container->setGrow(1.0f);  // Fill available space (respects margins unlike setWidthPercentage)
     container->setFocusable(true);
 
     // Left side: icon and info

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -403,6 +403,7 @@ brls::Box* ExtensionsTab::createSectionHeader(const std::string& title, int coun
     header->setPadding(10, 15, 10, 15);
     header->setMarginTop(5);
     header->setMarginBottom(5);
+    header->setWidthPercentage(100);  // Constrain width to parent
     header->setBackgroundColor(nvgRGBA(0, 100, 80, 255));  // Teal section header
     header->setCornerRadius(6);
     header->setFocusable(true);
@@ -436,6 +437,7 @@ brls::Box* ExtensionsTab::createLanguageHeader(const std::string& langCode, int 
     header->setMarginTop(8);
     header->setMarginBottom(3);
     header->setMarginLeft(10);
+    header->setWidthPercentage(100);  // Constrain width to parent
     header->setBackgroundColor(nvgRGBA(50, 50, 50, 255));
     header->setCornerRadius(4);
     header->setFocusable(true);
@@ -605,6 +607,7 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     container->setPadding(8, 12, 8, 12);
     container->setMarginBottom(3);
     container->setMarginLeft(ext.installed ? 0 : 20);  // Indent uninstalled items under language headers
+    container->setWidthPercentage(100);  // Constrain width to parent
     container->setFocusable(true);
 
     // Left side: icon and info
@@ -612,6 +615,7 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     leftBox->setAxis(brls::Axis::ROW);
     leftBox->setAlignItems(brls::AlignItems::CENTER);
     leftBox->setGrow(1.0f);
+    leftBox->setShrink(1.0f);  // Allow shrinking to prevent overflow
 
     // Extension icon - created but loading deferred
     auto* icon = new brls::Image();
@@ -622,6 +626,7 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     // Extension info - simplified layout
     auto* infoBox = new brls::Box();
     infoBox->setAxis(brls::Axis::COLUMN);
+    infoBox->setShrink(1.0f);  // Allow shrinking to prevent overflow
 
     auto* nameLabel = new brls::Label();
     nameLabel->setText(ext.name);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1268,7 +1268,7 @@ void ExtensionsTab::scheduleDeferredUIRefresh() {
 
 void ExtensionsTab::showSearchDialog() {
     // Get user's configured language for the keyboard if available
-    brls::Swkbd::openForText([this](std::string text) {
+    brls::Application::getImeManager()->openForText([this](std::string text) {
         if (text.empty()) {
             // User cancelled or entered empty - clear search
             clearSearch();

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1045,41 +1045,37 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     leftBox->addView(infoBox);
     container->addView(leftBox);
 
-    // Right side: action button
-    auto* actionBtn = new brls::Button();
+    // Right side: status indicator label (no button, whole row is clickable)
+    auto* statusLabel = new brls::Label();
+    statusLabel->setFontSize(11);
+    statusLabel->setMarginLeft(8);
 
     if (ext.installed) {
         if (ext.hasUpdate) {
-            actionBtn->setText("Update");
-            actionBtn->setBackgroundColor(nvgRGBA(255, 152, 0, 255));  // Orange for updates
-            actionBtn->registerClickAction([this, ext](brls::View*) {
+            statusLabel->setText("Update");
+            statusLabel->setTextColor(nvgRGB(255, 152, 0));  // Orange for updates
+            container->registerClickAction([this, ext](brls::View*) {
                 updateExtension(ext);
                 return true;
             });
         } else {
-            actionBtn->setText("Uninstall");
-            actionBtn->setBackgroundColor(nvgRGBA(100, 100, 100, 255));  // Gray for uninstall
-            actionBtn->registerClickAction([this, ext](brls::View*) {
+            statusLabel->setText("Installed");
+            statusLabel->setTextColor(nvgRGB(100, 100, 100));  // Gray for installed
+            container->registerClickAction([this, ext](brls::View*) {
                 uninstallExtension(ext);
                 return true;
             });
         }
     } else {
-        actionBtn->setText("Install");
-        actionBtn->setBackgroundColor(nvgRGBA(0, 150, 136, 255));  // Teal for install
-        actionBtn->registerClickAction([this, ext](brls::View*) {
-            installExtension(ext);
-            return true;
-        });
-
-        // Make whole row clickable to install for uninstalled extensions
+        statusLabel->setText("Install");
+        statusLabel->setTextColor(nvgRGB(0, 150, 136));  // Teal for install
         container->registerClickAction([this, ext](brls::View*) {
             installExtension(ext);
             return true;
         });
     }
 
-    container->addView(actionBtn);
+    container->addView(statusLabel);
 
     // Add touch gesture support
     container->addGestureRecognizer(new brls::TapGestureRecognizer(container));

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -694,8 +694,8 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
 
     // Load icon on focus/hover only (not all at once)
     size_t itemIndex = m_extensionItems.size() - 1;
-    container->setFocusListener([this, itemIndex, icon](bool focused) {
-        if (focused && itemIndex < m_extensionItems.size()) {
+    container->getFocusEvent()->subscribe([this, itemIndex, icon](brls::View* view) {
+        if (itemIndex < m_extensionItems.size()) {
             auto& item = m_extensionItems[itemIndex];
             if (!item.iconLoaded && !item.iconUrl.empty() && item.icon) {
                 item.iconLoaded = true;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -10,6 +10,7 @@
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "utils/async.hpp"
+#include "utils/image_loader.hpp"
 
 namespace vitasuwayomi {
 
@@ -333,9 +334,9 @@ void SearchTab::showSources() {
             sourceIcon->setMarginRight(12);
             sourceIcon->setScalingType(brls::ImageScalingType::FIT);
             if (!source.iconUrl.empty()) {
-                // Load icon from server
+                // Load icon asynchronously from server
                 std::string iconUrl = Application::getInstance().getServerUrl() + source.iconUrl;
-                sourceIcon->setImageFromFile(iconUrl);
+                ImageLoader::loadAsync(iconUrl, [](brls::Image* img) {}, sourceIcon);
             }
             sourceRow->addView(sourceIcon);
 

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -5,6 +5,7 @@
 
 #include "view/source_browse_tab.hpp"
 #include "app/suwayomi_client.hpp"
+#include "app/application.hpp"
 #include "view/media_item_cell.hpp"
 #include "utils/image_loader.hpp"
 
@@ -21,12 +22,33 @@ SourceBrowseTab::SourceBrowseTab(const Source& source)
     this->setAxis(brls::Axis::COLUMN);
     this->setPadding(20, 30, 20, 30);
 
+    // Header with icon and title
+    m_headerBox = new brls::Box();
+    m_headerBox->setAxis(brls::Axis::ROW);
+    m_headerBox->setAlignItems(brls::AlignItems::CENTER);
+    m_headerBox->setMarginBottom(15);
+
+    // Source icon
+    m_sourceIcon = new brls::Image();
+    m_sourceIcon->setWidth(32);
+    m_sourceIcon->setHeight(32);
+    m_sourceIcon->setMarginRight(12);
+    m_sourceIcon->setScalingType(brls::ImageScalingType::FIT);
+    m_headerBox->addView(m_sourceIcon);
+
+    // Load icon asynchronously
+    if (!source.iconUrl.empty()) {
+        std::string iconUrl = Application::getInstance().getServerUrl() + source.iconUrl;
+        ImageLoader::loadAsync(iconUrl, [](brls::Image* img) {}, m_sourceIcon);
+    }
+
     // Title
     m_titleLabel = new brls::Label();
     m_titleLabel->setText(source.name);
     m_titleLabel->setFontSize(24);
-    m_titleLabel->setMarginBottom(15);
-    this->addView(m_titleLabel);
+    m_headerBox->addView(m_titleLabel);
+
+    this->addView(m_headerBox);
 
     // Mode buttons
     auto* modeBox = new brls::Box();


### PR DESCRIPTION
Improves the Browse and Extensions tabs: a source icon in the browse header, extension icons loaded on focus/hover, several fixes for boxes and section headers overflowing the screen edge, a programmatic layout with lazy loading for 500+ extensions, whole-row clickable items, and install/update/uninstall crash fixes.

---
_Generated by [Claude Code](https://claude.ai/code)_