### PR TITLE
Fix end-of-load freeze on large libraries (75+ books)

### DIFF
--- a/include/utils/library_cache.hpp
+++ b/include/utils/library_cache.hpp
@@ -95,7 +95,8 @@ private:
     bool m_enabled = true;
     bool m_coverCacheEnabled = true;
     bool m_initialized = false;
-    std::mutex m_mutex;
+    std::mutex m_mutex;       // Protects metadata operations (categories, manga lists, details)
+    std::mutex m_coverMutex;  // Separate mutex for cover image I/O (allows parallel reads by worker threads)
 };
 
 } // namespace vitasuwayomi

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -139,6 +139,7 @@ private:
     bool m_loaded = false;
     bool m_categoriesLoaded = false;
     bool m_focusGridAfterLoad = false;  // Focus first grid item after loading new category
+    int m_combinedQueryCategoryId = -1; // Category being fetched by combined query (skip redundant fetch)
 
     // Shared pointer to track if this object is still alive
     std::shared_ptr<bool> m_alive;

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -51,6 +51,8 @@ private:
     Manga m_manga;
     std::string m_originalTitle;
     bool m_thumbnailLoaded = false;
+    bool m_starImageLoaded = false;       // Lazy: load star.png only when first shown
+    bool m_startHintImageLoaded = false;  // Lazy: load start_button.png only when first shown
 
     brls::Image* m_thumbnailImage = nullptr;
     brls::Box* m_titleOverlay = nullptr;  // Title overlay container (grid mode)

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <vector>
 #include <set>
+#include <memory>
 
 namespace vitasuwayomi {
 
@@ -18,6 +19,7 @@ class MangaItemCell;
 class RecyclingGrid : public brls::ScrollingFrame {
 public:
     RecyclingGrid();
+    ~RecyclingGrid();
 
     void setDataSource(const std::vector<Manga>& items);
     void updateDataOrder(const std::vector<Manga>& items);  // Update cell data in place without rebuilding grid
@@ -69,6 +71,8 @@ public:
 
 private:
     void setupGrid();
+    void createRowRange(int startRow, int endRow);  // Create rows [startRow, endRow)
+    void buildNextRowBatch();  // Continue incremental grid building
     void updateVisibleCells();
     void onItemClicked(int index);
 
@@ -109,6 +113,13 @@ private:
 
     // Long-press tracking - when true, the next click should be skipped
     bool m_longPressTriggered = false;
+
+    // Incremental grid building state - spreads cell creation across frames
+    // to prevent multi-second freezes on large libraries (98+ books)
+    std::shared_ptr<bool> m_alive;
+    int m_incrementalBuildRow = 0;
+    int m_totalRowsNeeded = 0;
+    bool m_incrementalBuildActive = false;
 };
 
 } // namespace vitasuwayomi

--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -408,7 +408,7 @@ void LibraryCache::invalidateCategoryCache(int categoryId) {
 bool LibraryCache::saveCoverImage(int mangaId, const std::vector<uint8_t>& imageData) {
     if (!m_coverCacheEnabled || imageData.empty()) return false;
 
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_coverMutex);
 
     std::string path = getCoverCachePath(mangaId);
 
@@ -434,7 +434,7 @@ bool LibraryCache::saveCoverImage(int mangaId, const std::vector<uint8_t>& image
 bool LibraryCache::loadCoverImage(int mangaId, std::vector<uint8_t>& imageData) {
     if (!m_coverCacheEnabled) return false;
 
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_coverMutex);
 
     std::string path = getCoverCachePath(mangaId);
     imageData.clear();

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -144,11 +144,11 @@ MangaItemCell::MangaItemCell() {
     this->addView(m_newBadge);
 
     // Star badge - top right corner (shows if manga is in library, browser/search only)
+    // Image loaded lazily on first visibility to avoid 98+ useless GPU texture creations
     m_starBadge = new brls::Image();
     m_starBadge->setWidth(16);
     m_starBadge->setHeight(16);
     m_starBadge->setScalingType(brls::ImageScalingType::FIT);
-    m_starBadge->setImageFromFile("app0:resources/icons/star.png");
     m_starBadge->setPositionType(brls::PositionType::ABSOLUTE);
     m_starBadge->setPositionTop(6);
     m_starBadge->setPositionRight(6);
@@ -162,11 +162,11 @@ MangaItemCell::MangaItemCell() {
     m_descriptionLabel->setVisibility(brls::Visibility::GONE);
 
     // Start button hint icon - shown on focus (top-right) to indicate menu action
+    // Image loaded lazily on first focus to avoid 98+ useless GPU texture creations
     m_startHintIcon = new brls::Image();
     m_startHintIcon->setWidth(64);
     m_startHintIcon->setHeight(16);
     m_startHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_startHintIcon->setImageFromFile("app0:resources/images/start_button.png");
     m_startHintIcon->setPositionType(brls::PositionType::ABSOLUTE);
     m_startHintIcon->setPositionTop(6);
     m_startHintIcon->setPositionRight(6);
@@ -257,6 +257,10 @@ void MangaItemCell::updateDisplay() {
     if (m_starBadge) {
         bool inLib = m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id);
         bool showStar = m_showLibraryBadge && inLib;
+        if (showStar && !m_starImageLoaded) {
+            m_starBadge->setImageFromFile("app0:resources/icons/star.png");
+            m_starImageLoaded = true;
+        }
         m_starBadge->setVisibility(showStar ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
 }
@@ -331,6 +335,10 @@ void MangaItemCell::onFocusGained() {
     updateFocusInfo(true);
     // Show start button hint on focus (but not in browser/search tabs where library badge is shown)
     if (m_startHintIcon && !m_showLibraryBadge) {
+        if (!m_startHintImageLoaded) {
+            m_startHintIcon->setImageFromFile("app0:resources/images/start_button.png");
+            m_startHintImageLoaded = true;
+        }
         m_startHintIcon->setVisibility(brls::Visibility::VISIBLE);
     }
 }
@@ -411,6 +419,10 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     // Update star badge visibility (also check recent additions cache)
     if (m_starBadge) {
         bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id));
+        if (inLib && !m_starImageLoaded) {
+            m_starBadge->setImageFromFile("app0:resources/icons/star.png");
+            m_starImageLoaded = true;
+        }
         m_starBadge->setVisibility(inLib ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
     // Hide start hint icon when in browser/search mode


### PR DESCRIPTION
Fixes the end-of-load freeze on large libraries (75+ books) by replacing per-load thread spawning with a persistent worker pool, and fixes the cached-category load freeze.

---
_Generated by [Claude Code](https://claude.ai/code)_