### PR TITLE
Fix library updates, remove download badge, improve downloads tab

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -166,7 +166,6 @@ struct AppSettings {
 
     // Display Settings
     bool showUnreadBadge = true;
-    bool showDownloadedBadge = true;
 
     // Per-manga reader settings (keyed by manga ID)
     // If a manga has custom settings, they override the defaults above

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -32,8 +32,6 @@ private:
     void showDownloadOptions(const std::string& ratingKey, const std::string& title);
     void startAutoRefresh();
     void stopAutoRefresh();
-    void pauseAllDownloads();
-    void clearAllDownloads();
 
     // Queue section (server downloads)
     brls::Box* m_queueSection = nullptr;

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -90,6 +90,12 @@ private:
         brls::Point touchStart;
         bool isValidSwipe = false;
     };
+
+    // Focus tracking for UI rebuilds
+    int m_focusedServerIndex = -1;  // Index of focused item in server queue
+    int m_focusedLocalIndex = -1;   // Index of focused item in local queue
+    bool m_hadFocusOnServerQueue = false;
+    bool m_hadFocusOnLocalQueue = false;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -61,6 +61,10 @@ private:
     brls::Button* m_startStopBtn = nullptr;
     brls::Label* m_startStopLabel = nullptr;
 
+    // Pause and Clear buttons (for d-pad navigation)
+    brls::Button* m_pauseBtn = nullptr;
+    brls::Button* m_clearBtn = nullptr;
+
     // Download status display
     brls::Label* m_downloadStatusLabel = nullptr;
     bool m_downloaderRunning = false;
@@ -114,6 +118,7 @@ private:
     // Helper methods for incremental updates
     void updateLocalProgress(int mangaId, int chapterIndex, int downloadedPages, int pageCount, int state);
     void removeLocalItem(int mangaId, int chapterIndex);
+    void updateNavigationRoutes();  // Update d-pad navigation between buttons and queue items
     void addLocalItem(int mangaId, int chapterIndex, const std::string& mangaTitle,
                       const std::string& chapterName, float chapterNumber,
                       int downloadedPages, int pageCount, int state);

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -78,6 +78,7 @@ private:
         int chapterId = 0;
         int mangaId = 0;
         int downloadedPages = 0;
+        int pageCount = 0;
         int state = 0;  // DownloadState as int
     };
     std::vector<CachedQueueItem> m_lastServerQueue;
@@ -90,6 +91,36 @@ private:
         int state = 0;  // LocalDownloadState as int
     };
     std::vector<CachedLocalItem> m_lastLocalQueue;
+
+    // UI element tracking for incremental updates (avoid full rebuilds)
+    struct LocalRowElements {
+        brls::Box* row = nullptr;
+        brls::Label* progressLabel = nullptr;
+        brls::Image* xButtonIcon = nullptr;
+        int mangaId = 0;
+        int chapterIndex = 0;
+    };
+    std::vector<LocalRowElements> m_localRowElements;
+
+    struct ServerRowElements {
+        brls::Box* row = nullptr;
+        brls::Label* progressLabel = nullptr;
+        brls::Image* xButtonIcon = nullptr;
+        int chapterId = 0;
+        int mangaId = 0;
+    };
+    std::vector<ServerRowElements> m_serverRowElements;
+
+    // Helper methods for incremental updates
+    void updateLocalProgress(int mangaId, int chapterIndex, int downloadedPages, int pageCount, int state);
+    void removeLocalItem(int mangaId, int chapterIndex);
+    void addLocalItem(int mangaId, int chapterIndex, const std::string& mangaTitle,
+                      const std::string& chapterName, float chapterNumber,
+                      int downloadedPages, int pageCount, int state);
+    brls::Box* createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
+                              const std::string& chapterName, float chapterNumber,
+                              int downloadedPages, int pageCount, int state,
+                              brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon);
 
     // Swipe gesture state (avoid static variables)
     struct SwipeState {

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -8,6 +8,8 @@
 #include <borealis.hpp>
 #include <vector>
 #include <string>
+#include <atomic>
+#include <chrono>
 
 namespace vitasuwayomi {
 
@@ -63,9 +65,13 @@ private:
     brls::Label* m_downloadStatusLabel = nullptr;
     bool m_downloaderRunning = false;
 
-    // Auto-refresh state
-    bool m_autoRefreshEnabled = false;
-    bool m_autoRefreshTimerActive = false;
+    // Auto-refresh state (atomic for thread safety)
+    std::atomic<bool> m_autoRefreshEnabled{false};
+    std::atomic<bool> m_autoRefreshTimerActive{false};
+
+    // Throttle progress updates to avoid excessive UI refreshes
+    std::chrono::steady_clock::time_point m_lastProgressRefresh;
+    static constexpr int PROGRESS_REFRESH_INTERVAL_MS = 500;  // Only refresh UI every 500ms
 
     // Cached queue state for smart refresh (only update when data changes)
     struct CachedQueueItem {

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -59,7 +59,7 @@ private:
     brls::Label* m_unreadBadge = nullptr;
     brls::Label* m_newBadge = nullptr;  // NEW indicator for recently updated
     brls::Image* m_startHintIcon = nullptr;  // Start button hint shown on focus
-    brls::Label* m_starBadge = nullptr;  // Star icon for manga in library
+    brls::Image* m_starBadge = nullptr;  // Star icon for manga in library
 };
 
 // Alias for backward compatibility

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -22,6 +22,7 @@ public:
     // Display mode
     void setCompactMode(bool compact);  // Hide title overlay (covers only)
     void setListMode(bool listMode);    // Horizontal list layout
+    void setShowLibraryBadge(bool show);  // Show star badge for library items (browser/search only)
 
     void onFocusGained() override;
     void onFocusLost() override;
@@ -42,6 +43,7 @@ private:
     bool m_selected = false;
     bool m_compactMode = false;
     bool m_listMode = false;
+    bool m_showLibraryBadge = false;  // Whether to show star badge for library items
 
     Manga m_manga;
     std::string m_originalTitle;
@@ -57,6 +59,7 @@ private:
     brls::Label* m_unreadBadge = nullptr;
     brls::Label* m_newBadge = nullptr;  // NEW indicator for recently updated
     brls::Image* m_startHintIcon = nullptr;  // Start button hint shown on focus
+    brls::Label* m_starBadge = nullptr;  // Star icon for manga in library
 };
 
 // Alias for backward compatibility

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -55,7 +55,6 @@ private:
     brls::Label* m_descriptionLabel = nullptr;
     brls::Rectangle* m_progressBar = nullptr;
     brls::Label* m_unreadBadge = nullptr;
-    brls::Label* m_downloadBadge = nullptr;
     brls::Label* m_newBadge = nullptr;  // NEW indicator for recently updated
     brls::Image* m_startHintIcon = nullptr;  // Start button hint shown on focus
 };

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -30,6 +30,7 @@ public:
     void setGridSize(int columns);  // 4, 6, or 8 columns
     void setCompactMode(bool compact);  // Compact mode (covers only, no titles)
     void setListMode(bool listMode);  // List view instead of grid
+    void setShowLibraryBadge(bool show);  // Show star badge for library items (browser/search only)
     int getGridColumns() const { return m_columns; }
     bool isCompactMode() const { return m_compactMode; }
     bool isListMode() const { return m_listMode; }
@@ -88,6 +89,7 @@ private:
     int m_rowMargin = 10;
     bool m_compactMode = false;
     bool m_listMode = false;
