### PR TITLE
Add Start button icon above search in extensions and browse tabs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,20 @@ vita_create_vpk(${PROJECT_NAME}.vpk ${VITA_TITLEID} ${PROJECT_NAME}.self
     FILE ${BOREALIS_DIR}/resources/i18n/en-US/hints.json resources/i18n/en-US/hints.json
     FILE resources/i18n/en-US/main.json resources/i18n/en-US/main.json
 
+    # Borealis system images (for Dialog widgets)
+    FILE ${BOREALIS_DIR}/resources/img/sys/battery_back_dark.png resources/img/sys/battery_back_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/battery_back_light.png resources/img/sys/battery_back_light.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_0_dark.png resources/img/sys/wifi_0_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_0_light.png resources/img/sys/wifi_0_light.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_1_dark.png resources/img/sys/wifi_1_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_1_light.png resources/img/sys/wifi_1_light.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_2_dark.png resources/img/sys/wifi_2_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_2_light.png resources/img/sys/wifi_2_light.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_3_dark.png resources/img/sys/wifi_3_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/wifi_3_light.png resources/img/sys/wifi_3_light.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/ethernet_dark.png resources/img/sys/ethernet_dark.png
+    FILE ${BOREALIS_DIR}/resources/img/sys/ethernet_light.png resources/img/sys/ethernet_light.png
+
     # App resources
     FILE resources/xml/activity/main.xml resources/xml/activity/main.xml
     FILE resources/xml/activity/login.xml resources/xml/activity/login.xml

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -59,6 +59,7 @@ struct Extension {
     bool hasUpdate = false;
     bool obsolete = false;
     bool isNsfw = false;
+    bool hasConfigurableSources = false;  // True if any source has settings
 };
 
 // Category for organizing manga library

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -290,6 +290,64 @@ struct Tracker {
     std::vector<std::string> scoreFormat;
 };
 
+// Source preference types (matches Suwayomi preference types)
+enum class SourcePreferenceType {
+    SWITCH,
+    CHECKBOX,
+    EDIT_TEXT,
+    LIST,
+    MULTI_SELECT_LIST
+};
+
+// Source preference (for source settings/configuration)
+struct SourcePreference {
+    SourcePreferenceType type = SourcePreferenceType::SWITCH;
+    std::string key;
+    std::string title;
+    std::string summary;
+    bool visible = true;
+    bool enabled = true;
+
+    // For Switch/CheckBox preferences
+    bool currentValue = false;
+    bool defaultValue = false;
+
+    // For EditText preferences
+    std::string currentText;
+    std::string defaultText;
+    std::string dialogTitle;
+    std::string dialogMessage;
+
+    // For List preferences (single select)
+    std::vector<std::string> entries;      // Display names
+    std::vector<std::string> entryValues;  // Actual values
+    std::string selectedValue;
+    std::string defaultListValue;
+
+    // For MultiSelectList preferences
+    std::vector<std::string> selectedValues;
+    std::vector<std::string> defaultMultiValues;
+};
+
+// Source preference change (for updating preferences)
+struct SourcePreferenceChange {
+    int position = 0;  // Position in preferences list
+
+    // Only one of these should be set based on preference type
+    bool switchState = false;
+    bool checkBoxState = false;
+    std::string editTextState;
+    std::string listState;
+    std::vector<std::string> multiSelectState;
+
+    // Which field is set
+    bool hasSwitchState = false;
+    bool hasCheckBoxState = false;
+    bool hasEditTextState = false;
+    bool hasListState = false;
+    bool hasMultiSelectState = false;
+};
+
 /**
  * Suwayomi Server API Client singleton
  */
@@ -316,6 +374,17 @@ public:
     bool fetchSource(int64_t sourceId, Source& source);
     bool fetchSourceFilters(int64_t sourceId, std::vector<SourceFilter>& filters);
     bool setSourceFilters(int64_t sourceId, const std::vector<SourceFilter>& filters);
+
+    // Source Preferences (for configurable sources)
+    bool fetchSourcePreferences(int64_t sourceId, std::vector<SourcePreference>& preferences);
+    bool updateSourcePreference(int64_t sourceId, const SourcePreferenceChange& change);
+
+    // Source Metadata
+    bool setSourceMeta(int64_t sourceId, const std::string& key, const std::string& value);
+    bool deleteSourceMeta(int64_t sourceId, const std::string& key);
+
+    // Get sources for an extension (by package name)
+    bool fetchSourcesForExtension(const std::string& pkgName, std::vector<Source>& sources);
 
     // Source Browsing
     bool fetchPopularManga(int64_t sourceId, int page, std::vector<Manga>& manga, bool& hasNextPage);
@@ -477,6 +546,16 @@ private:
 
     // Single source GraphQL
     bool fetchSourceGraphQL(int64_t sourceId, Source& source);
+
+    // Source Preferences GraphQL
+    bool fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector<SourcePreference>& preferences);
+    bool updateSourcePreferenceGraphQL(int64_t sourceId, const SourcePreferenceChange& change);
+    bool setSourceMetaGraphQL(int64_t sourceId, const std::string& key, const std::string& value);
+    bool deleteSourceMetaGraphQL(int64_t sourceId, const std::string& key);
+    bool fetchSourcesForExtensionGraphQL(const std::string& pkgName, std::vector<Source>& sources);
+
+    // Parse source preference from GraphQL
+    SourcePreference parseSourcePreferenceFromGraphQL(const std::string& json);
 
     // Parse extension from GraphQL
     Extension parseExtensionFromGraphQL(const std::string& json);

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -91,11 +91,15 @@ private:
     struct ExtensionItemInfo {
         brls::Box* container = nullptr;
         brls::Image* icon = nullptr;
+        brls::Box* settingsBtn = nullptr;  // Settings button for D-pad navigation
         std::string pkgName;
         std::string iconUrl;
         bool iconLoaded = false;
     };
     std::vector<ExtensionItemInfo> m_extensionItems;
