### PR TITLE
Fix missing closing parenthesis in setHorizontalAlign

### DIFF
--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1644,7 +1644,7 @@ void MangaDetailView::downloadAllChapters() {
 
         brls::Label* label = new brls::Label();
         label->setText(message);
-        label->setHorizontalAlign(brls::HorizontalAlign::CENTER;
+        label->setHorizontalAlign(brls::HorizontalAlign::CENTER);
         confirmDialog->addView(label);
 
         confirmDialog->addButton("Download", [downloadMode, mangaId, mangaTitle, serverChapterIds, localChapterPairs, confirmDialog]() {


### PR DESCRIPTION
Fix missing closing parenthesis in setHorizontalAlign

---
_Generated by [Claude Code](https://claude.ai/code)_