### PR TITLE
Fix crash from dangling focus when switching library grouping mode

### DIFF
--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -648,6 +648,24 @@ void LibrarySectionTab::loadCategories() {
 void LibrarySectionTab::createCategoryTabs() {
     if (!m_categoryScrollContainer) return;
 
+    // Move focus away from tab buttons before destroying them
+    // Otherwise borealis dereferences a dangling focus pointer
+    brls::View* focused = brls::Application::getCurrentFocus();
+    if (focused) {
+        brls::View* parent = focused;
+        while (parent) {
+            if (parent == m_categoryScrollContainer) {
+                if (m_contentGrid) {
+                    brls::Application::giveFocus(m_contentGrid);
+                } else {
+                    brls::Application::giveFocus(this);
+                }
+                break;
+            }
+            parent = parent->hasParent() ? parent->getParent() : nullptr;
+        }
+    }
+
     // Clear existing buttons
     m_categoryScrollContainer->clearViews();
     m_categoryScrollContainer->setTranslationX(0);
@@ -2494,6 +2512,24 @@ void LibrarySectionTab::setGroupMode(LibraryGroupMode mode) {
     Application::getInstance().getSettings().libraryGroupMode = mode;
     Application::getInstance().saveSettings();
 
+    // Move focus away from tab buttons before switching modes
+    // The old tab buttons may be destroyed or hidden during the switch
+    brls::View* focused = brls::Application::getCurrentFocus();
+    if (focused && m_categoryScrollContainer) {
+        brls::View* parent = focused;
+        while (parent) {
+            if (parent == m_categoryScrollContainer) {
+                if (m_contentGrid) {
+                    brls::Application::giveFocus(m_contentGrid);
+                } else {
+                    brls::Application::giveFocus(this);
+                }
+                break;
+            }
+            parent = parent->hasParent() ? parent->getParent() : nullptr;
+        }
+    }
+
     // Reload library with new grouping
     if (mode == LibraryGroupMode::BY_CATEGORY) {
         // Show category tabs and recreate them from categories
@@ -2633,6 +2669,23 @@ void LibrarySectionTab::loadBySource() {
 
 void LibrarySectionTab::createSourceTabs() {
     if (!m_categoryScrollContainer) return;
+
+    // Move focus away from tab buttons before destroying them
+    brls::View* focused = brls::Application::getCurrentFocus();
+    if (focused) {
+        brls::View* parent = focused;
+        while (parent) {
+            if (parent == m_categoryScrollContainer) {
+                if (m_contentGrid) {
+                    brls::Application::giveFocus(m_contentGrid);
+                } else {
+                    brls::Application::giveFocus(this);
+                }
+                break;
+            }
+            parent = parent->hasParent() ? parent->getParent() : nullptr;
+        }
+    }
 
     // Clear existing buttons
     m_categoryScrollContainer->clearViews();


### PR DESCRIPTION
Fix crash from dangling focus when switching library grouping mode

When switching grouping modes, the old tab buttons (category or
source) get destroyed via clearViews(). If borealis had restored
focus to one of those buttons after the dropdown dismissed, the
subsequent clearViews() would dereference a dangling pointer.

Fix: move focus away from tab buttons before destroying them in
setGroupMode(), createCategoryTabs(), and createSourceTabs().
Walk the parent chain to detect if focus is inside the scroll
container, then transfer focus to the content grid.

---
_Generated by [Claude Code](https://claude.ai/code)_