+    bool m_showLibraryBadge = false;
 
     int m_visibleStartRow = 0;
     int m_lastScrollY = 0;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -421,7 +421,6 @@ bool Application::loadSettings() {
 
     // Load display settings
     m_settings.showUnreadBadge = extractBool("showUnreadBadge", true);
-    m_settings.showDownloadedBadge = extractBool("showDownloadedBadge", true);
 
     // Load library grid customization
     int displayModeInt = extractInt("libraryDisplayMode");
@@ -744,7 +743,6 @@ bool Application::saveSettings() {
 
     // Display settings
     json += "  \"showUnreadBadge\": " + std::string(m_settings.showUnreadBadge ? "true" : "false") + ",\n";
-    json += "  \"showDownloadedBadge\": " + std::string(m_settings.showDownloadedBadge ? "true" : "false") + ",\n";
 
     // Library grid customization
     json += "  \"libraryDisplayMode\": " + std::to_string(static_cast<int>(m_settings.libraryDisplayMode)) + ",\n";

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -5393,8 +5393,8 @@ bool SuwayomiClient::updateCategoryOrderGraphQL(int categoryId, int newPosition)
 
 bool SuwayomiClient::triggerCategoryUpdateGraphQL(int categoryId) {
     const char* query = R"(
-        mutation UpdateLibraryManga($categoryIds: [Int!]) {
-            updateLibraryManga(input: { categoryIds: $categoryIds }) {
+        mutation UpdateCategoryManga($categories: [Int!]!) {
+            updateCategoryManga(input: { categories: $categories }) {
                 updateStatus {
                     isRunning
                 }
@@ -5402,7 +5402,7 @@ bool SuwayomiClient::triggerCategoryUpdateGraphQL(int categoryId) {
         }
     )";
 
-    std::string variables = "{\"categoryIds\":[" + std::to_string(categoryId) + "]}";
+    std::string variables = "{\"categories\":[" + std::to_string(categoryId) + "]}";
     std::string response = executeGraphQL(query, variables);
 
     if (response.empty()) {

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -261,24 +261,31 @@ DownloadsTab::DownloadsTab() {
 void DownloadsTab::willAppear(bool resetState) {
     brls::Box::willAppear(resetState);
 
+    // Clear tracking vectors for fresh start
+    m_localRowElements.clear();
+    m_serverRowElements.clear();
+    m_lastLocalQueue.clear();
+    m_lastServerQueue.clear();
+
     // Initialize last progress refresh time
     m_lastProgressRefresh = std::chrono::steady_clock::now();
 
     // Register progress callback for real-time UI updates during local downloads
-    // Throttled to avoid excessive UI refreshes (max once every 500ms)
+    // Now uses incremental updates instead of full refresh
     DownloadsManager& mgr = DownloadsManager::getInstance();
     mgr.setProgressCallback([this](int downloadedPages, int totalPages) {
-        // Check if enough time has passed since last refresh (throttle)
+        // For local downloads, we can update more frequently since we're just updating labels
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastProgressRefresh).count();
 
-        // Only refresh if 500ms has passed, or if we're on the last page (chapter complete)
-        if (elapsed >= PROGRESS_REFRESH_INTERVAL_MS || downloadedPages == totalPages) {
+        // Update every 100ms for smooth progress, or immediately for completion
+        const int FAST_PROGRESS_INTERVAL_MS = 100;
+        if (elapsed >= FAST_PROGRESS_INTERVAL_MS || downloadedPages == totalPages) {
             m_lastProgressRefresh = now;
-            // Schedule a refresh on the main thread - check if auto-refresh still enabled
             if (m_autoRefreshEnabled.load()) {
                 brls::sync([this]() {
                     if (m_autoRefreshEnabled.load()) {
+                        // Use incremental refresh - much faster than full rebuild
                         refreshLocalDownloads();
                     }
                 });
@@ -287,9 +294,7 @@ void DownloadsTab::willAppear(bool resetState) {
     });
 
     // Register chapter completion callback - remove completed chapter from UI directly
-    // This is more efficient than refreshing the entire list
     mgr.setChapterCompletionCallback([this](int mangaId, int chapterIndex, bool success) {
-        // Only sync if the tab is still active
         if (!m_autoRefreshEnabled.load()) {
             return;
         }
@@ -298,55 +303,8 @@ void DownloadsTab::willAppear(bool resetState) {
             if (!m_autoRefreshEnabled.load() || !m_localContainer) {
                 return;
             }
-
-            // Find the index of this chapter in our cache
-            int removeIndex = -1;
-            for (size_t i = 0; i < m_lastLocalQueue.size(); i++) {
-                if (m_lastLocalQueue[i].mangaId == mangaId &&
-                    m_lastLocalQueue[i].chapterIndex == chapterIndex) {
-                    removeIndex = static_cast<int>(i);
-                    break;
-                }
-            }
-
-            if (removeIndex < 0) {
-                return;  // Chapter not found in our list (already removed or not displayed)
-            }
-
-            // Check if focus is on the item we're removing
-            brls::View* currentFocus = brls::Application::getCurrentFocus();
-            auto& children = m_localContainer->getChildren();
-            bool hadFocusOnRemovedItem = (removeIndex < static_cast<int>(children.size()) &&
-                                          children[removeIndex] == currentFocus);
-
-            // Remove the item from the UI
-            if (removeIndex < static_cast<int>(children.size())) {
-                m_localContainer->removeView(children[removeIndex]);
-            }
-
-            // Remove from cache
-            m_lastLocalQueue.erase(m_lastLocalQueue.begin() + removeIndex);
-
-            // Handle focus and visibility after removal
-            if (m_lastLocalQueue.empty()) {
-                // No more local downloads - hide the section
-                m_localSection->setVisibility(brls::Visibility::GONE);
-                // Clear status if server queue is also empty
-                if (m_lastServerQueue.empty() && m_downloadStatusLabel) {
-                    m_downloadStatusLabel->setText("");
-                }
-                // Move focus to buttons
-                if (m_startStopBtn) {
-                    brls::Application::giveFocus(m_startStopBtn);
-                }
-            } else if (hadFocusOnRemovedItem) {
-                // Focus was on removed item - move to next item or previous
-                auto& newChildren = m_localContainer->getChildren();
-                if (!newChildren.empty()) {
-                    int newIndex = std::min(removeIndex, static_cast<int>(newChildren.size()) - 1);
-                    brls::Application::giveFocus(newChildren[newIndex]);
-                }
-            }
+            // Use the new efficient removal method
+            removeLocalItem(mangaId, chapterIndex);
         });
     });
 
@@ -368,6 +326,10 @@ void DownloadsTab::willDisappear(bool resetState) {
     DownloadsManager& mgr = DownloadsManager::getInstance();
     mgr.setProgressCallback(nullptr);
     mgr.setChapterCompletionCallback(nullptr);
+
+    // Clear tracking vectors to free memory
+    m_localRowElements.clear();
+    m_serverRowElements.clear();
 }
 
 void DownloadsTab::refresh() {
@@ -376,21 +338,6 @@ void DownloadsTab::refresh() {
 }
 
 void DownloadsTab::refreshQueue() {
-    // Save focus state before refresh - check if focus is on a server queue item
-    brls::View* currentFocus = brls::Application::getCurrentFocus();
-    m_focusedServerIndex = -1;
-    m_hadFocusOnServerQueue = false;
-    if (currentFocus && m_queueContainer) {
-        auto& children = m_queueContainer->getChildren();
-        for (size_t i = 0; i < children.size(); i++) {
-            if (children[i] == currentFocus) {
-                m_focusedServerIndex = static_cast<int>(i);
-                m_hadFocusOnServerQueue = true;
-                break;
-            }
-        }
-    }
-
     // Fetch download queue and status from server
     asyncRun([this]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
@@ -401,29 +348,23 @@ void DownloadsTab::refreshQueue() {
                 // Hide entire section on fetch failure or empty
                 m_queueSection->setVisibility(brls::Visibility::GONE);
                 m_lastServerQueue.clear();
-                // Clear container
+                m_serverRowElements.clear();
                 while (m_queueContainer->getChildren().size() > 0) {
                     m_queueContainer->removeView(m_queueContainer->getChildren()[0]);
                 }
 
-                // Only clear status if no local downloads exist
-                if (m_lastLocalQueue.empty()) {
+                if (m_lastLocalQueue.empty() && m_downloadStatusLabel) {
                     m_downloadStatusLabel->setText("");
                 }
 
-                // If focus was on server queue, try to move to local queue or buttons
-                if (m_hadFocusOnServerQueue) {
-                    if (m_localContainer && !m_localContainer->getChildren().empty()) {
-                        brls::Application::giveFocus(m_localContainer->getChildren()[0]);
-                    } else if (m_startStopBtn) {
-                        brls::Application::giveFocus(m_startStopBtn);
-                    }
+                if (m_startStopBtn && brls::Application::getCurrentFocus() == nullptr) {
+                    brls::Application::giveFocus(m_startStopBtn);
                 }
             });
             return;
         }
 
-        // Build new cache and check if anything changed
+        // Build new cache
         std::vector<CachedQueueItem> newCache;
         newCache.reserve(queue.size());
         for (const auto& item : queue) {
@@ -431,25 +372,12 @@ void DownloadsTab::refreshQueue() {
             cached.chapterId = item.chapterId;
             cached.mangaId = item.mangaId;
             cached.downloadedPages = item.downloadedPages;
+            cached.pageCount = item.pageCount;
             cached.state = static_cast<int>(item.state);
             newCache.push_back(cached);
         }
 
-        // Compare with last state - skip UI update if nothing changed
-        bool hasChanged = (newCache.size() != m_lastServerQueue.size());
-        if (!hasChanged) {
-            for (size_t i = 0; i < newCache.size(); i++) {
-                if (newCache[i].chapterId != m_lastServerQueue[i].chapterId ||
-                    newCache[i].mangaId != m_lastServerQueue[i].mangaId ||
-                    newCache[i].downloadedPages != m_lastServerQueue[i].downloadedPages ||
-                    newCache[i].state != m_lastServerQueue[i].state) {
-                    hasChanged = true;
-                    break;
-                }
-            }
-        }
-
-        // Determine downloader state based on queue items
+        // Determine downloader state
         bool isDownloading = false;
         for (const auto& item : queue) {
             if (item.state == DownloadState::DOWNLOADING) {
@@ -458,13 +386,8 @@ void DownloadsTab::refreshQueue() {
             }
         }
 
-        brls::sync([this, queue, isDownloading, hasChanged, newCache]() {
-            // Always update the cache
-            m_lastServerQueue = newCache;
-            // Update downloader state
+        brls::sync([this, queue, isDownloading, newCache]() {
             m_downloaderRunning = isDownloading;
-            // Only update button label if no local downloads exist
-            // (refreshLocalDownloads will set correct label based on local state)
             if (m_startStopLabel && m_lastLocalQueue.empty()) {
                 m_startStopLabel->setText(m_downloaderRunning ? "Pause" : "Start");
             }
@@ -472,7 +395,6 @@ void DownloadsTab::refreshQueue() {
             // Update status label
             if (m_downloadStatusLabel) {
                 if (queue.empty()) {
-                    // Only clear if no local downloads exist (local refresh will set proper status)
                     if (m_lastLocalQueue.empty()) {
                         m_downloadStatusLabel->setText("");
                     }
@@ -485,37 +407,94 @@ void DownloadsTab::refreshQueue() {
                 }
             }
 
-            // Hide entire section if queue is empty
+            // Handle empty queue
             if (queue.empty()) {
                 m_queueSection->setVisibility(brls::Visibility::GONE);
-                // Clear container if there were items before
+                m_lastServerQueue.clear();
+                m_serverRowElements.clear();
                 while (m_queueContainer->getChildren().size() > 0) {
                     m_queueContainer->removeView(m_queueContainer->getChildren()[0]);
                 }
-                // Transfer focus when server queue becomes empty
-                if (m_hadFocusOnServerQueue) {
-                    if (m_localContainer && !m_localContainer->getChildren().empty()) {
-                        brls::Application::giveFocus(m_localContainer->getChildren()[0]);
-                    } else if (m_startStopBtn) {
-                        brls::Application::giveFocus(m_startStopBtn);
-                    }
-                } else if (m_startStopBtn && brls::Application::getCurrentFocus() == nullptr) {
+                if (m_startStopBtn && brls::Application::getCurrentFocus() == nullptr) {
                     brls::Application::giveFocus(m_startStopBtn);
                 }
                 return;
             }
 
-            // Show section and scroll when there are items
+            // Show section
             m_queueSection->setVisibility(brls::Visibility::VISIBLE);
             m_queueEmptyLabel->setVisibility(brls::Visibility::GONE);
             m_queueScroll->setVisibility(brls::Visibility::VISIBLE);
 
-            // Skip UI rebuild if nothing changed
-            if (!hasChanged) {
-                return;
+            // INCREMENTAL UPDATE for server queue
+            // 1. Update existing items in place
+            for (size_t i = 0; i < newCache.size() && i < m_lastServerQueue.size(); i++) {
+                const auto& newItem = newCache[i];
+                const auto& oldItem = m_lastServerQueue[i];
+
+                // If same item, just update progress
+                if (newItem.chapterId == oldItem.chapterId && newItem.mangaId == oldItem.mangaId) {
+                    if (newItem.downloadedPages != oldItem.downloadedPages ||
+                        newItem.state != oldItem.state) {
+                        // Update progress label in place
+                        if (i < m_serverRowElements.size() && m_serverRowElements[i].progressLabel) {
+                            auto* progressLabel = m_serverRowElements[i].progressLabel;
+                            std::string progressText;
+                            if (newItem.state == static_cast<int>(DownloadState::DOWNLOADING)) {
+                                progressText = std::to_string(newItem.downloadedPages) + "/" +
+                                               std::to_string(newItem.pageCount) + " pages";
+                                progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));
+                            } else if (newItem.state == static_cast<int>(DownloadState::QUEUED)) {
+                                progressText = "Queued";
+                                progressLabel->setTextColor(nvgRGBA(255, 255, 255, 255));
+                            } else if (newItem.state == static_cast<int>(DownloadState::DOWNLOADED)) {
+                                progressText = "Done";
+                            } else if (newItem.state == static_cast<int>(DownloadState::ERROR)) {
+                                progressText = "Error";
+                                progressLabel->setTextColor(nvgRGBA(200, 100, 100, 255));
+                            } else {
+                                progressText = std::to_string(newItem.downloadedPages) + "/" +
+                                               std::to_string(newItem.pageCount);
+                            }
+                            progressLabel->setText(progressText);
+
+                            // Update background color
+                            if (m_serverRowElements[i].row) {
+                                if (newItem.state == static_cast<int>(DownloadState::DOWNLOADING)) {
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                                } else if (newItem.state == static_cast<int>(DownloadState::ERROR)) {
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
+                                } else {
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
-            // Clear existing items and rebuild
+            // Check if queue structure changed (order or items changed)
+            bool structureChanged = (newCache.size() != m_lastServerQueue.size());
+            if (!structureChanged) {
+                for (size_t i = 0; i < newCache.size(); i++) {
+                    if (newCache[i].chapterId != m_lastServerQueue[i].chapterId ||
+                        newCache[i].mangaId != m_lastServerQueue[i].mangaId) {
+                        structureChanged = true;
+                        break;
+                    }
+                }
+            }
+
+            // Update cache
+            m_lastServerQueue = newCache;
+
+            // If structure changed, need full rebuild
+            if (!structureChanged) {
+                return;  // Just progress updates, no rebuild needed
+            }
+
+            // Full rebuild for structure changes
+            m_serverRowElements.clear();
             while (m_queueContainer->getChildren().size() > 0) {
                 m_queueContainer->removeView(m_queueContainer->getChildren()[0]);
             }
@@ -523,7 +502,7 @@ void DownloadsTab::refreshQueue() {
             int queueIndex = 0;
             int queueSize = static_cast<int>(queue.size());
             for (const auto& item : queue) {
-                int currentIndex = queueIndex++;  // Capture current position
+                int currentIndex = queueIndex++;
                 auto row = new brls::Box();
                 row->setAxis(brls::Axis::ROW);
                 row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
@@ -533,29 +512,25 @@ void DownloadsTab::refreshQueue() {
                 row->setCornerRadius(6);
                 row->setFocusable(true);
 
-                // Background color based on state
                 NVGcolor originalBgColor;
                 if (item.state == DownloadState::DOWNLOADING) {
-                    originalBgColor = nvgRGBA(30, 60, 30, 200);  // Green tint for active
+                    originalBgColor = nvgRGBA(30, 60, 30, 200);
                 } else if (item.state == DownloadState::ERROR) {
-                    originalBgColor = nvgRGBA(60, 30, 30, 200);  // Red tint for error
+                    originalBgColor = nvgRGBA(60, 30, 30, 200);
                 } else {
                     originalBgColor = nvgRGBA(40, 40, 40, 200);
                 }
                 row->setBackgroundColor(originalBgColor);
 
-                // Info box
                 auto infoBox = new brls::Box();
                 infoBox->setAxis(brls::Axis::COLUMN);
                 infoBox->setGrow(1.0f);
 
-                // Manga title
                 auto titleLabel = new brls::Label();
                 titleLabel->setText(item.mangaTitle);
                 titleLabel->setFontSize(16);
                 infoBox->addView(titleLabel);
 
-                // Chapter name
                 auto chapterLabel = new brls::Label();
                 std::string chapterText = item.chapterName;
                 if (item.chapterNumber > 0) {
@@ -571,12 +546,10 @@ void DownloadsTab::refreshQueue() {
 
                 row->addView(infoBox);
 
-                // Status box (progress + X button icon)
                 auto statusBox = new brls::Box();
                 statusBox->setAxis(brls::Axis::ROW);
                 statusBox->setAlignItems(brls::AlignItems::CENTER);
 
-                // Progress label (x/x pages)
                 auto progressLabel = new brls::Label();
                 progressLabel->setFontSize(16);
                 progressLabel->setMargins(0, 0, 0, 10);
@@ -585,68 +558,65 @@ void DownloadsTab::refreshQueue() {
                 if (item.state == DownloadState::DOWNLOADING) {
                     progressText = std::to_string(item.downloadedPages) + "/" +
                                    std::to_string(item.pageCount) + " pages";
+                    progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));
                 } else if (item.state == DownloadState::QUEUED) {
                     progressText = "Queued";
                 } else if (item.state == DownloadState::DOWNLOADED) {
                     progressText = "Done";
                 } else if (item.state == DownloadState::ERROR) {
                     progressText = "Error";
+                    progressLabel->setTextColor(nvgRGBA(200, 100, 100, 255));
                 } else {
                     progressText = std::to_string(item.downloadedPages) + "/" +
                                    std::to_string(item.pageCount);
                 }
                 progressLabel->setText(progressText);
 
-                // Color based on state
-                if (item.state == DownloadState::DOWNLOADING) {
-                    progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));  // Green
-                } else if (item.state == DownloadState::ERROR) {
-                    progressLabel->setTextColor(nvgRGBA(200, 100, 100, 255));  // Red
-                }
-
                 statusBox->addView(progressLabel);
 
-                // X button icon indicator - only visible when focused (like book detail view)
                 auto* xButtonIcon = new brls::Image();
                 xButtonIcon->setWidth(24);
                 xButtonIcon->setHeight(24);
                 xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
                 xButtonIcon->setImageFromFile("app0:resources/images/square_button.png");
                 xButtonIcon->setMarginLeft(8);
-                xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);  // Hidden by default
+                xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
                 statusBox->addView(xButtonIcon);
 
                 row->addView(statusBox);
 
-                // Show X button icon when this row gets focus, hide previous
+                // Track this row's elements
+                ServerRowElements elem;
+                elem.row = row;
+                elem.progressLabel = progressLabel;
+                elem.xButtonIcon = xButtonIcon;
+                elem.chapterId = item.chapterId;
+                elem.mangaId = item.mangaId;
+                m_serverRowElements.push_back(elem);
+
                 row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
-                    // Hide previously focused icon
                     if (m_currentFocusedIcon && m_currentFocusedIcon != xButtonIcon) {
                         m_currentFocusedIcon->setVisibility(brls::Visibility::INVISIBLE);
                     }
-                    // Show this icon
                     xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
                     m_currentFocusedIcon = xButtonIcon;
                 });
 
-                // X button action - remove from server queue
                 int mangaId = item.mangaId;
                 int chapterId = item.chapterId;
                 row->registerAction("Remove", brls::ControllerButton::BUTTON_X,
                     [this, mangaId, chapterId](brls::View* view) {
                         asyncRun([this, mangaId, chapterId]() {
                             SuwayomiClient& client = SuwayomiClient::getInstance();
-                            // Remove from server queue using existing method
                             std::vector<int> chapterIds = {chapterId};
                             client.deleteChapterDownloads(chapterIds, mangaId);
                             brls::sync([this]() {
-                                refresh();
+                                refreshQueue();
                             });
                         });
                         return true;
                     });
 
-                // Move Up action (LB button) - move to earlier position in queue
                 row->registerAction("Move Up", brls::ControllerButton::BUTTON_LB,
                     [this, chapterId, mangaId, currentIndex](brls::View* view) {
                         if (currentIndex > 0) {
@@ -654,7 +624,7 @@ void DownloadsTab::refreshQueue() {
                                 SuwayomiClient& client = SuwayomiClient::getInstance();
                                 if (client.reorderDownload(chapterId, mangaId, 0, currentIndex - 1)) {
                                     brls::sync([this]() {
-                                        refresh();
+                                        refreshQueue();
                                     });
                                 }
                             });
@@ -662,7 +632,6 @@ void DownloadsTab::refreshQueue() {
                         return true;
                     });
 
-                // Move Down action (RB button) - move to later position in queue
                 row->registerAction("Move Down", brls::ControllerButton::BUTTON_RB,
                     [this, chapterId, mangaId, currentIndex, queueSize](brls::View* view) {
                         if (currentIndex < queueSize - 1) {
@@ -670,7 +639,7 @@ void DownloadsTab::refreshQueue() {
                                 SuwayomiClient& client = SuwayomiClient::getInstance();
                                 if (client.reorderDownload(chapterId, mangaId, 0, currentIndex + 1)) {
                                     brls::sync([this]() {
-                                        refresh();
+                                        refreshQueue();
                                     });
                                 }
                             });
@@ -678,7 +647,6 @@ void DownloadsTab::refreshQueue() {
                         return true;
                     });
 
-                // Add swipe gesture for removal - use shared_ptr to avoid static variables
                 auto swipeState = std::make_shared<SwipeState>();
                 row->addGestureRecognizer(new brls::PanGestureRecognizer(
                     [this, row, mangaId, chapterId, originalBgColor, swipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
@@ -692,11 +660,9 @@ void DownloadsTab::refreshQueue() {
                             float dx = status.position.x - swipeState->touchStart.x;
                             float dy = status.position.y - swipeState->touchStart.y;
 
-                            // Visual feedback during swipe
                             if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
                                 swipeState->isValidSwipe = true;
                                 if (dx < -SWIPE_THRESHOLD * 0.5f) {
-                                    // Left swipe - red tint for removal
                                     row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
                                 } else {
                                     row->setBackgroundColor(originalBgColor);
@@ -707,124 +673,98 @@ void DownloadsTab::refreshQueue() {
 
                             float dx = status.position.x - swipeState->touchStart.x;
                             if (swipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
-                                // Left swipe confirmed - remove from queue
                                 asyncRun([this, mangaId, chapterId]() {
                                     SuwayomiClient& client = SuwayomiClient::getInstance();
                                     std::vector<int> chapterIds = {chapterId};
                                     client.deleteChapterDownloads(chapterIds, mangaId);
                                     brls::sync([this]() {
-                                        refresh();
+                                        refreshQueue();
                                     });
                                 });
                             }
                         }
                     }, brls::PanAxis::HORIZONTAL));
 
-                // Add row
                 m_queueContainer->addView(row);
-            }
-
-            // Restore focus after rebuild if we had focus on server queue
-            if (m_hadFocusOnServerQueue && m_focusedServerIndex >= 0) {
-                auto& children = m_queueContainer->getChildren();
-                if (!children.empty()) {
-                    int newIndex = std::min(m_focusedServerIndex, static_cast<int>(children.size()) - 1);
-                    brls::Application::giveFocus(children[newIndex]);
-                }
-                m_hadFocusOnServerQueue = false;
             }
         });
     });
 }
 
 void DownloadsTab::refreshLocalDownloads() {
-    // Save focus state before refresh - check if focus is on a local queue item
-    brls::View* currentFocus = brls::Application::getCurrentFocus();
-    m_focusedLocalIndex = -1;
-    m_hadFocusOnLocalQueue = false;
-    if (currentFocus && m_localContainer) {
-        auto& children = m_localContainer->getChildren();
-        for (size_t i = 0; i < children.size(); i++) {
-            if (children[i] == currentFocus) {
-                m_focusedLocalIndex = static_cast<int>(i);
-                m_hadFocusOnLocalQueue = true;
-                break;
-            }
-        }
-    }
-
     // Ensure manager is initialized and state is loaded
     DownloadsManager& mgr = DownloadsManager::getInstance();
     mgr.init();
 
     auto downloads = mgr.getDownloads();
 
-    // Build new cache and count active chapters
-    std::vector<CachedLocalItem> newCache;
+    // Build new state from current downloads
+    struct NewItemInfo {
+        int mangaId;
+        int chapterIndex;
+        std::string mangaTitle;
+        std::string chapterName;
+        float chapterNumber;
+        int downloadedPages;
+        int pageCount;
+        int state;
+    };
+    std::vector<NewItemInfo> newItems;
+
     for (const auto& manga : downloads) {
         for (const auto& chapter : manga.chapters) {
             if (chapter.state == LocalDownloadState::QUEUED ||
                 chapter.state == LocalDownloadState::DOWNLOADING) {
-                CachedLocalItem cached;
-                cached.mangaId = manga.mangaId;
-                cached.chapterIndex = chapter.chapterIndex;
-                cached.downloadedPages = chapter.downloadedPages;
-                cached.pageCount = chapter.pageCount;
-                cached.state = static_cast<int>(chapter.state);
-                newCache.push_back(cached);
+                NewItemInfo info;
+                info.mangaId = manga.mangaId;
+                info.chapterIndex = chapter.chapterIndex;
+                info.mangaTitle = manga.title;
+                info.chapterName = chapter.name;
+                info.chapterNumber = chapter.chapterNumber;
+                info.downloadedPages = chapter.downloadedPages;
+                info.pageCount = chapter.pageCount;
+                info.state = static_cast<int>(chapter.state);
+                newItems.push_back(info);
             }
         }
     }
 
-    // Compare with last state - skip UI update if nothing changed
-    bool hasChanged = (newCache.size() != m_lastLocalQueue.size());
-    if (!hasChanged) {
-        for (size_t i = 0; i < newCache.size(); i++) {
-            if (newCache[i].mangaId != m_lastLocalQueue[i].mangaId ||
-                newCache[i].chapterIndex != m_lastLocalQueue[i].chapterIndex ||
-                newCache[i].downloadedPages != m_lastLocalQueue[i].downloadedPages ||
-                newCache[i].pageCount != m_lastLocalQueue[i].pageCount ||
-                newCache[i].state != m_lastLocalQueue[i].state) {
-                hasChanged = true;
-                break;
-            }
-        }
-    }
-
-    // Update cache
-    m_lastLocalQueue = newCache;
-
-    // Hide entire section if no active downloads
-    if (newCache.empty()) {
-        m_localSection->setVisibility(brls::Visibility::GONE);
-        // Clear container if there were items before
-        while (m_localContainer->getChildren().size() > 0) {
+    // Handle empty state
+    if (newItems.empty()) {
+        // Clear all items
+        m_localRowElements.clear();
+        m_lastLocalQueue.clear();
+        while (m_localContainer && m_localContainer->getChildren().size() > 0) {
             m_localContainer->removeView(m_localContainer->getChildren()[0]);
         }
-        // Transfer focus to start/stop button when queue becomes empty
-        // Check if focus was on local queue or is now null
-        if (m_startStopBtn && (m_hadFocusOnLocalQueue || brls::Application::getCurrentFocus() == nullptr)) {
+        m_localSection->setVisibility(brls::Visibility::GONE);
+
+        // Update status if no server downloads either
+        if (m_lastServerQueue.empty() && m_downloadStatusLabel) {
+            m_downloadStatusLabel->setText("");
+        }
+
+        // Transfer focus
+        if (m_startStopBtn && brls::Application::getCurrentFocus() == nullptr) {
             brls::Application::giveFocus(m_startStopBtn);
         }
-        m_hadFocusOnLocalQueue = false;
         return;
     }
 
-    // Show section and scroll when there are items
+    // Show section
     m_localSection->setVisibility(brls::Visibility::VISIBLE);
     m_localEmptyLabel->setVisibility(brls::Visibility::GONE);
     m_localScroll->setVisibility(brls::Visibility::VISIBLE);
 
-    // Update status label for local downloads if server queue is empty
+    // Update status label
     bool localDownloading = false;
-    for (const auto& item : newCache) {
+    for (const auto& item : newItems) {
         if (item.state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
             localDownloading = true;
             break;
         }
     }
 
-    // If server queue is empty but local downloads exist, update status
     if (m_lastServerQueue.empty() && m_downloadStatusLabel) {
         if (localDownloading) {
             m_downloadStatusLabel->setText("• Downloading (Local)");
@@ -833,213 +773,79 @@ void DownloadsTab::refreshLocalDownloads() {
             if (m_startStopLabel) {
                 m_startStopLabel->setText("Pause");
             }
-        } else if (!newCache.empty()) {
+        } else {
             m_downloadStatusLabel->setText("• Queued (Local)");
             m_downloadStatusLabel->setTextColor(nvgRGBA(200, 150, 100, 255));
         }
     }
 
-    // Skip UI rebuild if nothing changed
-    if (!hasChanged) {
-        return;
-    }
-
-    // Clear existing local items and rebuild
-    while (m_localContainer->getChildren().size() > 0) {
-        m_localContainer->removeView(m_localContainer->getChildren()[0]);
-    }
-
-    // Show each chapter as a queue item (like server downloads)
-    for (const auto& manga : downloads) {
-        for (const auto& chapter : manga.chapters) {
-            // Only show queued or downloading chapters
-            if (chapter.state != LocalDownloadState::QUEUED &&
-                chapter.state != LocalDownloadState::DOWNLOADING) {
-                continue;
+    // INCREMENTAL UPDATE: Check what changed
+    // 1. Find items to remove (in old but not in new)
+    std::vector<std::pair<int, int>> toRemove;  // mangaId, chapterIndex
+    for (const auto& elem : m_localRowElements) {
+        bool found = false;
+        for (const auto& newItem : newItems) {
+            if (elem.mangaId == newItem.mangaId && elem.chapterIndex == newItem.chapterIndex) {
+                found = true;
+                break;
             }
-
-            int mangaId = manga.mangaId;
-            int chapterIndex = chapter.chapterIndex;
-
-            auto row = new brls::Box();
-            row->setAxis(brls::Axis::ROW);
-            row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-            row->setAlignItems(brls::AlignItems::CENTER);
-            row->setPadding(8);
-            row->setMargins(0, 0, 8, 0);
-            row->setCornerRadius(6);
-            row->setFocusable(true);
-
-            // Background color based on state
-            NVGcolor originalBgColor;
-            if (chapter.state == LocalDownloadState::DOWNLOADING) {
-                originalBgColor = nvgRGBA(30, 60, 30, 200);  // Green tint for active
-            } else {
-                originalBgColor = nvgRGBA(40, 40, 40, 200);
-            }
-            row->setBackgroundColor(originalBgColor);
-
-            // Info box
-            auto infoBox = new brls::Box();
-            infoBox->setAxis(brls::Axis::COLUMN);
-            infoBox->setGrow(1.0f);
-
-            // Manga title
-            auto titleLabel = new brls::Label();
-            titleLabel->setText(manga.title);
-            titleLabel->setFontSize(16);
-            infoBox->addView(titleLabel);
-
-            // Chapter name
-            auto chapterLabel = new brls::Label();
-            std::string chapterText;
-            if (chapter.chapterNumber > 0) {
-                chapterText = "Ch. " + std::to_string(static_cast<int>(chapter.chapterNumber));
-                if (!chapter.name.empty()) {
-                    chapterText += " - " + chapter.name;
-                }
-            } else {
-                chapterText = "Ch. " + std::to_string(chapter.chapterIndex);
-                if (!chapter.name.empty()) {
-                    chapterText += " - " + chapter.name;
-                }
-            }
-            chapterLabel->setText(chapterText);
-            chapterLabel->setFontSize(14);
-            chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
-            infoBox->addView(chapterLabel);
-
-            row->addView(infoBox);
-
-            // Status box (progress + X button icon)
-            auto statusBox = new brls::Box();
-            statusBox->setAxis(brls::Axis::ROW);
-            statusBox->setAlignItems(brls::AlignItems::CENTER);
-
-            // Progress label
-            auto progressLabel = new brls::Label();
-            progressLabel->setFontSize(16);
-            progressLabel->setMargins(0, 0, 0, 10);
-
-            std::string progressText;
-            if (chapter.state == LocalDownloadState::DOWNLOADING) {
-                if (chapter.pageCount > 0) {
-                    progressText = std::to_string(chapter.downloadedPages) + "/" +
-                                   std::to_string(chapter.pageCount) + " pages";
-                } else {
-                    progressText = "Downloading...";
-                }
-                progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));  // Green
-            } else {
-                progressText = "Queued";
-            }
-            progressLabel->setText(progressText);
-
-            statusBox->addView(progressLabel);
-
-            // X button icon indicator - only visible when focused (like book detail view)
-            auto* xButtonIcon = new brls::Image();
-            xButtonIcon->setWidth(24);
-            xButtonIcon->setHeight(24);
-            xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-            xButtonIcon->setImageFromFile("app0:resources/images/square_button.png");
-            xButtonIcon->setMarginLeft(8);
-            xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);  // Hidden by default
-            statusBox->addView(xButtonIcon);
-
-            row->addView(statusBox);
-
-            // Show X button icon when this row gets focus, hide previous
-            row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
-                // Hide previously focused icon
-                if (m_currentFocusedIcon && m_currentFocusedIcon != xButtonIcon) {
-                    m_currentFocusedIcon->setVisibility(brls::Visibility::INVISIBLE);
-                }
-                // Show this icon
-                xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
-                m_currentFocusedIcon = xButtonIcon;
-            });
-
-            // X button action - remove from local queue
-            row->registerAction("Remove", brls::ControllerButton::BUTTON_X,
-                [this, mangaId, chapterIndex](brls::View* view) {
-                    DownloadsManager& mgr = DownloadsManager::getInstance();
-                    mgr.cancelChapterDownload(mangaId, chapterIndex);
-                    refresh();
-                    return true;
-                });
-
-            // Up button action - move up in queue
-            row->registerAction("Move Up", brls::ControllerButton::BUTTON_LB,
-                [this, mangaId, chapterIndex](brls::View* view) {
-                    DownloadsManager& mgr = DownloadsManager::getInstance();
-                    if (mgr.moveChapterInQueue(mangaId, chapterIndex, -1)) {
-                        refresh();
-                    }
-                    return true;
-                });
-
-            // Down button action - move down in queue
-            row->registerAction("Move Down", brls::ControllerButton::BUTTON_RB,
-                [this, mangaId, chapterIndex](brls::View* view) {
-                    DownloadsManager& mgr = DownloadsManager::getInstance();
-                    if (mgr.moveChapterInQueue(mangaId, chapterIndex, 1)) {
-                        refresh();
-                    }
-                    return true;
-                });
-
-            // Add swipe gesture for removal (horizontal only, like server downloads)
-            auto localSwipeState = std::make_shared<SwipeState>();
-            row->addGestureRecognizer(new brls::PanGestureRecognizer(
-                [this, row, mangaId, chapterIndex, originalBgColor, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-                    const float SWIPE_THRESHOLD = 60.0f;
-                    const float TAP_THRESHOLD = 15.0f;
-
-                    if (status.state == brls::GestureState::START) {
-                        localSwipeState->touchStart = status.position;
-                        localSwipeState->isValidSwipe = false;
-                    } else if (status.state == brls::GestureState::STAY) {
-                        float dx = status.position.x - localSwipeState->touchStart.x;
-                        float dy = status.position.y - localSwipeState->touchStart.y;
-
-                        // Visual feedback during swipe
-                        if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
-                            localSwipeState->isValidSwipe = true;
-                            if (dx < -SWIPE_THRESHOLD * 0.5f) {
-                                // Left swipe - red tint for removal
-                                row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
-                            } else {
-                                row->setBackgroundColor(originalBgColor);
-                            }
-                        }
-                    } else if (status.state == brls::GestureState::END) {
-                        row->setBackgroundColor(originalBgColor);
-
-                        float dx = status.position.x - localSwipeState->touchStart.x;
-                        if (localSwipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
-                            // Left swipe confirmed - remove from queue
-                            DownloadsManager& mgr = DownloadsManager::getInstance();
-                            mgr.cancelChapterDownload(mangaId, chapterIndex);
-                            refresh();
-                        }
-                    }
-                }, brls::PanAxis::HORIZONTAL));
-
-            // Add row
-            m_localContainer->addView(row);
+        }
+        if (!found) {
+            toRemove.push_back({elem.mangaId, elem.chapterIndex});
         }
     }
 
-    // Restore focus after rebuild if we had focus on local queue
-    if (m_hadFocusOnLocalQueue && m_focusedLocalIndex >= 0) {
-        auto& children = m_localContainer->getChildren();
-        if (!children.empty()) {
-            int newIndex = std::min(m_focusedLocalIndex, static_cast<int>(children.size()) - 1);
-            brls::Application::giveFocus(children[newIndex]);
+    // 2. Find items to add (in new but not in old)
+    std::vector<NewItemInfo> toAdd;
+    for (const auto& newItem : newItems) {
+        bool found = false;
+        for (const auto& elem : m_localRowElements) {
+            if (elem.mangaId == newItem.mangaId && elem.chapterIndex == newItem.chapterIndex) {
+                found = true;
+                break;
+            }
         }
-        m_hadFocusOnLocalQueue = false;
+        if (!found) {
+            toAdd.push_back(newItem);
+        }
     }
+
+    // 3. Find items to update (same item, different progress)
+    for (const auto& newItem : newItems) {
+        for (size_t i = 0; i < m_lastLocalQueue.size(); i++) {
+            const auto& cached = m_lastLocalQueue[i];
+            if (cached.mangaId == newItem.mangaId && cached.chapterIndex == newItem.chapterIndex) {
+                // Check if progress changed
+                if (cached.downloadedPages != newItem.downloadedPages ||
+                    cached.pageCount != newItem.pageCount ||
+                    cached.state != newItem.state) {
+                    // Update in place - no rebuild needed!
+                    updateLocalProgress(newItem.mangaId, newItem.chapterIndex,
+                                        newItem.downloadedPages, newItem.pageCount, newItem.state);
+                    // Update cache
+                    m_lastLocalQueue[i].downloadedPages = newItem.downloadedPages;
+                    m_lastLocalQueue[i].pageCount = newItem.pageCount;
+                    m_lastLocalQueue[i].state = newItem.state;
+                }
+                break;
+            }
+        }
+    }
+
+    // 4. Remove items that are no longer in the queue
+    for (const auto& item : toRemove) {
+        removeLocalItem(item.first, item.second);
+    }
+
+    // 5. Add new items
+    for (const auto& item : toAdd) {
+        addLocalItem(item.mangaId, item.chapterIndex, item.mangaTitle,
+                     item.chapterName, item.chapterNumber,
+                     item.downloadedPages, item.pageCount, item.state);
+    }
+
+    // Note: We don't need to restore focus because we're doing incremental updates
+    // Items are updated in-place, so focus is preserved automatically
 }
 
 void DownloadsTab::showDownloadOptions(const std::string& ratingKey, const std::string& title) {
@@ -1121,6 +927,301 @@ void DownloadsTab::clearAllDownloads() {
             });
         }
     });
+}
+
+// Helper: Create a local download row with all UI elements
+brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
+                                        const std::string& chapterName, float chapterNumber,
+                                        int downloadedPages, int pageCount, int state,
+                                        brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon) {
+    auto row = new brls::Box();
+    row->setAxis(brls::Axis::ROW);
+    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    row->setAlignItems(brls::AlignItems::CENTER);
+    row->setPadding(8);
+    row->setMargins(0, 0, 8, 0);
+    row->setCornerRadius(6);
+    row->setFocusable(true);
+
+    // Background color based on state
+    NVGcolor originalBgColor;
+    if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
+        originalBgColor = nvgRGBA(30, 60, 30, 200);  // Green tint for active
+    } else {
+        originalBgColor = nvgRGBA(40, 40, 40, 200);
+    }
+    row->setBackgroundColor(originalBgColor);
+
+    // Info box
+    auto infoBox = new brls::Box();
+    infoBox->setAxis(brls::Axis::COLUMN);
+    infoBox->setGrow(1.0f);
+
+    // Manga title
+    auto titleLabel = new brls::Label();
+    titleLabel->setText(mangaTitle);
+    titleLabel->setFontSize(16);
+    infoBox->addView(titleLabel);
+
+    // Chapter name
+    auto chapterLabel = new brls::Label();
+    std::string chapterText;
+    if (chapterNumber > 0) {
+        chapterText = "Ch. " + std::to_string(static_cast<int>(chapterNumber));
+        if (!chapterName.empty()) {
+            chapterText += " - " + chapterName;
+        }
+    } else {
+        chapterText = "Ch. " + std::to_string(chapterIndex);
+        if (!chapterName.empty()) {
+            chapterText += " - " + chapterName;
+        }
+    }
+    chapterLabel->setText(chapterText);
+    chapterLabel->setFontSize(14);
+    chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
+    infoBox->addView(chapterLabel);
+
+    row->addView(infoBox);
+
+    // Status box (progress + X button icon)
+    auto statusBox = new brls::Box();
+    statusBox->setAxis(brls::Axis::ROW);
+    statusBox->setAlignItems(brls::AlignItems::CENTER);
+
+    // Progress label
+    auto progressLabel = new brls::Label();
+    progressLabel->setFontSize(16);
+    progressLabel->setMargins(0, 0, 0, 10);
+
+    std::string progressText;
+    if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
+        if (pageCount > 0) {
+            progressText = std::to_string(downloadedPages) + "/" +
+                           std::to_string(pageCount) + " pages";
+        } else {
+            progressText = "Downloading...";
+        }
+        progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));  // Green
+    } else {
+        progressText = "Queued";
+    }
+    progressLabel->setText(progressText);
+    outProgressLabel = progressLabel;
+
+    statusBox->addView(progressLabel);
+
+    // X button icon indicator - only visible when focused
+    auto* xButtonIcon = new brls::Image();
+    xButtonIcon->setWidth(24);
+    xButtonIcon->setHeight(24);
+    xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    xButtonIcon->setImageFromFile("app0:resources/images/square_button.png");
+    xButtonIcon->setMarginLeft(8);
+    xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
+    outXButtonIcon = xButtonIcon;
+    statusBox->addView(xButtonIcon);
+
+    row->addView(statusBox);
+
+    // Show X button icon when this row gets focus
+    row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
+        if (m_currentFocusedIcon && m_currentFocusedIcon != xButtonIcon) {
+            m_currentFocusedIcon->setVisibility(brls::Visibility::INVISIBLE);
+        }
+        xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
+        m_currentFocusedIcon = xButtonIcon;
+    });
+
+    // X button action - remove from local queue
+    row->registerAction("Remove", brls::ControllerButton::BUTTON_X,
+        [this, mangaId, chapterIndex](brls::View* view) {
+            DownloadsManager& mgr = DownloadsManager::getInstance();
+            mgr.cancelChapterDownload(mangaId, chapterIndex);
+            removeLocalItem(mangaId, chapterIndex);
+            return true;
+        });
+
+    // Up button action - move up in queue
+    row->registerAction("Move Up", brls::ControllerButton::BUTTON_LB,
+        [this, mangaId, chapterIndex](brls::View* view) {
+            DownloadsManager& mgr = DownloadsManager::getInstance();
+            if (mgr.moveChapterInQueue(mangaId, chapterIndex, -1)) {
+                refreshLocalDownloads();  // Need full refresh for reordering
+            }
+            return true;
+        });
+
+    // Down button action - move down in queue
+    row->registerAction("Move Down", brls::ControllerButton::BUTTON_RB,
+        [this, mangaId, chapterIndex](brls::View* view) {
+            DownloadsManager& mgr = DownloadsManager::getInstance();
+            if (mgr.moveChapterInQueue(mangaId, chapterIndex, 1)) {
+                refreshLocalDownloads();  // Need full refresh for reordering
+            }
+            return true;
+        });
+
+    // Add swipe gesture for removal
+    auto localSwipeState = std::make_shared<SwipeState>();
+    row->addGestureRecognizer(new brls::PanGestureRecognizer(
+        [this, row, mangaId, chapterIndex, originalBgColor, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            const float SWIPE_THRESHOLD = 60.0f;
+            const float TAP_THRESHOLD = 15.0f;
+
+            if (status.state == brls::GestureState::START) {
+                localSwipeState->touchStart = status.position;
+                localSwipeState->isValidSwipe = false;
+            } else if (status.state == brls::GestureState::STAY) {
+                float dx = status.position.x - localSwipeState->touchStart.x;
+                float dy = status.position.y - localSwipeState->touchStart.y;
+
+                if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
+                    localSwipeState->isValidSwipe = true;
+                    if (dx < -SWIPE_THRESHOLD * 0.5f) {
+                        row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
+                    } else {
+                        row->setBackgroundColor(originalBgColor);
+                    }
+                }
+            } else if (status.state == brls::GestureState::END) {
+                row->setBackgroundColor(originalBgColor);
+
+                float dx = status.position.x - localSwipeState->touchStart.x;
+                if (localSwipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
+                    DownloadsManager& mgr = DownloadsManager::getInstance();
+                    mgr.cancelChapterDownload(mangaId, chapterIndex);
+                    removeLocalItem(mangaId, chapterIndex);
+                }
+            }
+        }, brls::PanAxis::HORIZONTAL));
+
+    return row;
+}
+
+// Helper: Update progress for an existing local download item (no rebuild)
+void DownloadsTab::updateLocalProgress(int mangaId, int chapterIndex, int downloadedPages, int pageCount, int state) {
+    for (auto& elem : m_localRowElements) {
+        if (elem.mangaId == mangaId && elem.chapterIndex == chapterIndex) {
+            if (elem.progressLabel) {
+                std::string progressText;
+                if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
+                    if (pageCount > 0) {
+                        progressText = std::to_string(downloadedPages) + "/" +
+                                       std::to_string(pageCount) + " pages";
+                    } else {
+                        progressText = "Downloading...";
+                    }
+                    elem.progressLabel->setTextColor(nvgRGBA(100, 200, 100, 255));
+                } else {
+                    progressText = "Queued";
+                    elem.progressLabel->setTextColor(nvgRGBA(255, 255, 255, 255));
+                }
+                elem.progressLabel->setText(progressText);
+
+                // Update background color based on state
+                if (elem.row) {
+                    if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
+                        elem.row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                    } else {
+                        elem.row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                    }
+                }
+            }
+            return;
+        }
+    }
+}
+
+// Helper: Remove a local download item from the UI
+void DownloadsTab::removeLocalItem(int mangaId, int chapterIndex) {
+    // Find and remove from tracking vector
+    int removeIdx = -1;
+    for (size_t i = 0; i < m_localRowElements.size(); i++) {
+        if (m_localRowElements[i].mangaId == mangaId &&
+            m_localRowElements[i].chapterIndex == chapterIndex) {
+            removeIdx = static_cast<int>(i);
+            break;
+        }
+    }
+
+    if (removeIdx < 0) return;
+
+    auto& elem = m_localRowElements[removeIdx];
+
+    // Check if this item has focus
+    brls::View* currentFocus = brls::Application::getCurrentFocus();
+    bool hadFocus = (elem.row == currentFocus);
+
+    // Remove from container
+    if (m_localContainer && elem.row) {
+        m_localContainer->removeView(elem.row);
+    }
+
+    // Remove from cache
+    for (auto it = m_lastLocalQueue.begin(); it != m_lastLocalQueue.end(); ++it) {
+        if (it->mangaId == mangaId && it->chapterIndex == chapterIndex) {
+            m_lastLocalQueue.erase(it);
+            break;
+        }
+    }
+
+    // Remove from tracking
+    m_localRowElements.erase(m_localRowElements.begin() + removeIdx);
+
+    // Handle empty state and focus
+    if (m_localRowElements.empty()) {
+        m_localSection->setVisibility(brls::Visibility::GONE);
+        if (m_lastServerQueue.empty() && m_downloadStatusLabel) {
+            m_downloadStatusLabel->setText("");
+        }
+        if (m_startStopBtn) {
+            brls::Application::giveFocus(m_startStopBtn);
+        }
+    } else if (hadFocus) {
+        // Move focus to next item
+        int newIdx = std::min(removeIdx, static_cast<int>(m_localRowElements.size()) - 1);
+        if (newIdx >= 0 && m_localRowElements[newIdx].row) {
+            brls::Application::giveFocus(m_localRowElements[newIdx].row);
+        }
+    }
+}
+
+// Helper: Add a new local download item to the UI
+void DownloadsTab::addLocalItem(int mangaId, int chapterIndex, const std::string& mangaTitle,
+                                const std::string& chapterName, float chapterNumber,
+                                int downloadedPages, int pageCount, int state) {
+    brls::Label* progressLabel = nullptr;
+    brls::Image* xButtonIcon = nullptr;
+
+    auto* row = createLocalRow(mangaId, chapterIndex, mangaTitle, chapterName, chapterNumber,
+                               downloadedPages, pageCount, state, progressLabel, xButtonIcon);
+
+    // Add to container
+    m_localContainer->addView(row);
+
+    // Track the elements
+    LocalRowElements elem;
+    elem.row = row;
+    elem.progressLabel = progressLabel;
+    elem.xButtonIcon = xButtonIcon;
+    elem.mangaId = mangaId;
+    elem.chapterIndex = chapterIndex;
+    m_localRowElements.push_back(elem);
+
+    // Add to cache
+    CachedLocalItem cached;
+    cached.mangaId = mangaId;
+    cached.chapterIndex = chapterIndex;
+    cached.downloadedPages = downloadedPages;
+    cached.pageCount = pageCount;
+    cached.state = state;
+    m_lastLocalQueue.push_back(cached);
+
+    // Ensure section is visible
+    m_localSection->setVisibility(brls::Visibility::VISIBLE);
+    m_localEmptyLabel->setVisibility(brls::Visibility::GONE);
+    m_localScroll->setVisibility(brls::Visibility::VISIBLE);
 }
 
 } // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -79,7 +79,7 @@ LibrarySectionTab::LibrarySectionTab() {
     sortContainer->setMarginLeft(10);
 
     auto* sortHintIcon = new brls::Image();
-    sortHintIcon->setWidth(64);
+    sortHintIcon->setWidth(16);
     sortHintIcon->setHeight(16);
     sortHintIcon->setScalingType(brls::ImageScalingType::FIT);
     sortHintIcon->setImageFromFile("app0:resources/images/triangle_button.png");
@@ -121,7 +121,7 @@ LibrarySectionTab::LibrarySectionTab() {
     updateContainer->setMarginLeft(8);
 
     auto* updateHintIcon = new brls::Image();
-    updateHintIcon->setWidth(64);
+    updateHintIcon->setWidth(16);
     updateHintIcon->setHeight(16);
     updateHintIcon->setScalingType(brls::ImageScalingType::FIT);
     updateHintIcon->setImageFromFile("app0:resources/images/select_button.png");

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -900,10 +900,10 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
 
     std::vector<std::string> options;
     if (m_selectionMode) {
-        options = {"Select / Deselect", "Download All", "Download Next 5", "Mark as Read", "Mark as Unread",
+        options = {"Select / Deselect", "Download", "Mark as Read", "Mark as Unread",
                    "Change Categories", "Remove from Library", "Cancel Selection"};
     } else {
-        options = {"Select", "Download All", "Download Next 5", "Track", "Mark as Read", "Mark as Unread",
+        options = {"Select", "Download", "Track", "Mark as Read", "Mark as Unread",
                    "Change Categories", "Remove from Library", "Migrate Source"};
     }
 
@@ -924,47 +924,40 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
                         m_contentGrid->toggleSelection(index);
                         updateSelectionTitle();
                         break;
-                    case 1: { // Download All
+                    case 1: { // Download
                         auto selectedManga = m_contentGrid->getSelectedManga();
                         if (selectedManga.empty()) selectedManga.push_back(manga);
                         showDownloadSubmenu(selectedManga);
                         break;
                     }
-                    case 2: { // Download Next 5
-                        auto selectedManga = m_contentGrid->getSelectedManga();
-                        if (selectedManga.empty()) selectedManga.push_back(manga);
-                        downloadNextChapters(selectedManga, 5);
-                        exitSelectionMode();
-                        break;
-                    }
-                    case 3: { // Mark as Read
+                    case 2: { // Mark as Read
                         auto selectedManga = m_contentGrid->getSelectedManga();
                         if (selectedManga.empty()) selectedManga.push_back(manga);
                         markMangaRead(selectedManga);
                         exitSelectionMode();
                         break;
                     }
-                    case 4: { // Mark as Unread
+                    case 3: { // Mark as Unread
                         auto selectedManga = m_contentGrid->getSelectedManga();
                         if (selectedManga.empty()) selectedManga.push_back(manga);
                         markMangaUnread(selectedManga);
                         exitSelectionMode();
                         break;
                     }
-                    case 5: { // Change Categories
+                    case 4: { // Change Categories
                         auto selectedManga = m_contentGrid->getSelectedManga();
                         if (selectedManga.empty()) selectedManga.push_back(manga);
                         showChangeCategoryDialog(selectedManga);
                         break;
                     }
-                    case 6: { // Remove from Library
+                    case 5: { // Remove from Library
                         auto selectedManga = m_contentGrid->getSelectedManga();
                         if (selectedManga.empty()) selectedManga.push_back(manga);
                         removeFromLibrary(selectedManga);
                         exitSelectionMode();
                         break;
                     }
-                    case 7: // Cancel Selection
+                    case 6: // Cancel Selection
                         exitSelectionMode();
                         break;
                 }
@@ -974,40 +967,35 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
                     case 0: // Select
                         enterSelectionMode(index);
                         break;
-                    case 1: { // Download All
+                    case 1: { // Download
                         std::vector<Manga> list = {manga};
                         showDownloadSubmenu(list);
                         break;
                     }
-                    case 2: { // Download Next 5
-                        std::vector<Manga> list = {manga};
-                        downloadNextChapters(list, 5);
-                        break;
-                    }
-                    case 3: // Track
+                    case 2: // Track
                         openTracking(manga);
                         break;
-                    case 4: { // Mark as Read
+                    case 3: { // Mark as Read
                         std::vector<Manga> list = {manga};
                         markMangaRead(list);
                         break;
                     }
-                    case 5: { // Mark as Unread
+                    case 4: { // Mark as Unread
                         std::vector<Manga> list = {manga};
                         markMangaUnread(list);
                         break;
                     }
-                    case 6: { // Change Categories
+                    case 5: { // Change Categories
                         std::vector<Manga> list = {manga};
                         showChangeCategoryDialog(list);
                         break;
                     }
-                    case 7: { // Remove from Library
+                    case 6: { // Remove from Library
                         std::vector<Manga> list = {manga};
                         removeFromLibrary(list);
                         break;
                     }
-                    case 8: // Migrate Source
+                    case 7: // Migrate Source
                         showMigrateSourceMenu(manga);
                         break;
                 }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -57,6 +57,41 @@ MangaDetailView::MangaDetailView(const Manga& manga)
         return true;
     });
 
+    // Register Y button for chapter filter
+    this->registerAction("Filter", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
+        // Show filter options dialog
+        std::vector<std::string> options = {"Toggle Downloaded", "Toggle Unread", "Toggle Bookmarked", "Clear Filters"};
+        brls::Dropdown* dropdown = new brls::Dropdown(
+            "Chapter Filters", options,
+            [this](int selected) {
+                if (selected < 0) return;
+                switch (selected) {
+                    case 0:
+                        m_filterDownloaded = !m_filterDownloaded;
+                        brls::Application::notify(m_filterDownloaded ? "Filtering: Downloaded" : "Filter removed");
+                        break;
+                    case 1:
+                        m_filterUnread = !m_filterUnread;
+                        brls::Application::notify(m_filterUnread ? "Filtering: Unread" : "Filter removed");
+                        break;
+                    case 2:
+                        m_filterBookmarked = !m_filterBookmarked;
+                        brls::Application::notify(m_filterBookmarked ? "Filtering: Bookmarked" : "Filter removed");
+                        break;
+                    case 3:
+                        m_filterDownloaded = false;
+                        m_filterUnread = false;
+                        m_filterBookmarked = false;
+                        m_filterScanlator.clear();
+                        brls::Application::notify("Filters cleared");
+                        break;
+                }
+                populateChaptersList();
+            }, 0);
+        brls::Application::pushActivity(new brls::Activity(dropdown));
+        return true;
+    });
+
     // ========== LEFT PANEL: Cover + Action Buttons (260px) ==========
     auto* leftPanel = new brls::Box();
     leftPanel->setAxis(brls::Axis::COLUMN);
@@ -318,19 +353,19 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     sortContainer->addView(m_sortBtn);
     chaptersActions->addView(sortContainer);
 
-    // Filter button with L icon above
+    // Filter button with Y (triangle) icon above
     auto* filterContainer = new brls::Box();
     filterContainer->setAxis(brls::Axis::COLUMN);
     filterContainer->setAlignItems(brls::AlignItems::CENTER);
     filterContainer->setMarginRight(10);
 
-    auto* lButtonIcon = new brls::Image();
-    lButtonIcon->setWidth(36);
-    lButtonIcon->setHeight(24);
-    lButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    lButtonIcon->setImageFromFile("app0:resources/images/l_button.png");
-    lButtonIcon->setMarginBottom(2);
-    filterContainer->addView(lButtonIcon);
+    auto* yButtonIcon = new brls::Image();
+    yButtonIcon->setWidth(24);
+    yButtonIcon->setHeight(24);
+    yButtonIcon->setScalingType(brls::ImageScalingType::FIT);
+    yButtonIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    yButtonIcon->setMarginBottom(2);
+    filterContainer->addView(yButtonIcon);
 
     m_filterBtn = new brls::Button();
     m_filterBtn->setWidth(44);
@@ -456,6 +491,36 @@ void MangaDetailView::loadDetails() {
 
     // Load tracking data
     loadTrackingData();
+
+    // Fetch full manga details from API if description is empty
+    if (m_manga.description.empty()) {
+        brls::Logger::info("MangaDetailView: Description is empty, fetching from API...");
+        asyncRun([this]() {
+            SuwayomiClient& client = SuwayomiClient::getInstance();
+            Manga updatedManga;
+
+            if (client.fetchManga(m_manga.id, updatedManga)) {
+                brls::sync([this, updatedManga]() {
+                    // Update description if we got one
+                    if (!updatedManga.description.empty()) {
+                        m_manga.description = updatedManga.description;
+                        m_fullDescription = updatedManga.description;
+                        m_descriptionExpanded = false;
+
+                        // Update the description label
+                        if (m_descriptionLabel) {
+                            std::string truncatedDesc = m_fullDescription;
+                            if (truncatedDesc.length() > 80) {
+                                truncatedDesc = truncatedDesc.substr(0, 77) + "... [L]";
+                            }
+                            m_descriptionLabel->setText(truncatedDesc);
+                        }
+                        brls::Logger::info("MangaDetailView: Updated description from API");
+                    }
+                });
+            }
+        });
+    }
 }
 
 void MangaDetailView::loadCover() {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2330,7 +2330,6 @@ void MangaDetailView::toggleDescription() {
     if (m_descriptionExpanded) {
         // Show full description
         m_descriptionLabel->setText(m_fullDescription + " [L]");
-        brls::Application::notify("Summary expanded");
     } else {
         // Show truncated description (first ~80 chars / 2 lines)
         std::string truncatedDesc = m_fullDescription;
@@ -2338,7 +2337,6 @@ void MangaDetailView::toggleDescription() {
             truncatedDesc = truncatedDesc.substr(0, 77) + "... [L]";
         }
         m_descriptionLabel->setText(truncatedDesc);
-        brls::Application::notify("Summary collapsed");
     }
 }
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -137,10 +137,11 @@ MangaItemCell::MangaItemCell() {
     this->addView(m_newBadge);
 
     // Star badge - top right corner (shows if manga is in library, browser/search only)
-    m_starBadge = new brls::Label();
-    m_starBadge->setFontSize(14);
-    m_starBadge->setText("\u2605");  // Unicode filled star character
-    m_starBadge->setTextColor(nvgRGB(255, 215, 0));  // Gold color
+    m_starBadge = new brls::Image();
+    m_starBadge->setWidth(16);
+    m_starBadge->setHeight(16);
+    m_starBadge->setScalingType(brls::ImageScalingType::FIT);
+    m_starBadge->setImageFromFile("app0:resources/icons/star.png");
     m_starBadge->setPositionType(brls::PositionType::ABSOLUTE);
     m_starBadge->setPositionTop(6);
     m_starBadge->setPositionRight(6);

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -136,6 +136,17 @@ MangaItemCell::MangaItemCell() {
     m_newBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_newBadge);
 
+    // Star badge - top right corner (shows if manga is in library, browser/search only)
+    m_starBadge = new brls::Label();
+    m_starBadge->setFontSize(14);
+    m_starBadge->setText("\u2605");  // Unicode filled star character
+    m_starBadge->setTextColor(nvgRGB(255, 215, 0));  // Gold color
+    m_starBadge->setPositionType(brls::PositionType::ABSOLUTE);
+    m_starBadge->setPositionTop(6);
+    m_starBadge->setPositionRight(6);
+    m_starBadge->setVisibility(brls::Visibility::GONE);
+    this->addView(m_starBadge);
+
     // Description label (hidden, for focus state)
     m_descriptionLabel = new brls::Label();
     m_descriptionLabel->setFontSize(9);
@@ -205,6 +216,12 @@ void MangaItemCell::updateDisplay() {
         }
 
         m_newBadge->setVisibility(showNew ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+
+    // Show star badge if manga is in library (browser/search tabs only)
+    if (m_starBadge) {
+        bool showStar = m_showLibraryBadge && m_manga.inLibrary;
+        m_starBadge->setVisibility(showStar ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
 }
 
@@ -344,6 +361,16 @@ void MangaItemCell::setListMode(bool listMode) {
     applyDisplayMode();
 }
 
+void MangaItemCell::setShowLibraryBadge(bool show) {
+    if (m_showLibraryBadge == show) return;
+    m_showLibraryBadge = show;
+    // Update star badge visibility
+    if (m_starBadge) {
+        bool showStar = m_showLibraryBadge && m_manga.inLibrary;
+        m_starBadge->setVisibility(showStar ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+}
+
 void MangaItemCell::applyDisplayMode() {
     if (m_listMode) {
         // List mode: simple horizontal layout with title only (no cover)
@@ -395,6 +422,11 @@ void MangaItemCell::applyDisplayMode() {
             m_startHintIcon->setPositionTop(4);
             m_startHintIcon->setPositionRight(4);
         }
+        // Position star badge for list mode (top-right, below start hint)
+        if (m_starBadge) {
+            m_starBadge->setPositionTop(4);
+            m_starBadge->setPositionRight(72);  // Left of start hint
+        }
 
     } else if (m_compactMode) {
         // Compact mode: grid with covers only (no title overlay)
@@ -438,6 +470,11 @@ void MangaItemCell::applyDisplayMode() {
             m_startHintIcon->setPositionTop(6);
             m_startHintIcon->setPositionRight(6);
         }
+        // Star badge position for compact mode (top-right, below start hint area)
+        if (m_starBadge) {
+            m_starBadge->setPositionTop(26);
+            m_starBadge->setPositionRight(6);
+        }
 
     } else {
         // Normal grid mode: cover + title overlay
@@ -480,6 +517,11 @@ void MangaItemCell::applyDisplayMode() {
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(6);
             m_startHintIcon->setPositionRight(6);
+        }
+        // Star badge position for normal grid mode (top-right, below start hint area)
+        if (m_starBadge) {
+            m_starBadge->setPositionTop(26);
+            m_starBadge->setPositionRight(6);
         }
     }
 }

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -6,7 +6,6 @@
 #include "view/media_item_cell.hpp"
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
-#include "app/downloads_manager.hpp"
 #include "utils/image_loader.hpp"
 #include <ctime>
 #include <fstream>
@@ -113,38 +112,26 @@ MangaItemCell::MangaItemCell() {
     m_listInfoBox->setVisibility(brls::Visibility::GONE);
     this->addView(m_listInfoBox);
 
-    // Unread badge - top right corner
+    // Unread badge - top left corner
     m_unreadBadge = new brls::Label();
     m_unreadBadge->setFontSize(10);
     m_unreadBadge->setTextColor(nvgRGB(255, 255, 255));
     m_unreadBadge->setBackgroundColor(nvgRGBA(0, 150, 136, 255)); // Teal badge
-    m_unreadBadge->setMargins(6, 6, 0, 0);
+    m_unreadBadge->setMargins(6, 0, 0, 6);
     m_unreadBadge->setPositionType(brls::PositionType::ABSOLUTE);
     m_unreadBadge->setPositionTop(0);
-    m_unreadBadge->setPositionRight(0);
+    m_unreadBadge->setPositionLeft(0);
     m_unreadBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_unreadBadge);
 
-    // Download badge - top left corner (shows checkmark if downloaded)
-    m_downloadBadge = new brls::Label();
-    m_downloadBadge->setFontSize(12);
-    m_downloadBadge->setTextColor(nvgRGB(255, 255, 255));
-    m_downloadBadge->setBackgroundColor(nvgRGBA(76, 175, 80, 255)); // Green badge
-    m_downloadBadge->setMargins(6, 0, 0, 6);
-    m_downloadBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_downloadBadge->setPositionTop(0);
-    m_downloadBadge->setPositionLeft(0);
-    m_downloadBadge->setVisibility(brls::Visibility::GONE);
-    this->addView(m_downloadBadge);
-
-    // NEW badge - below download badge (shows if recently updated)
+    // NEW badge - top left, below unread badge (shows if recently updated)
     m_newBadge = new brls::Label();
     m_newBadge->setFontSize(8);
     m_newBadge->setText("NEW");
     m_newBadge->setTextColor(nvgRGB(255, 255, 255));
     m_newBadge->setBackgroundColor(nvgRGBA(231, 76, 60, 255)); // Red badge
     m_newBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_newBadge->setPositionTop(26);  // Below download badge
+    m_newBadge->setPositionTop(26);  // Below unread badge
     m_newBadge->setPositionLeft(0);
     m_newBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_newBadge);
@@ -155,15 +142,15 @@ MangaItemCell::MangaItemCell() {
     m_descriptionLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
     m_descriptionLabel->setVisibility(brls::Visibility::GONE);
 
-    // Start button hint icon - shown on focus to indicate menu action
+    // Start button hint icon - shown on focus (top-right) to indicate menu action
     m_startHintIcon = new brls::Image();
     m_startHintIcon->setWidth(64);
     m_startHintIcon->setHeight(16);
     m_startHintIcon->setScalingType(brls::ImageScalingType::FIT);
     m_startHintIcon->setImageFromFile("app0:resources/images/start_button.png");
     m_startHintIcon->setPositionType(brls::PositionType::ABSOLUTE);
-    m_startHintIcon->setPositionBottom(6);
-    m_startHintIcon->setPositionLeft(6);
+    m_startHintIcon->setPositionTop(6);
+    m_startHintIcon->setPositionRight(6);
     m_startHintIcon->setVisibility(brls::Visibility::GONE);
     this->addView(m_startHintIcon);
 }
@@ -194,7 +181,7 @@ void MangaItemCell::updateDisplay() {
         }
     }
 
-    // Show unread badge (teal, top-right) - respects showUnreadBadge setting
+    // Show unread badge (teal, top-left) - respects showUnreadBadge setting
     if (m_unreadBadge) {
         const auto& settings = Application::getInstance().getSettings();
         if (settings.showUnreadBadge && m_manga.unreadCount > 0) {
@@ -202,20 +189,6 @@ void MangaItemCell::updateDisplay() {
             m_unreadBadge->setVisibility(brls::Visibility::VISIBLE);
         } else {
             m_unreadBadge->setVisibility(brls::Visibility::GONE);
-        }
-    }
-
-    // Show download badge if any chapters are downloaded locally - respects showDownloadedBadge setting
-    if (m_downloadBadge) {
-        const auto& settings = Application::getInstance().getSettings();
-        static const std::string ICON_CHECK = "\xEE\xA1\xAC";
-        DownloadsManager& dm = DownloadsManager::getInstance();
-        DownloadItem* download = dm.getMangaDownload(m_manga.id);
-        if (settings.showDownloadedBadge && download != nullptr) {
-            m_downloadBadge->setText(ICON_CHECK);
-            m_downloadBadge->setVisibility(brls::Visibility::VISIBLE);
-        } else {
-            m_downloadBadge->setVisibility(brls::Visibility::GONE);
         }
     }
 
@@ -408,23 +381,19 @@ void MangaItemCell::applyDisplayMode() {
             m_listInfoBox->addView(listTitle);
         }
 
-        // Position badges for list mode (right side)
+        // Position badges for list mode (left side)
         if (m_unreadBadge) {
             m_unreadBadge->setPositionTop(4);
-            m_unreadBadge->setPositionRight(8);
-        }
-        if (m_downloadBadge) {
-            m_downloadBadge->setPositionTop(4);
-            m_downloadBadge->setPositionRight(40);  // Position next to unread badge
+            m_unreadBadge->setPositionLeft(8);
         }
         if (m_newBadge) {
             m_newBadge->setPositionTop(4);
-            m_newBadge->setPositionRight(72);  // Position next to download badge
+            m_newBadge->setPositionLeft(40);  // Position next to unread badge
         }
-        // Position start hint for list mode
+        // Position start hint for list mode (top-right)
         if (m_startHintIcon) {
-            m_startHintIcon->setPositionBottom(4);
-            m_startHintIcon->setPositionLeft(4);
+            m_startHintIcon->setPositionTop(4);
+            m_startHintIcon->setPositionRight(4);
         }
 
     } else if (m_compactMode) {
@@ -455,23 +424,19 @@ void MangaItemCell::applyDisplayMode() {
             m_listInfoBox->setVisibility(brls::Visibility::GONE);
         }
 
-        // Restore badge positions for grid mode
+        // Restore badge positions for grid mode (left side)
         if (m_unreadBadge) {
             m_unreadBadge->setPositionTop(0);
-            m_unreadBadge->setPositionRight(0);
-        }
-        if (m_downloadBadge) {
-            m_downloadBadge->setPositionTop(0);
-            m_downloadBadge->setPositionLeft(0);
+            m_unreadBadge->setPositionLeft(0);
         }
         if (m_newBadge) {
             m_newBadge->setPositionTop(26);
             m_newBadge->setPositionLeft(0);
         }
-        // Restore start hint position for compact mode
+        // Restore start hint position for compact mode (top-right)
         if (m_startHintIcon) {
-            m_startHintIcon->setPositionBottom(6);
-            m_startHintIcon->setPositionLeft(6);
+            m_startHintIcon->setPositionTop(6);
+            m_startHintIcon->setPositionRight(6);
         }
 
     } else {
@@ -502,23 +467,19 @@ void MangaItemCell::applyDisplayMode() {
             m_listInfoBox->setVisibility(brls::Visibility::GONE);
         }
 
-        // Restore badge positions for grid mode
+        // Restore badge positions for grid mode (left side)
         if (m_unreadBadge) {
             m_unreadBadge->setPositionTop(0);
-            m_unreadBadge->setPositionRight(0);
-        }
-        if (m_downloadBadge) {
-            m_downloadBadge->setPositionTop(0);
-            m_downloadBadge->setPositionLeft(0);
+            m_unreadBadge->setPositionLeft(0);
         }
         if (m_newBadge) {
             m_newBadge->setPositionTop(26);
             m_newBadge->setPositionLeft(0);
         }
-        // Restore start hint position for normal grid mode
+        // Restore start hint position for normal grid mode (top-right)
         if (m_startHintIcon) {
-            m_startHintIcon->setPositionBottom(6);
-            m_startHintIcon->setPositionLeft(6);
+            m_startHintIcon->setPositionTop(6);
+            m_startHintIcon->setPositionRight(6);
         }
     }
 }

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -286,8 +286,8 @@ brls::View* MangaItemCell::create() {
 void MangaItemCell::onFocusGained() {
     brls::Box::onFocusGained();
     updateFocusInfo(true);
-    // Show start button hint on focus
-    if (m_startHintIcon) {
+    // Show start button hint on focus (but not in browser/search tabs where library badge is shown)
+    if (m_startHintIcon && !m_showLibraryBadge) {
         m_startHintIcon->setVisibility(brls::Visibility::VISIBLE);
     }
 }
@@ -369,6 +369,10 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     if (m_starBadge) {
         bool showStar = m_showLibraryBadge && m_manga.inLibrary;
         m_starBadge->setVisibility(showStar ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+    // Hide start hint icon when in browser/search mode
+    if (m_startHintIcon && m_showLibraryBadge) {
+        m_startHintIcon->setVisibility(brls::Visibility::GONE);
     }
 }
 

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -141,6 +141,11 @@ void RecyclingGrid::setupGrid() {
                 cell->setCompactMode(true);
             }
 
+            // Apply library badge setting (for browser/search tabs)
+            if (m_showLibraryBadge) {
+                cell->setShowLibraryBadge(true);
+            }
+
             // Load first rows immediately, defer rest for staggered loading
             if (row < maxInitialRows) {
                 cell->setManga(m_items[i]);
@@ -323,6 +328,16 @@ void RecyclingGrid::setListMode(bool listMode) {
     // Rebuild grid if we have items
     if (!m_items.empty()) {
         setupGrid();
+    }
+}
+
+void RecyclingGrid::setShowLibraryBadge(bool show) {
+    if (m_showLibraryBadge == show) return;
+    m_showLibraryBadge = show;
+
+    // Update existing cells
+    for (auto* cell : m_cells) {
+        cell->setShowLibraryBadge(show);
     }
 }
 

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -250,6 +250,7 @@ SearchTab::SearchTab() {
     // Content grid
     m_contentGrid = new RecyclingGrid();
     m_contentGrid->setGrow(1.0f);
+    m_contentGrid->setShowLibraryBadge(true);  // Show star for library items in browser/search
     m_contentGrid->setOnItemSelected([this](const Manga& manga) {
         onMangaSelected(manga);
     });
@@ -989,6 +990,7 @@ brls::View* SearchTab::createSourceRow(const std::string& sourceName, const std:
     // Create manga cells for each result
     for (size_t i = 0; i < manga.size(); i++) {
         auto* cell = new MangaItemCell();
+        cell->setShowLibraryBadge(true);  // Show star for library items in search results
         cell->setManga(manga[i]);
         cell->setWidth(150);
         cell->setHeight(185);

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -334,14 +334,6 @@ void SettingsTab::createLibrarySection() {
     });
     m_contentBox->addView(showUnreadBadgeToggle);
 
-    // Show downloaded badge toggle
-    auto* showDownloadedBadgeToggle = new brls::BooleanCell();
-    showDownloadedBadgeToggle->init("Show Downloaded Badge", settings.showDownloadedBadge, [](bool value) {
-        Application::getInstance().getSettings().showDownloadedBadge = value;
-        Application::getInstance().saveSettings();
-    });
-    m_contentBox->addView(showDownloadedBadgeToggle);
-
     // Clear Cache button
     auto* clearCacheCell = new brls::DetailCell();
     clearCacheCell->setText("Clear Cache");

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -228,6 +228,7 @@ void SourceBrowseTab::updateGrid() {
 
     for (const auto& manga : m_mangaList) {
         auto* cell = new MangaItemCell();
+        cell->setShowLibraryBadge(true);  // Show star for library items in browser
         cell->setManga(manga);
         cell->registerClickAction([this, manga](brls::View*) {
             onMangaSelected(manga);


### PR DESCRIPTION
Overhauls the downloads tab and library updates: incremental UI updates, hidden empty sections, throttling and crash prevention, D-pad navigation between server and local queues, start/pause/stop working on both, plus a gold-star library badge in the browser and several button-hint fixes.

---
_Generated by [Claude Code](https://claude.ai/code)_