### PR TITLE
Add reader zoom/scale features and fix chapter view crash

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -131,9 +131,11 @@ private:
     BRLS_BIND(brls::Button, settingsFormatBtn, "reader/settings_format_btn");
     BRLS_BIND(brls::Button, settingsDirBtn, "reader/settings_dir_btn");
     BRLS_BIND(brls::Button, settingsRotBtn, "reader/settings_rot_btn");
+    BRLS_BIND(brls::Button, settingsScaleBtn, "reader/settings_scale_btn");
     BRLS_BIND(brls::Label, settingsFormatLabel, "reader/settings_format_label");
     BRLS_BIND(brls::Label, settingsDirLabel, "reader/settings_dir_label");
     BRLS_BIND(brls::Label, settingsRotLabel, "reader/settings_rot_label");
+    BRLS_BIND(brls::Label, settingsScaleLabel, "reader/settings_scale_label");
 
     // Webtoon continuous scroll view
     BRLS_BIND(WebtoonScrollView, webtoonScroll, "reader/webtoon_scroll");

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -158,6 +158,7 @@ private:
     struct ChapterDownloadUI {
         int chapterIndex;
         brls::Button* dlBtn = nullptr;
+        brls::Image* dlIcon = nullptr;  // Cached icon for this button
         int cachedState = -1;       // LocalDownloadState as int, -1 = not local
         int cachedPercent = -1;     // Download percent (0-100)
     };

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -69,6 +69,31 @@ public:
      */
     bool hasImage() const { return m_nvgImage != 0; }
 
+    /**
+     * Set zoom level (1.0 = normal, >1.0 = zoomed in)
+     */
+    void setZoomLevel(float level);
+
+    /**
+     * Get current zoom level
+     */
+    float getZoomLevel() const { return m_zoomLevel; }
+
+    /**
+     * Set zoom offset (pan position when zoomed)
+     */
+    void setZoomOffset(brls::Point offset);
+
+    /**
+     * Get current zoom offset
+     */
+    brls::Point getZoomOffset() const { return m_zoomOffset; }
+
+    /**
+     * Reset zoom to normal (1.0x with no offset)
+     */
+    void resetZoom();
+
     static brls::View* create();
 
 private:
@@ -79,6 +104,10 @@ private:
     float m_rotationRadians = 0.0f;
     brls::ImageScalingType m_scalingType = brls::ImageScalingType::FIT;
     NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Default dark mode color