+
+    // D-pad navigation: Link settings buttons vertically
+    void updateSettingsButtonNavigation();
 
     // Performance: Cached grouped data
     std::map<std::string, std::vector<Extension>> m_cachedGrouped;

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -53,6 +53,7 @@ private:
 
     brls::Label* m_titleLabel = nullptr;
     brls::Box* m_listBox = nullptr;
+    brls::Box* m_refreshBox = nullptr;  // Safe focus target during refresh
     brls::Image* m_refreshIcon = nullptr;
     brls::Image* m_searchIcon = nullptr;
     brls::ScrollingFrame* m_scrollFrame = nullptr;

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -32,6 +32,10 @@ private:
     void showSearchDialog();
     // Clear search and show all extensions
     void clearSearch();
+    // Show search results on a separate page
+    void showSearchResults();
+    // Go back from search results to main list
+    void hideSearchResults();
 
     void populateUnifiedList();
     brls::Box* createSectionHeader(const std::string& title, int count);
@@ -52,6 +56,12 @@ private:
     brls::Image* m_refreshIcon = nullptr;
     brls::Image* m_searchIcon = nullptr;
     brls::ScrollingFrame* m_scrollFrame = nullptr;
+
+    // Search results view (separate page)
+    brls::ScrollingFrame* m_searchResultsFrame = nullptr;
+    brls::Box* m_searchResultsBox = nullptr;
+    brls::Box* m_searchHeaderBox = nullptr;
+    brls::Label* m_searchTitleLabel = nullptr;
 
     // Search state
     std::string m_searchQuery;

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -44,6 +44,8 @@ private:
     void installExtension(const Extension& ext);
     void updateExtension(const Extension& ext);
     void uninstallExtension(const Extension& ext);
+    void showSourceSettings(const Extension& ext);
+    void showSourcePreferencesDialog(const Source& source);
     void showError(const std::string& message);
     void showLoading(const std::string& message);
     std::vector<Extension> getFilteredExtensions(const std::vector<Extension>& extensions, bool forceLanguageFilter = false);

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3660,22 +3660,22 @@ SourcePreference SuwayomiClient::parseSourcePreferenceFromGraphQL(const std::str
     // Type-specific fields
     if (pref.type == SourcePreferenceType::SWITCH || pref.type == SourcePreferenceType::CHECKBOX) {
         pref.currentValue = extractJsonBool(json, "currentValue");
-        pref.defaultValue = extractJsonBool(json, "defaultValue");
+        pref.defaultValue = extractJsonBool(json, "default");
     } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {
         pref.currentText = extractJsonValue(json, "currentValue");
-        pref.defaultText = extractJsonValue(json, "defaultValue");
+        pref.defaultText = extractJsonValue(json, "default");
         pref.dialogTitle = extractJsonValue(json, "dialogTitle");
         pref.dialogMessage = extractJsonValue(json, "dialogMessage");
     } else if (pref.type == SourcePreferenceType::LIST) {
         pref.entries = extractJsonStringArray(json, "entries");
         pref.entryValues = extractJsonStringArray(json, "entryValues");
         pref.selectedValue = extractJsonValue(json, "currentValue");
-        pref.defaultListValue = extractJsonValue(json, "defaultValue");
+        pref.defaultListValue = extractJsonValue(json, "default");
     } else if (pref.type == SourcePreferenceType::MULTI_SELECT_LIST) {
         pref.entries = extractJsonStringArray(json, "entries");
         pref.entryValues = extractJsonStringArray(json, "entryValues");
         pref.selectedValues = extractJsonStringArray(json, "currentValue");
-        pref.defaultMultiValues = extractJsonStringArray(json, "defaultValue");
+        pref.defaultMultiValues = extractJsonStringArray(json, "default");
     }
 
     return pref;
@@ -3694,7 +3694,7 @@ bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector
                         visible
                         enabled
                         currentValue
-                        defaultValue
+                        default
                     }
                     ... on CheckBoxPreference {
                         key
@@ -3703,7 +3703,7 @@ bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector
                         visible
                         enabled
                         currentValue
-                        defaultValue
+                        default
                     }
                     ... on EditTextPreference {
                         key
@@ -3712,7 +3712,7 @@ bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector
                         visible
                         enabled
                         currentValue
-                        defaultValue
+                        default
                         dialogTitle
                         dialogMessage
                     }
@@ -3723,7 +3723,7 @@ bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector
                         visible
                         enabled
                         currentValue
-                        defaultValue
+                        default
                         entries
                         entryValues
                     }
@@ -3734,7 +3734,7 @@ bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector
                         visible
                         enabled
                         currentValue
