### PR TITLE
Use combined GraphQL queries to reduce network round-trips

### DIFF
--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -473,6 +473,10 @@ public:
     bool removeMangaFromCategory(int mangaId, int categoryId);
     bool fetchCategoryManga(int categoryId, std::vector<Manga>& manga);
 
+    // Combined/parallel fetch operations (single request for multiple data)
+    bool fetchCategoriesWithManga(std::vector<Category>& categories, int categoryId, std::vector<Manga>& manga);
+    bool fetchMangaWithChapters(int mangaId, Manga& manga, std::vector<Chapter>& chapters);
+
     // Library Operations
     bool fetchLibraryManga(std::vector<Manga>& manga);
     bool fetchLibraryMangaByCategory(int categoryId, std::vector<Manga>& manga);
@@ -604,6 +608,8 @@ private:
     bool setMangaCategoriesGraphQL(int mangaId, const std::vector<int>& categoryIds);
     bool fetchCategoryMangaGraphQL(int categoryId, std::vector<Manga>& manga);
     bool fetchCategoryMangaGraphQLFallback(int categoryId, std::vector<Manga>& manga);
+    bool fetchCategoriesWithMangaGraphQL(std::vector<Category>& categories, int categoryId, std::vector<Manga>& manga);
+    bool fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, std::vector<Chapter>& chapters);
 
     // Category Management GraphQL methods
     bool createCategoryGraphQL(const std::string& name);


### PR DESCRIPTION
Use combined GraphQL queries to reduce network round-trips

Library tab: Fetch categories + default category manga in a single
GraphQL request instead of sequentially (categories first, then manga).
This cuts initial library load from 2 round-trips to 1.

Manga detail view: When description is missing, fetch manga details +
chapters in one combined query instead of 2 separate parallel requests.
This reduces network overhead on the Vita's limited connection.

Both changes include fallback to separate fetches if the combined
query fails, maintaining compatibility with older server versions.

---
_Generated by [Claude Code](https://claude.ai/code)_