+
+    // Zoom state
+    float m_zoomLevel = 1.0f;      // Current zoom level (1.0 = normal)
+    brls::Point m_zoomOffset = {0, 0};  // Pan offset when zoomed
 
     // Calculate image bounds for current scaling type
     void calculateImageBounds(float viewX, float viewY, float viewW, float viewH,

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -190,10 +190,26 @@
                 style="bordered"
                 width="100%"
                 height="40"
-                marginBottom="15">
+                marginBottom="10">
                 <brls:Label
                     id="reader/settings_rot_label"
                     text="0°"
+                    fontSize="14"
+                    textColor="#ffffff"
+                    horizontalAlign="center"
+                    width="100%"/>
+            </brls:Button>
+
+            <!-- Scale button -->
+            <brls:Button
+                id="reader/settings_scale_btn"
+                style="bordered"
+                width="100%"
+                height="40"
+                marginBottom="15">
+                <brls:Label
+                    id="reader/settings_scale_label"
+                    text="Fit Screen"
                     fontSize="14"
                     textColor="#ffffff"
                     horizontalAlign="center"

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -352,6 +352,25 @@ void ReaderActivity::onContentAvailable() {
                     float dx = m_touchCurrent.x - m_touchStart.x;
                     float dy = m_touchCurrent.y - m_touchStart.y;
 
+                    // If zoomed, use pan to scroll the zoomed image instead of page navigation
+                    if (m_isZoomed) {
+                        // Update zoom offset based on pan delta
+                        brls::Point newOffset = {
+                            m_zoomOffset.x + dx,
+                            m_zoomOffset.y + dy
+                        };
+
+                        // Apply offset to image
+                        if (pageImage) {
+                            pageImage->setZoomOffset(newOffset);
+                        }
+
+                        // Update touch start for next delta calculation
+                        m_touchStart = m_touchCurrent;
+                        m_zoomOffset = newOffset;
+                        return;
+                    }
+
                     // Raw delta follows the finger (for visual feedback)
                     float rawDelta = useVerticalSwipe ? dy : dx;
                     float crossDelta = useVerticalSwipe ? dx : dy;
@@ -619,6 +638,31 @@ void ReaderActivity::onContentAvailable() {
             return true;
         });
         settingsRotBtn->addGestureRecognizer(new brls::TapGestureRecognizer(settingsRotBtn));
+    }
+
+    if (settingsScaleBtn) {
+        settingsScaleBtn->registerClickAction([this](brls::View*) {
+            // Cycle through scale modes: FIT_SCREEN -> FIT_WIDTH -> FIT_HEIGHT -> ORIGINAL -> FIT_SCREEN
+            switch (m_settings.scaleMode) {
+                case ReaderScaleMode::FIT_SCREEN:
+                    m_settings.scaleMode = ReaderScaleMode::FIT_WIDTH;
+                    break;
+                case ReaderScaleMode::FIT_WIDTH:
+                    m_settings.scaleMode = ReaderScaleMode::FIT_HEIGHT;
+                    break;
+                case ReaderScaleMode::FIT_HEIGHT:
+                    m_settings.scaleMode = ReaderScaleMode::ORIGINAL;
+                    break;
+                case ReaderScaleMode::ORIGINAL:
+                    m_settings.scaleMode = ReaderScaleMode::FIT_SCREEN;
+                    break;
+            }
+            applySettings();
+            saveSettingsToApp();
+            updateSettingsLabels();
+            return true;
+        });
+        settingsScaleBtn->addGestureRecognizer(new brls::TapGestureRecognizer(settingsScaleBtn));
     }
 
     // Update direction label
@@ -1225,6 +1269,18 @@ void ReaderActivity::updateSettingsLabels() {
         }
         settingsRotLabel->setText(rotText);
     }