-                        defaultValue
+                        default
                         entries
                         entryValues
                     }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -536,6 +536,7 @@ Source SuwayomiClient::parseSourceFromGraphQL(const std::string& json) {
     src.lang = extractJsonValue(json, "lang");
     src.iconUrl = extractJsonValue(json, "iconUrl");
     src.supportsLatest = extractJsonBool(json, "supportsLatest");
+    src.isConfigurable = extractJsonBool(json, "isConfigurable");
     src.isNsfw = extractJsonBool(json, "isNsfw");
 
     return src;
@@ -601,6 +602,7 @@ bool SuwayomiClient::fetchSourceListGraphQL(std::vector<Source>& sources) {
                     iconUrl
                     isNsfw
                     supportsLatest
+                    isConfigurable
                 }
             }
         }
@@ -3607,6 +3609,7 @@ bool SuwayomiClient::fetchSourceGraphQL(int64_t sourceId, Source& source) {
                 iconUrl
                 isNsfw
                 supportsLatest
+                isConfigurable
             }
         }
     )";
@@ -3624,6 +3627,386 @@ bool SuwayomiClient::fetchSourceGraphQL(int64_t sourceId, Source& source) {
 
     source = parseSourceFromGraphQL(sourceJson);
     return true;
+}
+
+// ============================================================================
+// GraphQL Source Preferences
+// ============================================================================
+
+SourcePreference SuwayomiClient::parseSourcePreferenceFromGraphQL(const std::string& json) {
+    SourcePreference pref;
+
+    // Determine type from __typename
+    std::string typeName = extractJsonValue(json, "__typename");
+    if (typeName == "SwitchPreference") {
+        pref.type = SourcePreferenceType::SWITCH;
+    } else if (typeName == "CheckBoxPreference") {
+        pref.type = SourcePreferenceType::CHECKBOX;
+    } else if (typeName == "EditTextPreference") {
+        pref.type = SourcePreferenceType::EDIT_TEXT;
+    } else if (typeName == "ListPreference") {
+        pref.type = SourcePreferenceType::LIST;
+    } else if (typeName == "MultiSelectListPreference") {
+        pref.type = SourcePreferenceType::MULTI_SELECT_LIST;
+    }
+
+    // Common fields
+    pref.key = extractJsonValue(json, "key");
+    pref.title = extractJsonValue(json, "title");
+    pref.summary = extractJsonValue(json, "summary");
+    pref.visible = extractJsonBool(json, "visible");
+    pref.enabled = extractJsonBool(json, "enabled");
+
+    // Type-specific fields
+    if (pref.type == SourcePreferenceType::SWITCH || pref.type == SourcePreferenceType::CHECKBOX) {
+        pref.currentValue = extractJsonBool(json, "currentValue");
+        pref.defaultValue = extractJsonBool(json, "defaultValue");
+    } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {
+        pref.currentText = extractJsonValue(json, "currentValue");
+        pref.defaultText = extractJsonValue(json, "defaultValue");
+        pref.dialogTitle = extractJsonValue(json, "dialogTitle");
+        pref.dialogMessage = extractJsonValue(json, "dialogMessage");
+    } else if (pref.type == SourcePreferenceType::LIST) {
+        pref.entries = extractJsonStringArray(json, "entries");
+        pref.entryValues = extractJsonStringArray(json, "entryValues");
+        pref.selectedValue = extractJsonValue(json, "currentValue");
+        pref.defaultListValue = extractJsonValue(json, "defaultValue");
+    } else if (pref.type == SourcePreferenceType::MULTI_SELECT_LIST) {
+        pref.entries = extractJsonStringArray(json, "entries");
+        pref.entryValues = extractJsonStringArray(json, "entryValues");
+        pref.selectedValues = extractJsonStringArray(json, "currentValue");
+        pref.defaultMultiValues = extractJsonStringArray(json, "defaultValue");
+    }
+
+    return pref;
+}
+
+bool SuwayomiClient::fetchSourcePreferencesGraphQL(int64_t sourceId, std::vector<SourcePreference>& preferences) {
+    const char* query = R"(
+        query GetSourcePreferences($id: LongString!) {
+            source(id: $id) {
+                preferences {
+                    __typename
+                    ... on SwitchPreference {
+                        key
+                        title
+                        summary
+                        visible
+                        enabled
+                        currentValue
+                        defaultValue
+                    }
+                    ... on CheckBoxPreference {
+                        key
+                        title
+                        summary
+                        visible
+                        enabled
+                        currentValue
+                        defaultValue
+                    }
+                    ... on EditTextPreference {
+                        key
+                        title
+                        summary
+                        visible
+                        enabled
+                        currentValue
+                        defaultValue
+                        dialogTitle
+                        dialogMessage
+                    }
+                    ... on ListPreference {
+                        key
+                        title
+                        summary
+                        visible
+                        enabled
+                        currentValue
+                        defaultValue
+                        entries
+                        entryValues
+                    }
+                    ... on MultiSelectListPreference {
+                        key
+                        title
+                        summary
+                        visible
+                        enabled
+                        currentValue
+                        defaultValue
+                        entries
+                        entryValues
+                    }
+                }
+            }
+        }
+    )";
+
+    std::string variables = "{\"id\":\"" + std::to_string(sourceId) + "\"}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) return false;
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) return false;
+
+    std::string sourceJson = extractJsonObject(data, "source");
+    if (sourceJson.empty()) return false;
+
+    std::string prefsJson = extractJsonArray(sourceJson, "preferences");
+    if (prefsJson.empty()) {
+        preferences.clear();
+        return true;  // Source might not have preferences
+    }
+
+    preferences.clear();
+    std::vector<std::string> items = splitJsonArray(prefsJson);
+    for (const auto& item : items) {
+        preferences.push_back(parseSourcePreferenceFromGraphQL(item));
+    }
+
+    brls::Logger::debug("GraphQL: Fetched {} source preferences", preferences.size());
+    return true;
+}
+
+bool SuwayomiClient::updateSourcePreferenceGraphQL(int64_t sourceId, const SourcePreferenceChange& change) {
+    const char* query = R"(
+        mutation UpdateSourcePreference($sourceId: LongString!, $change: SourcePreferenceChangeInput!) {
+            updateSourcePreference(input: { source: $sourceId, change: $change }) {
+                source {
+                    id
+                }
+            }
+        }
+    )";
+
+    // Build the change object based on which field is set
+    std::string changeJson = "{\"position\":" + std::to_string(change.position);
+
+    if (change.hasSwitchState) {
+        changeJson += ",\"switchState\":" + std::string(change.switchState ? "true" : "false");
+    } else if (change.hasCheckBoxState) {
+        changeJson += ",\"checkBoxState\":" + std::string(change.checkBoxState ? "true" : "false");
+    } else if (change.hasEditTextState) {
+        // Escape the text value
+        std::string escaped;
+        for (char c : change.editTextState) {
+            switch (c) {
+                case '"': escaped += "\\\""; break;
+                case '\\': escaped += "\\\\"; break;
+                case '\n': escaped += "\\n"; break;
+                case '\r': escaped += "\\r"; break;
+                case '\t': escaped += "\\t"; break;
+                default: escaped += c; break;
+            }
+        }
+        changeJson += ",\"editTextState\":\"" + escaped + "\"";
+    } else if (change.hasListState) {
+        // Escape the value
+        std::string escaped;
+        for (char c : change.listState) {
+            switch (c) {
+                case '"': escaped += "\\\""; break;
+                case '\\': escaped += "\\\\"; break;
+                default: escaped += c; break;
+            }
+        }
+        changeJson += ",\"listState\":\"" + escaped + "\"";
+    } else if (change.hasMultiSelectState) {
+        changeJson += ",\"multiSelectState\":[";
+        for (size_t i = 0; i < change.multiSelectState.size(); i++) {
+            if (i > 0) changeJson += ",";
+            // Escape each value
+            std::string escaped;
+            for (char c : change.multiSelectState[i]) {
+                switch (c) {
+                    case '"': escaped += "\\\""; break;
+                    case '\\': escaped += "\\\\"; break;
+                    default: escaped += c; break;
+                }
+            }
+            changeJson += "\"" + escaped + "\"";
+        }
+        changeJson += "]";
+    }
+
+    changeJson += "}";
+
+    std::string variables = "{\"sourceId\":\"" + std::to_string(sourceId) + "\",\"change\":" + changeJson + "}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::error("Failed to update source preference");
+        return false;
+    }
+
+    brls::Logger::debug("GraphQL: Updated source preference at position {}", change.position);
+    return true;
+}
+
+bool SuwayomiClient::setSourceMetaGraphQL(int64_t sourceId, const std::string& key, const std::string& value) {
+    const char* query = R"(
+        mutation SetSourceMeta($sourceId: LongString!, $key: String!, $value: String!) {
+            setSourceMeta(input: { meta: { sourceId: $sourceId, key: $key, value: $value } }) {
+                meta {
+                    key
+                    value
+                }
+            }
+        }
+    )";
+
+    // Escape key and value
+    std::string escapedKey, escapedValue;
+    for (char c : key) {
+        switch (c) {
+            case '"': escapedKey += "\\\""; break;
+            case '\\': escapedKey += "\\\\"; break;
+            default: escapedKey += c; break;
+        }
+    }
+    for (char c : value) {
+        switch (c) {
+            case '"': escapedValue += "\\\""; break;
+            case '\\': escapedValue += "\\\\"; break;
+            case '\n': escapedValue += "\\n"; break;
+            case '\r': escapedValue += "\\r"; break;
+            case '\t': escapedValue += "\\t"; break;
+            default: escapedValue += c; break;
+        }
+    }
+
+    std::string variables = "{\"sourceId\":\"" + std::to_string(sourceId) +
+                            "\",\"key\":\"" + escapedKey +
+                            "\",\"value\":\"" + escapedValue + "\"}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::error("Failed to set source meta: {} = {}", key, value);
+        return false;
+    }
+
+    brls::Logger::debug("GraphQL: Set source meta {} = {}", key, value);
+    return true;
+}
+
+bool SuwayomiClient::deleteSourceMetaGraphQL(int64_t sourceId, const std::string& key) {
+    const char* query = R"(
+        mutation DeleteSourceMeta($sourceId: LongString!, $key: String!) {
+            deleteSourceMeta(input: { sourceId: $sourceId, key: $key }) {
+                source {
+                    id
+                }
+            }
+        }
+    )";
+
+    // Escape key
+    std::string escapedKey;
+    for (char c : key) {
+        switch (c) {
+            case '"': escapedKey += "\\\""; break;
+            case '\\': escapedKey += "\\\\"; break;
+            default: escapedKey += c; break;
+        }
+    }
+
+    std::string variables = "{\"sourceId\":\"" + std::to_string(sourceId) +
+                            "\",\"key\":\"" + escapedKey + "\"}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::error("Failed to delete source meta: {}", key);
+        return false;
+    }
+
+    brls::Logger::debug("GraphQL: Deleted source meta {}", key);
+    return true;
+}
+
+bool SuwayomiClient::fetchSourcesForExtensionGraphQL(const std::string& pkgName, std::vector<Source>& sources) {
+    const char* query = R"(
+        query GetExtensionSources($pkgName: String!) {
+            extension(pkgName: $pkgName) {
+                source {
+                    nodes {
+                        id
+                        name
+                        displayName
+                        lang
+                        iconUrl
+                        isNsfw
+                        supportsLatest
+                        isConfigurable
+                    }
+                }
+            }
+        }
+    )";
+
+    // Escape pkgName
+    std::string escapedPkg;
+    for (char c : pkgName) {
+        switch (c) {
+            case '"': escapedPkg += "\\\""; break;
+            case '\\': escapedPkg += "\\\\"; break;
+            default: escapedPkg += c; break;
+        }
+    }
+
+    std::string variables = "{\"pkgName\":\"" + escapedPkg + "\"}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) return false;
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) return false;
+
+    std::string extJson = extractJsonObject(data, "extension");
+    if (extJson.empty()) return false;
+
+    std::string sourceObj = extractJsonObject(extJson, "source");
+    if (sourceObj.empty()) return false;
+
+    std::string nodesJson = extractJsonArray(sourceObj, "nodes");
+    if (nodesJson.empty()) {
+        sources.clear();
+        return true;  // Extension might not have sources yet
+    }
+
+    sources.clear();
+    std::vector<std::string> items = splitJsonArray(nodesJson);
+    for (const auto& item : items) {
+        sources.push_back(parseSourceFromGraphQL(item));
+    }
+
+    brls::Logger::debug("GraphQL: Fetched {} sources for extension {}", sources.size(), pkgName);
+    return true;
+}
+
+// ============================================================================
+// Public Source Preferences API
+// ============================================================================
+
+bool SuwayomiClient::fetchSourcePreferences(int64_t sourceId, std::vector<SourcePreference>& preferences) {
+    return fetchSourcePreferencesGraphQL(sourceId, preferences);
+}
+
+bool SuwayomiClient::updateSourcePreference(int64_t sourceId, const SourcePreferenceChange& change) {
+    return updateSourcePreferenceGraphQL(sourceId, change);
+}
+
+bool SuwayomiClient::setSourceMeta(int64_t sourceId, const std::string& key, const std::string& value) {
+    return setSourceMetaGraphQL(sourceId, key, value);
+}
+
+bool SuwayomiClient::deleteSourceMeta(int64_t sourceId, const std::string& key) {
+    return deleteSourceMetaGraphQL(sourceId, key);
+}
+
+bool SuwayomiClient::fetchSourcesForExtension(const std::string& pkgName, std::vector<Source>& sources) {
+    return fetchSourcesForExtensionGraphQL(pkgName, sources);
 }
 
 } // namespace vitasuwayomi

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1598,9 +1598,8 @@ void ExtensionsTab::installExtension(const Extension& ext) {
         brls::sync([this, success, ext]() {
             if (success) {
                 brls::Application::notify("Installed: " + ext.name);
-                // Update local cache - UI will refresh when user returns to this tab
-                updateExtensionItemStatus(ext.pkgName, true, false);
-                m_needsRefresh = true;
+                // Auto-refresh to show updated extension list
+                refreshExtensions();
             } else {
                 brls::Application::notify("Failed to install: " + ext.name);
             }
@@ -1619,9 +1618,8 @@ void ExtensionsTab::updateExtension(const Extension& ext) {
         brls::sync([this, success, ext]() {
             if (success) {
                 brls::Application::notify("Updated: " + ext.name);
-                // Update local cache - UI will refresh when user returns to this tab
-                updateExtensionItemStatus(ext.pkgName, true, false);
-                m_needsRefresh = true;
+                // Auto-refresh to show updated extension list
+                refreshExtensions();
             } else {
                 brls::Application::notify("Failed to update: " + ext.name);
             }
@@ -1640,9 +1638,8 @@ void ExtensionsTab::uninstallExtension(const Extension& ext) {
         brls::sync([this, success, ext]() {
             if (success) {
                 brls::Application::notify("Uninstalled: " + ext.name);
-                // Update local cache - UI will refresh when user returns to this tab
-                updateExtensionItemStatus(ext.pkgName, false, false);
-                m_needsRefresh = true;
+                // Auto-refresh to show updated extension list
+                refreshExtensions();
             } else {
                 brls::Application::notify("Failed to uninstall: " + ext.name);
             }

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -101,13 +101,26 @@ ExtensionsTab::ExtensionsTab() {
     // Button container for icons
     auto* buttonBox = new brls::Box();
     buttonBox->setAxis(brls::Axis::ROW);
-    buttonBox->setAlignItems(brls::AlignItems::CENTER);
+    buttonBox->setAlignItems(brls::AlignItems::FLEX_END);
 
-    // Search button with icon
+    // Search button with Start icon above
+    auto* searchContainer = new brls::Box();
+    searchContainer->setAxis(brls::Axis::COLUMN);
+    searchContainer->setAlignItems(brls::AlignItems::CENTER);
+    searchContainer->setMarginRight(10);
+
+    // Start button icon (64x16 original, scale to 80x20)
+    auto* startButtonIcon = new brls::Image();
+    startButtonIcon->setWidth(80);
+    startButtonIcon->setHeight(20);
+    startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setMarginBottom(2);
+    searchContainer->addView(startButtonIcon);
+
     auto* searchBox = new brls::Box();
     searchBox->setFocusable(true);
     searchBox->setPadding(8, 8, 8, 8);
-    searchBox->setMarginRight(10);
     searchBox->setCornerRadius(4);
     searchBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
     m_searchIcon = new brls::Image();
@@ -119,7 +132,8 @@ ExtensionsTab::ExtensionsTab() {
         return true;
     });
     searchBox->addGestureRecognizer(new brls::TapGestureRecognizer(searchBox));
-    buttonBox->addView(searchBox);
+    searchContainer->addView(searchBox);
+    buttonBox->addView(searchContainer);
 
     // Refresh button with icon
     auto* refreshBox = new brls::Box();
@@ -141,6 +155,12 @@ ExtensionsTab::ExtensionsTab() {
     headerBox->addView(buttonBox);
 
     this->addView(headerBox);
+
+    // Register Start button to open search dialog
+    this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
+        showSearchDialog();
+        return true;
+    });
 
     // Scrolling content area
     m_scrollFrame = new brls::ScrollingFrame();

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -142,32 +142,32 @@ ExtensionsTab::ExtensionsTab() {
     refreshContainer->setAxis(brls::Axis::COLUMN);
     refreshContainer->setAlignItems(brls::AlignItems::CENTER);
 
-    // Triangle button icon - use actual image dimensions (64x16)
+    // Triangle button icon - use actual image dimensions (16x16)
     auto* triangleButtonIcon = new brls::Image();
-    triangleButtonIcon->setWidth(64);
+    triangleButtonIcon->setWidth(16);
     triangleButtonIcon->setHeight(16);
     triangleButtonIcon->setScalingType(brls::ImageScalingType::FIT);
     triangleButtonIcon->setImageFromFile("app0:resources/images/triangle_button.png");
     triangleButtonIcon->setMarginBottom(2);
     refreshContainer->addView(triangleButtonIcon);
 
-    auto* refreshBox = new brls::Box();
-    refreshBox->setFocusable(true);
-    refreshBox->setPadding(8, 8, 8, 8);
-    refreshBox->setCornerRadius(4);
-    refreshBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
+    m_refreshBox = new brls::Box();
+    m_refreshBox->setFocusable(true);
+    m_refreshBox->setPadding(8, 8, 8, 8);
+    m_refreshBox->setCornerRadius(4);
+    m_refreshBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
     m_refreshIcon = new brls::Image();
     m_refreshIcon->setSize(brls::Size(24, 24));
     m_refreshIcon->setImageFromFile("app0:resources/icons/refresh.png");
-    refreshBox->addView(m_refreshIcon);
-    refreshBox->registerClickAction([this](brls::View*) {
+    m_refreshBox->addView(m_refreshIcon);
+    m_refreshBox->registerClickAction([this](brls::View*) {
         brls::sync([this]() {
             refreshExtensions();
         });
         return true;
     });
-    refreshBox->addGestureRecognizer(new brls::TapGestureRecognizer(refreshBox));
-    refreshContainer->addView(refreshBox);
+    m_refreshBox->addGestureRecognizer(new brls::TapGestureRecognizer(m_refreshBox));
+    refreshContainer->addView(m_refreshBox);
     buttonBox->addView(refreshContainer);
 
     headerBox->addView(buttonBox);
@@ -211,6 +211,14 @@ ExtensionsTab::ExtensionsTab() {
     m_searchResultsBox = new brls::Box();
     m_searchResultsBox->setAxis(brls::Axis::COLUMN);
     m_searchResultsFrame->setContentView(m_searchResultsBox);
+
+    // Register Circle (B) button on search results box to go back
+    m_searchResultsBox->registerAction("Back", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        brls::sync([this]() {
+            hideSearchResults();
+        });
+        return true;
+    });
 
     this->addView(m_searchResultsFrame);
 
@@ -1416,13 +1424,26 @@ void ExtensionsTab::showSearchResults() {
     headerBox->setAlignItems(brls::AlignItems::CENTER);
     headerBox->setMarginBottom(15);
 
-    // Back button
+    // Back button with Circle icon above
+    auto* backContainer = new brls::Box();
+    backContainer->setAxis(brls::Axis::COLUMN);
+    backContainer->setAlignItems(brls::AlignItems::CENTER);
+    backContainer->setMarginRight(15);
+
+    // Circle button icon - use actual image dimensions (16x16)
+    auto* circleButtonIcon = new brls::Image();
+    circleButtonIcon->setWidth(16);
+    circleButtonIcon->setHeight(16);
+    circleButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    circleButtonIcon->setImageFromFile("app0:resources/images/circle_button.png");
+    circleButtonIcon->setMarginBottom(2);
+    backContainer->addView(circleButtonIcon);
+
     auto* backBox = new brls::Box();
     backBox->setFocusable(true);
     backBox->setPadding(8, 12, 8, 12);
     backBox->setCornerRadius(4);
     backBox->setBackgroundColor(nvgRGBA(60, 60, 60, 255));
-    backBox->setMarginRight(15);
     auto* backLabel = new brls::Label();
     backLabel->setText("< Back");
     backLabel->setFontSize(14);
@@ -1434,7 +1455,15 @@ void ExtensionsTab::showSearchResults() {
         return true;
     });
     backBox->addGestureRecognizer(new brls::TapGestureRecognizer(backBox));
-    headerBox->addView(backBox);
+    // Register Circle (B) button action on the back button itself
+    backBox->registerAction("Back", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        brls::sync([this]() {
+            hideSearchResults();
+        });
+        return true;
+    });
+    backContainer->addView(backBox);
+    headerBox->addView(backContainer);
 
     // Search query title
     auto* titleLabel = new brls::Label();
@@ -1550,6 +1579,12 @@ void ExtensionsTab::uninstallExtension(const Extension& ext) {
 void ExtensionsTab::showError(const std::string& message) {
     if (!m_listBox) return;
 
+    // Give focus to the refresh button before clearing views to avoid crash
+    // when the currently focused view gets destroyed
+    if (m_refreshBox) {
+        brls::Application::giveFocus(m_refreshBox);
+    }
+
     m_listBox->clearViews();
 
     auto* errorLabel = new brls::Label();
@@ -1562,6 +1597,12 @@ void ExtensionsTab::showError(const std::string& message) {
 
 void ExtensionsTab::showLoading(const std::string& message) {
     if (!m_listBox) return;
+
+    // Give focus to the refresh button before clearing views to avoid crash
+    // when the currently focused view gets destroyed
+    if (m_refreshBox) {
+        brls::Application::giveFocus(m_refreshBox);
+    }
 
     m_listBox->clearViews();
 

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -135,7 +135,20 @@ ExtensionsTab::ExtensionsTab() {
     searchContainer->addView(searchBox);
     buttonBox->addView(searchContainer);
 
-    // Refresh button with icon
+    // Refresh button with Triangle icon above
+    auto* refreshContainer = new brls::Box();
+    refreshContainer->setAxis(brls::Axis::COLUMN);
+    refreshContainer->setAlignItems(brls::AlignItems::CENTER);
+
+    // Triangle button icon
+    auto* triangleButtonIcon = new brls::Image();
+    triangleButtonIcon->setWidth(80);
+    triangleButtonIcon->setHeight(20);
+    triangleButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    triangleButtonIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    triangleButtonIcon->setMarginBottom(2);
+    refreshContainer->addView(triangleButtonIcon);
+
     auto* refreshBox = new brls::Box();
     refreshBox->setFocusable(true);
     refreshBox->setPadding(8, 8, 8, 8);
@@ -150,7 +163,8 @@ ExtensionsTab::ExtensionsTab() {
         return true;
     });
     refreshBox->addGestureRecognizer(new brls::TapGestureRecognizer(refreshBox));
-    buttonBox->addView(refreshBox);
+    refreshContainer->addView(refreshBox);
+    buttonBox->addView(refreshContainer);
 
     headerBox->addView(buttonBox);
 
@@ -159,6 +173,12 @@ ExtensionsTab::ExtensionsTab() {
     // Register Start button to open search dialog
     this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
         showSearchDialog();
+        return true;
+    });
+
+    // Register Triangle (Y) button to refresh extensions
+    this->registerAction("Refresh", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
+        refreshExtensions();
         return true;
     });
 

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -195,6 +195,8 @@ ExtensionsTab::ExtensionsTab() {
     // Scrolling content area
     m_scrollFrame = new brls::ScrollingFrame();
     m_scrollFrame->setGrow(1.0f);
+    // Use CENTERED scrolling to respect custom navigation routes on settings buttons
+    m_scrollFrame->setScrollingBehavior(brls::ScrollingBehavior::CENTERED);
 
     // Content box inside scroll frame
     m_listBox = new brls::Box();
@@ -206,6 +208,7 @@ ExtensionsTab::ExtensionsTab() {
     // Search results page (hidden initially)
     m_searchResultsFrame = new brls::ScrollingFrame();
     m_searchResultsFrame->setGrow(1.0f);
+    m_searchResultsFrame->setScrollingBehavior(brls::ScrollingBehavior::CENTERED);
     m_searchResultsFrame->setVisibility(brls::Visibility::GONE);
 
     m_searchResultsBox = new brls::Box();

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1187,9 +1187,9 @@ brls::Box* ExtensionsTab::createExtensionItem(const Extension& ext) {
     rightBox->setAxis(brls::Axis::ROW);
     rightBox->setAlignItems(brls::AlignItems::CENTER);
 
-    // Settings icon for installed extensions (shown when source is configurable)
+    // Settings icon for installed extensions (only shown when extension has configurable sources)
     brls::Box* settingsBtn = nullptr;
-    if (ext.installed) {
+    if (ext.installed && ext.hasConfigurableSources) {
         settingsBtn = new brls::Box();
         settingsBtn->setFocusable(true);
         settingsBtn->setPadding(6, 6, 6, 6);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1813,9 +1813,7 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
                 return;
             }
 
-            // Create preferences dialog
-            auto* dialog = new brls::Dialog("Source Settings");
-
+            // Create preferences dialog content
             auto* scrollFrame = new brls::ScrollingFrame();
             scrollFrame->setMinHeight(300);
             scrollFrame->setMaxHeight(450);
@@ -2124,7 +2122,9 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
             brls::Logger::info("Added {} preference UI elements to dialog", addedCount);
 
             scrollFrame->setContentView(contentBox);
-            dialog->addView(scrollFrame);
+
+            // Create dialog with scrollFrame as content view (not addView which adds to wrong parent)
+            auto* dialog = new brls::Dialog(scrollFrame);
             dialog->addButton("Close", []() {});
             dialog->open();
         });

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -34,7 +34,20 @@ SearchTab::SearchTab() {
     m_titleLabel->setFontSize(28);
     m_headerBox->addView(m_titleLabel);
 
-    // Global search button with search icon
+    // Global search button with Start icon above
+    auto* searchContainer = new brls::Box();
+    searchContainer->setAxis(brls::Axis::COLUMN);
+    searchContainer->setAlignItems(brls::AlignItems::CENTER);
+
+    // Start button icon - use actual image dimensions (64x16)
+    auto* startButtonIcon = new brls::Image();
+    startButtonIcon->setWidth(64);
+    startButtonIcon->setHeight(16);
+    startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setMarginBottom(2);
+    searchContainer->addView(startButtonIcon);
+
     m_globalSearchBtn = new brls::Button();
     m_globalSearchBtn->setWidth(44);
     m_globalSearchBtn->setHeight(44);
@@ -50,13 +63,25 @@ SearchTab::SearchTab() {
     m_globalSearchBtn->addView(searchIcon);
 
     m_globalSearchBtn->registerClickAction([this](brls::View* view) {
-        showGlobalSearchDialog();
+        brls::sync([this]() {
+            showGlobalSearchDialog();
+        });
         return true;
     });
     m_globalSearchBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_globalSearchBtn));
-    m_headerBox->addView(m_globalSearchBtn);
+    searchContainer->addView(m_globalSearchBtn);
+    m_headerBox->addView(searchContainer);
 
     this->addView(m_headerBox);
+
+    // Register Start button to open global search dialog
+    // Use brls::sync to defer IME opening to avoid crash during controller input handling
+    this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
+        brls::sync([this]() {
+            showGlobalSearchDialog();
+        });
+        return true;
+    });
 
     // Hidden search label (used for source-specific search)
     m_searchLabel = new brls::Label();

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -75,15 +75,36 @@ SourceBrowseTab::SourceBrowseTab(const Source& source)
         modeBox->addView(m_latestBtn);
     }
 
+    // Search button with Start icon above
+    auto* searchContainer = new brls::Box();
+    searchContainer->setAxis(brls::Axis::COLUMN);
+    searchContainer->setAlignItems(brls::AlignItems::CENTER);
+
+    // Start button icon (64x16 original, scale to 80x20)
+    auto* startButtonIcon = new brls::Image();
+    startButtonIcon->setWidth(80);
+    startButtonIcon->setHeight(20);
+    startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setMarginBottom(2);
+    searchContainer->addView(startButtonIcon);
+
     m_searchBtn = new brls::Button();
     m_searchBtn->setText("Search");
     m_searchBtn->registerClickAction([this](brls::View*) {
         showSearchDialog();
         return true;
     });
-    modeBox->addView(m_searchBtn);
+    searchContainer->addView(m_searchBtn);
+    modeBox->addView(searchContainer);
 
     this->addView(modeBox);
+
+    // Register Start button to open search dialog
+    this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
+        showSearchDialog();
+        return true;
+    });
 
     // Content grid
     m_contentGrid = new RecyclingGrid();

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -80,10 +80,10 @@ SourceBrowseTab::SourceBrowseTab(const Source& source)
     searchContainer->setAxis(brls::Axis::COLUMN);
     searchContainer->setAlignItems(brls::AlignItems::CENTER);
 
-    // Start button icon (64x16 original, scale to 80x20)
+    // Start button icon - use actual image dimensions (64x16)
     auto* startButtonIcon = new brls::Image();
-    startButtonIcon->setWidth(80);
-    startButtonIcon->setHeight(20);
+    startButtonIcon->setWidth(64);
+    startButtonIcon->setHeight(16);
     startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
     startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
     startButtonIcon->setMarginBottom(2);
@@ -101,8 +101,11 @@ SourceBrowseTab::SourceBrowseTab(const Source& source)
     this->addView(modeBox);
 
     // Register Start button to open search dialog
+    // Use brls::sync to defer IME opening to avoid crash during controller input handling
     this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
-        showSearchDialog();
+        brls::sync([this]() {
+            showSearchDialog();
+        });
         return true;
     });
 


### PR DESCRIPTION
Adds Start/Triangle button-icon hints above search and refresh in the Extensions and Browse tabs, and builds out source preferences for installed extensions — GraphQL preference queries, per-source settings dialogs, D-pad navigation for settings icons, and fixes for empty dialogs and 'Cannot set texture' errors.

---
_Generated by [Claude Code](https://claude.ai/code)_