### PR TITLE
Fix page scaling: Fit Screen, Fit Width, Fit Height, Original Size (1:1)

### DIFF
--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -10,6 +10,14 @@
 
 namespace vitasuwayomi {
 
+// Custom scale modes for the reader (more granular than borealis)
+enum class ImageScaleMode {
+    FIT_SCREEN,     // Fit entire image on screen, maintain aspect ratio
+    FIT_WIDTH,      // Fit width to screen, may crop top/bottom
+    FIT_HEIGHT,     // Fit height to screen, may crop left/right
+    ORIGINAL        // Show at native 1:1 pixel resolution, centered
+};
+
 class RotatableImage : public brls::Box {
 public:
     RotatableImage();
@@ -49,9 +57,20 @@ public:
     void cycleRotation();
 
     /**
-     * Set scaling type (FIT maintains aspect ratio)
+     * Set scaling type (legacy borealis compat - maps to custom mode)
      */
-    void setScalingType(brls::ImageScalingType type) { m_scalingType = type; }
+    void setScalingType(brls::ImageScalingType type) {
+        switch (type) {
+            case brls::ImageScalingType::FIT: m_scaleMode = ImageScaleMode::FIT_SCREEN; break;
+            case brls::ImageScalingType::FILL: m_scaleMode = ImageScaleMode::FIT_WIDTH; break;
+            default: m_scaleMode = ImageScaleMode::FIT_SCREEN; break;
+        }
+    }
+
+    /**
+     * Set custom scale mode (preferred over setScalingType)
+     */
+    void setScaleMode(ImageScaleMode mode) { m_scaleMode = mode; }
 
     /**
      * Set background color (shown in margins when image doesn't fill view)
@@ -102,7 +121,7 @@ private:
     int m_imageHeight = 0;
     float m_rotationDegrees = 0.0f;
     float m_rotationRadians = 0.0f;
-    brls::ImageScalingType m_scalingType = brls::ImageScalingType::FIT;
+    ImageScaleMode m_scaleMode = ImageScaleMode::FIT_SCREEN;
     NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Default dark mode color
 
     // Zoom state

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1277,7 +1277,7 @@ void ReaderActivity::updateSettingsLabels() {
             case ReaderScaleMode::FIT_SCREEN: scaleText = "Fit Screen"; break;
             case ReaderScaleMode::FIT_WIDTH: scaleText = "Fit Width"; break;
             case ReaderScaleMode::FIT_HEIGHT: scaleText = "Fit Height"; break;
-            case ReaderScaleMode::ORIGINAL: scaleText = "Original"; break;
+            case ReaderScaleMode::ORIGINAL: scaleText = "Original (1:1)"; break;
         }
         settingsScaleLabel->setText(scaleText);
     }
@@ -1286,33 +1286,27 @@ void ReaderActivity::updateSettingsLabels() {
 void ReaderActivity::applySettings() {
     if (!pageImage) return;
 
-    // Determine scaling type based on mode
-    brls::ImageScalingType scalingType = brls::ImageScalingType::FIT;
+    // Map reader scale mode to image scale mode
+    vitasuwayomi::ImageScaleMode imgMode = vitasuwayomi::ImageScaleMode::FIT_SCREEN;
     switch (m_settings.scaleMode) {
         case ReaderScaleMode::FIT_SCREEN:
-            scalingType = brls::ImageScalingType::FIT;
+            imgMode = vitasuwayomi::ImageScaleMode::FIT_SCREEN;
             break;
         case ReaderScaleMode::FIT_WIDTH:
-            // FIT_WIDTH: fit width to screen, allow vertical scrolling
-            // Use FILL to ensure width fills (may crop vertically)
-            scalingType = brls::ImageScalingType::FILL;
+            imgMode = vitasuwayomi::ImageScaleMode::FIT_WIDTH;
             break;
         case ReaderScaleMode::FIT_HEIGHT:
-            // FIT_HEIGHT: fit height to screen, allow horizontal scrolling
-            // Use FIT to maintain aspect ratio and fit height
-            scalingType = brls::ImageScalingType::FIT;
+            imgMode = vitasuwayomi::ImageScaleMode::FIT_HEIGHT;
             break;
         case ReaderScaleMode::ORIGINAL:
-            // ORIGINAL: no scaling, show image at native resolution
-            // Use SCALE to show at 1:1 pixel ratio
-            scalingType = brls::ImageScalingType::STRETCH;
+            imgMode = vitasuwayomi::ImageScaleMode::ORIGINAL;
             break;
     }
 
     // Apply scaling to both main and preview images
-    pageImage->setScalingType(scalingType);
+    pageImage->setScaleMode(imgMode);
     if (previewImage) {
-        previewImage->setScalingType(scalingType);
+        previewImage->setScaleMode(imgMode);
     }
 
     // Apply rotation to both main and preview images

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -207,7 +207,7 @@ std::string Application::getPageScaleModeString(PageScaleMode mode) {
         case PageScaleMode::FIT_SCREEN: return "Fit Screen";
         case PageScaleMode::FIT_WIDTH: return "Fit Width";
         case PageScaleMode::FIT_HEIGHT: return "Fit Height";
-        case PageScaleMode::ORIGINAL: return "Original";
+        case PageScaleMode::ORIGINAL: return "Original (1:1)";
         default: return "Unknown";
     }
 }

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -96,8 +96,8 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
     float imageAspect = (float)effectiveWidth / (float)effectiveHeight;
     float viewAspect = viewW / viewH;
 
-    switch (m_scalingType) {
-        case brls::ImageScalingType::FIT:
+    switch (m_scaleMode) {
+        case ImageScaleMode::FIT_SCREEN:
             // Fit entire image within view, maintaining aspect ratio
             if (viewAspect > imageAspect) {
                 // View is wider - fit to height
@@ -114,30 +114,29 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
             }
             break;
 
-        case brls::ImageScalingType::FILL:
-            // Fill view, cropping if necessary
-            if (viewAspect > imageAspect) {
-                // View is wider - fill width, crop top/bottom
-                imgW = viewW;
-                imgH = viewW / imageAspect;
-                imgX = viewX;
-                imgY = viewY + (viewH - imgH) / 2.0f;
-            } else {
-                // View is taller - fill height, crop left/right
-                imgH = viewH;
-                imgW = viewH * imageAspect;
-                imgX = viewX + (viewW - imgW) / 2.0f;
-                imgY = viewY;
-            }
+        case ImageScaleMode::FIT_WIDTH:
+            // Fit width to screen width, scale height proportionally
+            imgW = viewW;
+            imgH = viewW / imageAspect;
+            imgX = viewX;
+            imgY = viewY + (viewH - imgH) / 2.0f;
             break;
 
-        case brls::ImageScalingType::STRETCH:
-        default:
-            // Stretch to fill (distorts aspect ratio)
-            imgX = viewX;
-            imgY = viewY;
-            imgW = viewW;
+        case ImageScaleMode::FIT_HEIGHT:
+            // Fit height to screen height, scale width proportionally
             imgH = viewH;
+            imgW = viewH * imageAspect;
+            imgX = viewX + (viewW - imgW) / 2.0f;
+            imgY = viewY;
+            break;
+
+        case ImageScaleMode::ORIGINAL:
+        default:
+            // Show at native 1:1 pixel resolution, centered in view
+            imgW = (float)effectiveWidth;
+            imgH = (float)effectiveHeight;
+            imgX = viewX + (viewW - imgW) / 2.0f;
+            imgY = viewY + (viewH - imgH) / 2.0f;
             break;
     }
 }

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -659,7 +659,7 @@ void SettingsTab::createReaderSection() {
     // Page scale mode selector
     m_pageScaleModeSelector = new brls::SelectorCell();
     m_pageScaleModeSelector->init("Page Scale",
-        {"Fit Screen", "Fit Width", "Fit Height", "Original"},
+        {"Fit Screen", "Fit Width", "Fit Height", "Original Size (1:1)"},
         static_cast<int>(settings.pageScaleMode),
         [&settings](int index) {
             settings.pageScaleMode = static_cast<PageScaleMode>(index);


### PR DESCRIPTION
Fix page scaling: Fit Screen, Fit Width, Fit Height, Original Size (1:1)

The reader was mapping scaling modes to borealis ImageScalingType which
only has FIT/FILL/STRETCH - not enough for 4 distinct modes:

- FIT_HEIGHT used FIT (same as FIT_SCREEN, so it did nothing different)
- ORIGINAL used STRETCH (distorts the image to fill the container)

Fix: Add a custom ImageScaleMode enum to RotatableImage with proper
implementations for all 4 modes:

- FIT_SCREEN: fit entire image maintaining aspect ratio (unchanged)
- FIT_WIDTH: scale to match screen width, height proportional
- FIT_HEIGHT: scale to match screen height, width proportional
- ORIGINAL: render at native pixel dimensions (1:1), centered

The reader's applySettings() now calls setScaleMode() directly
instead of mapping through borealis types. setScalingType() is kept
for backward compatibility with other code using RotatableImage.

Labels updated to "Original Size (1:1)" in settings and reader panel
for clarity.

---
_Generated by [Claude Code](https://claude.ai/code)_