+
+    // Update scale label
+    if (settingsScaleLabel) {
+        std::string scaleText;
+        switch (m_settings.scaleMode) {
+            case ReaderScaleMode::FIT_SCREEN: scaleText = "Fit Screen"; break;
+            case ReaderScaleMode::FIT_WIDTH: scaleText = "Fit Width"; break;
+            case ReaderScaleMode::FIT_HEIGHT: scaleText = "Fit Height"; break;
+            case ReaderScaleMode::ORIGINAL: scaleText = "Original"; break;
+        }
+        settingsScaleLabel->setText(scaleText);
+    }
 }
 
 void ReaderActivity::applySettings() {
@@ -1234,13 +1290,22 @@ void ReaderActivity::applySettings() {
     brls::ImageScalingType scalingType = brls::ImageScalingType::FIT;
     switch (m_settings.scaleMode) {
         case ReaderScaleMode::FIT_SCREEN:
+            scalingType = brls::ImageScalingType::FIT;
+            break;
         case ReaderScaleMode::FIT_WIDTH:
+            // FIT_WIDTH: fit width to screen, allow vertical scrolling
+            // Use FILL to ensure width fills (may crop vertically)
+            scalingType = brls::ImageScalingType::FILL;
+            break;
         case ReaderScaleMode::FIT_HEIGHT:
+            // FIT_HEIGHT: fit height to screen, allow horizontal scrolling
+            // Use FIT to maintain aspect ratio and fit height
             scalingType = brls::ImageScalingType::FIT;
             break;
         case ReaderScaleMode::ORIGINAL:
-            // FILL maintains aspect ratio but may crop - closest to original
-            scalingType = brls::ImageScalingType::FILL;
+            // ORIGINAL: no scaling, show image at native resolution
+            // Use SCALE to show at 1:1 pixel ratio
+            scalingType = brls::ImageScalingType::SCALE;
             break;
     }
 
@@ -1391,8 +1456,9 @@ void ReaderActivity::resetZoom() {
     m_zoomOffset = {0, 0};
 
     if (pageImage) {
-        // Reset to fit scaling - maintains aspect ratio, shows margins
-        pageImage->setScalingType(brls::ImageScalingType::FIT);
+        pageImage->resetZoom();
+        // Restore scale mode settings
+        applySettings();
     }
 }
 
@@ -1401,8 +1467,22 @@ void ReaderActivity::zoomTo(float level, brls::Point center) {
     m_zoomLevel = level;
 
     if (pageImage) {
-        // Use FILL scaling for zoomed view
-        pageImage->setScalingType(brls::ImageScalingType::FILL);
+        pageImage->setZoomLevel(level);
+
+        // Calculate zoom offset to center on the tap position
+        // Transform center point to image space and zoom around it
+        brls::Rect frame = pageImage->getFrame();
+        float relX = (center.x - frame.getMinX()) / frame.getWidth();
+        float relY = (center.y - frame.getMinY()) / frame.getHeight();
+
+        // Offset to keep the tapped point in place
+        brls::Point offset = {
+            -(relX - 0.5f) * frame.getWidth() * (level - 1.0f),
+            -(relY - 0.5f) * frame.getHeight() * (level - 1.0f)
+        };
+
+        m_zoomOffset = offset;
+        pageImage->setZoomOffset(offset);
 
         std::string zoomText = "Zoom: " + std::to_string(static_cast<int>(level * 100)) + "%";
         brls::Application::notify(zoomText);
@@ -1425,11 +1505,10 @@ void ReaderActivity::handlePinchZoom(float scaleFactor) {
             m_isZoomed = (newZoom > 1.0f);
 
             if (pageImage) {
-                if (m_isZoomed) {
-                    pageImage->setScalingType(brls::ImageScalingType::FILL);
-                } else {
-                    pageImage->setScalingType(brls::ImageScalingType::FIT);
-                }
+                pageImage->setZoomLevel(newZoom);
+
+                // Preserve current zoom offset (user's pan position)
+                pageImage->setZoomOffset(m_zoomOffset);
             }
         }
     }


### PR DESCRIPTION
Add reader zoom/scale features and fix chapter view crash

This commit implements three critical reader improvements:

1. Proper Pinch-to-Zoom for Reader Pages
   - Added zoom level and offset support to RotatableImage class
   - Implemented true NVG transform (scale + translate) for arbitrary zoom
   - Added pan-to-scroll when zoomed (drag to navigate zoomed image)
   - Updated zoom methods to calculate proper zoom center on tap
   - Double-tap zooms to 2x centered on tap point
   - Zoom level clamped between 0.5x and 4x

2. Scale Mode Option in Reader Settings
   - Added scale mode button to reader settings panel
   - Cycles through: FIT_SCREEN → FIT_WIDTH → FIT_HEIGHT → ORIGINAL
   - Settings are saved per-manga (locally and to server)
   - Updated applySettings() to properly map scale modes to NVG types

3. Fix Download Progress Crash on Chapter View
   - Fixed willDisappear() to clear callbacks FIRST before cleanup
   - Added m_alive guard checks in all async sync lambdas
   - Cached icon Images in ChapterDownloadUI instead of recreating
   - Added null checks and isChild() validation in updateChapterDownloadStates()
   - Prevents crashes from stale pointers and view updates after destruction

Files changed:
- include/activity/reader_activity.hpp: Added scale button bindings
- include/view/media_detail_view.hpp: Added dlIcon cache member
- include/view/rotatable_image.hpp: Added zoom methods and state
- resources/xml/activity/reader.xml: Added scale button to settings
- src/activity/reader_activity.cpp: Zoom, pan, and scale implementations
- src/view/media_detail_view.cpp: Fixed crash with callback ordering
- src/view/rotatable_image.cpp: Implemented zoom transform rendering

---
_Generated by [Claude Code](https://claude.ai/code)_