### PR TITLE
Wire up Offline button on login page and add reconnect in settings

### DIFF
--- a/include/activity/login_activity.hpp
+++ b/include/activity/login_activity.hpp
@@ -22,6 +22,7 @@ public:
 private:
     void onConnectPressed();
     void onTestConnectionPressed();
+    void onOfflinePressed();
 
     BRLS_BIND(brls::Label, titleLabel, "login/title");
     BRLS_BIND(brls::Box, inputContainer, "login/input_container");
@@ -31,6 +32,7 @@ private:
     BRLS_BIND(brls::Label, authModeLabel, "login/auth_mode_label");
     BRLS_BIND(brls::Button, loginButton, "login/login_button");
     BRLS_BIND(brls::Button, testButton, "login/pin_button");
+    BRLS_BIND(brls::Button, offlineButton, "login/offline_button");
     BRLS_BIND(brls::Label, statusLabel, "login/status");
 
     std::string m_serverUrl;

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -222,6 +222,7 @@ private:
     brls::Label* m_errorLabel = nullptr;
     brls::Button* m_retryButton = nullptr;
     int m_pageLoadGeneration = 0;  // Track current load to detect stale timeouts
+    bool m_loadedFromLocal = false;  // True when current chapter was loaded from local downloads
     void showPageError(const std::string& message);
     void hidePageError();
 };

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -135,6 +135,7 @@ struct AppSettings {
     std::set<int> hiddenCategoryIds;  // Categories hidden from library view
     bool cacheLibraryData = true;     // Cache manga info for faster loading
     bool cacheCoverImages = true;     // Cache cover images to disk
+    bool downloadsOnlyMode = false;   // Show only locally downloaded manga/chapters (offline mode)
     int librarySortMode = 0;          // Library sort mode (0-10, see LibrarySortMode enum)
     bool chapterSortDescending = true; // Chapter sort order (true=newest first)
 

--- a/include/utils/library_cache.hpp
+++ b/include/utils/library_cache.hpp
@@ -48,6 +48,12 @@ public:
     bool hasHistoryCache();
     void invalidateHistoryCache();
 
+    // Chapter list caching (per manga)
+    bool saveChapters(int mangaId, const std::vector<Chapter>& chapters);
+    bool loadChapters(int mangaId, std::vector<Chapter>& chapters);
+    bool hasChaptersCache(int mangaId);
+    void invalidateChaptersCache(int mangaId);
+
     // Cache management
     void clearAllCache();
     void clearCoverCache();
@@ -91,6 +97,12 @@ private:
     std::string serializeHistoryItem(const ReadingHistoryItem& item);
     bool deserializeHistoryItem(const std::string& line, ReadingHistoryItem& item);
     std::string getHistoryFilePath();
+
+    // Serialize/deserialize chapter
+    std::string serializeChapter(const Chapter& chapter);
+    bool deserializeChapter(const std::string& line, Chapter& chapter);
+    std::string getChaptersCacheDir();
+    std::string getChaptersFilePath(int mangaId);
 
     bool m_enabled = true;
     bool m_coverCacheEnabled = true;

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -182,6 +182,7 @@ private:
 
     // UI elements
     brls::Label* m_titleLabel = nullptr;
+    brls::Label* m_errorLabel = nullptr;
     brls::RecyclerFrame* m_recycler = nullptr;
     brls::Box* m_refreshBox = nullptr;
     brls::Image* m_refreshIcon = nullptr;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -364,6 +364,7 @@ bool Application::loadSettings() {
     // Load cache settings
     m_settings.cacheLibraryData = extractBool("cacheLibraryData", true);
     m_settings.cacheCoverImages = extractBool("cacheCoverImages", true);
+    m_settings.downloadsOnlyMode = extractBool("downloadsOnlyMode", false);
     m_settings.librarySortMode = extractInt("librarySortMode");
     if (m_settings.librarySortMode < 0 || m_settings.librarySortMode > 10) m_settings.librarySortMode = 0;
     m_settings.chapterSortDescending = extractBool("chapterSortDescending", true);
@@ -754,6 +755,7 @@ bool Application::saveSettings() {
     // Cache settings
     json += "  \"cacheLibraryData\": " + std::string(m_settings.cacheLibraryData ? "true" : "false") + ",\n";
     json += "  \"cacheCoverImages\": " + std::string(m_settings.cacheCoverImages ? "true" : "false") + ",\n";
+    json += "  \"downloadsOnlyMode\": " + std::string(m_settings.downloadsOnlyMode ? "true" : "false") + ",\n";
     json += "  \"librarySortMode\": " + std::to_string(m_settings.librarySortMode) + ",\n";
     json += "  \"chapterSortDescending\": " + std::string(m_settings.chapterSortDescending ? "true" : "false") + ",\n";
 

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -558,7 +558,8 @@ DownloadedChapter* DownloadsManager::getChapterDownload(int mangaId, int chapter
     for (auto& manga : m_downloads) {
         if (manga.mangaId == mangaId) {
             for (auto& chapter : manga.chapters) {
-                if (chapter.chapterIndex == chapterIndex) {
+                // Match by chapterIndex OR chapterId (reader passes chapter ID)
+                if (chapter.chapterIndex == chapterIndex || chapter.chapterId == chapterIndex) {
                     return &chapter;
                 }
             }
@@ -591,7 +592,8 @@ bool DownloadsManager::isChapterDownloaded(int mangaId, int chapterIndex) const 
     for (const auto& manga : m_downloads) {
         if (manga.mangaId == mangaId) {
             for (const auto& chapter : manga.chapters) {
-                if (chapter.chapterIndex == chapterIndex) {
+                // Match by chapterIndex OR chapterId (reader passes chapter ID)
+                if (chapter.chapterIndex == chapterIndex || chapter.chapterId == chapterIndex) {
                     return chapter.state == LocalDownloadState::COMPLETED;
                 }
             }
@@ -607,7 +609,8 @@ std::string DownloadsManager::getPagePath(int mangaId, int chapterIndex, int pag
     for (const auto& manga : m_downloads) {
         if (manga.mangaId == mangaId) {
             for (const auto& chapter : manga.chapters) {
-                if (chapter.chapterIndex == chapterIndex) {
+                // Match by chapterIndex OR chapterId (reader passes chapter ID)
+                if (chapter.chapterIndex == chapterIndex || chapter.chapterId == chapterIndex) {
                     for (const auto& page : chapter.pages) {
                         if (page.index == pageIndex && page.downloaded) {
                             return page.localPath;
@@ -628,7 +631,8 @@ std::vector<std::string> DownloadsManager::getChapterPages(int mangaId, int chap
     for (const auto& manga : m_downloads) {
         if (manga.mangaId == mangaId) {
             for (const auto& chapter : manga.chapters) {
-                if (chapter.chapterIndex == chapterIndex) {
+                // Match by chapterIndex OR chapterId (reader passes chapter ID)
+                if (chapter.chapterIndex == chapterIndex || chapter.chapterId == chapterIndex) {
                     for (const auto& page : chapter.pages) {
                         if (page.downloaded) {
                             pages.push_back(page.localPath);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -832,6 +832,15 @@ ExtensionsTab::ExtensionsTab() {
         return false;  // Let default behavior handle it (go back)
     }, true);  // Hidden action (don't show in hints)
 
+    // Inline error/offline label (hidden by default)
+    m_errorLabel = new brls::Label();
+    m_errorLabel->setFontSize(16);
+    m_errorLabel->setTextColor(nvgRGB(180, 180, 180));
+    m_errorLabel->setMarginTop(40);
+    m_errorLabel->setMarginLeft(20);
+    m_errorLabel->setVisibility(brls::Visibility::GONE);
+    this->addView(m_errorLabel);
+
     this->addView(m_recycler);
 
     // Load extensions
@@ -1009,6 +1018,10 @@ void ExtensionsTab::refreshUIFromCache() {
 }
 
 void ExtensionsTab::reloadRecycler() {
+    // Hide error label and show recycler when data loads successfully
+    if (m_errorLabel) m_errorLabel->setVisibility(brls::Visibility::GONE);
+    if (m_recycler) m_recycler->setVisibility(brls::Visibility::VISIBLE);
+
     if (!m_dataSource) {
         m_dataSource = new ExtensionsDataSource(this);
         m_recycler->setDataSource(m_dataSource);
@@ -1055,7 +1068,13 @@ void ExtensionsTab::showLoading(const std::string& message) {
 }
 
 void ExtensionsTab::showError(const std::string& message) {
-    brls::Application::notify(message);
+    if (m_errorLabel) {
+        m_errorLabel->setText(message);
+        m_errorLabel->setVisibility(brls::Visibility::VISIBLE);
+    }
+    if (m_recycler) {
+        m_recycler->setVisibility(brls::Visibility::GONE);
+    }
 }
 
 std::map<std::string, std::vector<Extension>> ExtensionsTab::groupExtensionsByLanguage(

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -851,6 +851,12 @@ void ExtensionsTab::onFocusGained() {
 void ExtensionsTab::loadExtensionsFast() {
     brls::Logger::debug("Loading extensions list (fast mode)...");
 
+    // Show offline message if not connected and no cached data
+    if (!Application::getInstance().isConnected() && !m_cacheLoaded) {
+        showError("App is offline - connect to a server to manage extensions");
+        return;
+    }
+
     showLoading("Loading extensions...");
 
     brls::async([this]() {
@@ -864,7 +870,8 @@ void ExtensionsTab::loadExtensionsFast() {
         } else {
             bool success = client.fetchExtensionList(allExtensions);
             if (!success) {
-                brls::sync([this]() { showError("Failed to load extensions"); });
+                Application::getInstance().setConnected(false);
+                brls::sync([this]() { showError("App is offline - connect to a server to manage extensions"); });
                 return;
             }
             m_cachedExtensions = allExtensions;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1094,6 +1094,11 @@ void LibrarySectionTab::sortMangaList() {
         effectiveMode = static_cast<LibrarySortMode>(defaultSort);
     }
 
+    // Force DOWNLOADED_ONLY filter when downloads-only mode is enabled in settings
+    if (Application::getInstance().getSettings().downloadsOnlyMode) {
+        effectiveMode = LibrarySortMode::DOWNLOADED_ONLY;
+    }
+
     // Restore full list before sorting/filtering
     // This ensures switching away from DOWNLOADED_ONLY restores all books
     if (!m_fullMangaList.empty()) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -559,6 +559,9 @@ void LibrarySectionTab::loadCategories() {
         } else {
             brls::Logger::warning("LibrarySectionTab: Failed to fetch categories from server");
 
+            // Mark connection as lost to prevent cascading retries
+            Application::getInstance().setConnected(false);
+
             brls::sync([this, aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
@@ -956,6 +959,13 @@ void LibrarySectionTab::loadCategoryManga(int categoryId) {
         return;
     }
 
+    // Skip network fetch entirely if we know we're offline and have data to show
+    if (!Application::getInstance().isConnected() && !m_mangaList.empty()) {
+        brls::Logger::info("LibrarySectionTab: Offline with cached data, skipping fetch");
+        m_loaded = true;
+        return;
+    }
+
     asyncRun([this, categoryId, aliveWeak, cacheEnabled, isSameCategory]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         std::vector<Manga> manga;
@@ -970,6 +980,12 @@ void LibrarySectionTab::loadCategoryManga(int categoryId) {
             auto alive = aliveWeak.lock();
             if (!alive || !*alive) return;
 
+            // Skip retries if we've detected we're offline
+            if (attempt > 0 && !Application::getInstance().isConnected()) {
+                brls::Logger::info("LibrarySectionTab: Skipping retry, app is offline");
+                break;
+            }
+
             if (attempt > 0) {
                 int delayMs = baseDelayMs * (1 << (attempt - 1));  // 1s, 2s, 4s
                 brls::Logger::info("LibrarySectionTab: Retry {} for category {} in {}ms",
@@ -980,6 +996,11 @@ void LibrarySectionTab::loadCategoryManga(int categoryId) {
             manga.clear();
             success = client.fetchCategoryManga(categoryId, manga);
             if (success) break;
+        }
+
+        // If all retries failed, mark connection as lost
+        if (!success) {
+            Application::getInstance().setConnected(false);
         }
 
         if (success) {
@@ -2621,10 +2642,11 @@ void LibrarySectionTab::loadAllManga() {
 
         // Fetch all library manga
         if (!client.fetchLibraryManga(allManga)) {
+            Application::getInstance().setConnected(false);
             brls::sync([aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
-                brls::Application::notify("Failed to load library");
+                brls::Application::notify("Failed to load library - check connection");
             });
             return;
         }
@@ -2657,10 +2679,11 @@ void LibrarySectionTab::loadBySource() {
 
         // Fetch all library manga
         if (!client.fetchLibraryManga(allManga)) {
+            Application::getInstance().setConnected(false);
             brls::sync([aliveWeak]() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
-                brls::Application::notify("Failed to load library");
+                brls::Application::notify("Failed to load library - check connection");
             });
             return;
         }

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1094,8 +1094,9 @@ void LibrarySectionTab::sortMangaList() {
         effectiveMode = static_cast<LibrarySortMode>(defaultSort);
     }
 
-    // Force DOWNLOADED_ONLY filter when downloads-only mode is enabled in settings
-    if (Application::getInstance().getSettings().downloadsOnlyMode) {
+    // Force DOWNLOADED_ONLY filter when downloads-only mode is enabled and app is offline
+    if (Application::getInstance().getSettings().downloadsOnlyMode &&
+        !Application::getInstance().isConnected()) {
         effectiveMode = LibrarySortMode::DOWNLOADED_ONLY;
     }
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -950,9 +950,10 @@ void MangaDetailView::populateChaptersList() {
     // Get downloads manager to check local download state
     DownloadsManager& dmForFilter = DownloadsManager::getInstance();
 
-    // Force downloaded filter when downloads-only mode is enabled in settings
+    // Force downloaded filter when downloads-only mode is enabled and app is offline
     bool filterDownloaded = m_filterDownloaded ||
-                            Application::getInstance().getSettings().downloadsOnlyMode;
+                            (Application::getInstance().getSettings().downloadsOnlyMode &&
+                             !Application::getInstance().isConnected());
 
     // Create chapter cells (Komikku-style: rounded, clean design)
     for (const auto& chapter : sortedChapters) {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -606,6 +606,31 @@ void MangaDetailView::loadDetails() {
     // Load tracking data (parallel)
     loadTrackingData();
 
+    // Try loading chapters from cache for instant display
+    bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
+    LibraryCache& cache = LibraryCache::getInstance();
+    if (cacheEnabled && cache.hasChaptersCache(m_manga.id)) {
+        std::vector<Chapter> cachedChapters;
+        if (cache.loadChapters(m_manga.id, cachedChapters) && !cachedChapters.empty()) {
+            brls::Logger::info("MangaDetailView: Loaded {} chapters from cache for manga {}",
+                              cachedChapters.size(), m_manga.id);
+            m_chapters = cachedChapters;
+            populateChaptersList();
+            if (m_chapterCountLabel) {
+                std::string info = std::to_string(m_chapters.size()) + " chapters";
+                int unread = 0;
+                for (const auto& ch : m_chapters) {
+                    if (!ch.read) unread++;
+                }
+                if (unread > 0) {
+                    info += " (" + std::to_string(unread) + " unread)";
+                }
+                m_chapterCountLabel->setText(info);
+            }
+            updateReadButtonText();
+        }
+    }
+
     if (m_manga.description.empty()) {
         // Description missing: use combined query to fetch manga details + chapters in one request
         // This saves a network round-trip vs fetching them separately
@@ -691,8 +716,11 @@ void MangaDetailView::loadDetails() {
                         brls::Logger::info("MangaDetailView: Updated and cached manga details from combined query");
                     }
 
-                    // Apply chapters
+                    // Apply chapters and save to cache
                     m_chapters = chapters;
+                    if (Application::getInstance().getSettings().cacheLibraryData) {
+                        LibraryCache::getInstance().saveChapters(m_manga.id, chapters);
+                    }
                     populateChaptersList();
                     if (m_chapterCountLabel) {
                         std::string info = std::to_string(m_chapters.size()) + " chapters";
@@ -803,6 +831,9 @@ void MangaDetailView::loadChapters() {
                 }
 
                 m_chapters = chapters;
+                if (Application::getInstance().getSettings().cacheLibraryData) {
+                    LibraryCache::getInstance().saveChapters(m_manga.id, chapters);
+                }
                 populateChaptersList();
 
                 // Update chapter count label
@@ -919,10 +950,14 @@ void MangaDetailView::populateChaptersList() {
     // Get downloads manager to check local download state
     DownloadsManager& dmForFilter = DownloadsManager::getInstance();
 
+    // Force downloaded filter when downloads-only mode is enabled in settings
+    bool filterDownloaded = m_filterDownloaded ||
+                            Application::getInstance().getSettings().downloadsOnlyMode;
+
     // Create chapter cells (Komikku-style: rounded, clean design)
     for (const auto& chapter : sortedChapters) {
         // For downloaded filter, only check LOCAL download state (not server)
-        if (m_filterDownloaded) {
+        if (filterDownloaded) {
             DownloadedChapter* localCh = dmForFilter.getChapterDownload(m_manga.id, chapter.index);
             bool isLocallyDownloaded = localCh && localCh->state == LocalDownloadState::COMPLETED;
             if (!isLocallyDownloaded) continue;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -321,6 +321,14 @@ void SearchTab::loadSources() {
     brls::Logger::debug("SearchTab: Loading sources");
     m_browseMode = BrowseMode::SOURCES;
 
+    // Show offline message if not connected
+    if (!Application::getInstance().isConnected()) {
+        if (m_resultsLabel) {
+            m_resultsLabel->setText("App is offline - connect to a server to browse sources");
+        }
+        return;
+    }
+
     asyncRun([this]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         std::vector<Source> sources;
@@ -334,8 +342,9 @@ void SearchTab::loadSources() {
             });
         } else {
             brls::Logger::error("SearchTab: Failed to fetch sources");
+            Application::getInstance().setConnected(false);
             brls::sync([this]() {
-                m_resultsLabel->setText("Failed to load sources");
+                m_resultsLabel->setText("App is offline - connect to a server to browse sources");
                 // Focus on history button so user can still navigate
                 brls::Application::giveFocus(m_historyBtn);
             });

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -419,7 +419,7 @@ void SettingsTab::createLibrarySection() {
 
     // Downloads Only info label
     auto* downloadsOnlyInfoLabel = new brls::Label();
-    downloadsOnlyInfoLabel->setText("Only show locally downloaded manga and chapters");
+    downloadsOnlyInfoLabel->setText("When offline, only show locally downloaded manga and chapters");
     downloadsOnlyInfoLabel->setFontSize(14);
     downloadsOnlyInfoLabel->setMarginLeft(16);
     downloadsOnlyInfoLabel->setMarginTop(4);

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -408,6 +408,24 @@ void SettingsTab::createLibrarySection() {
     cacheInfoLabel->setMarginTop(4);
     m_contentBox->addView(cacheInfoLabel);
 
+    // Downloads Only Mode toggle
+    auto* downloadsOnlyToggle = new brls::BooleanCell();
+    downloadsOnlyToggle->init("Downloads Only Mode", settings.downloadsOnlyMode, [](bool value) {
+        Application::getInstance().getSettings().downloadsOnlyMode = value;
+        Application::getInstance().saveSettings();
+        brls::Application::notify(value ? "Showing downloaded only" : "Showing all manga");
+    });
+    m_contentBox->addView(downloadsOnlyToggle);
+
+    // Downloads Only info label
+    auto* downloadsOnlyInfoLabel = new brls::Label();
+    downloadsOnlyInfoLabel->setText("Only show locally downloaded manga and chapters");
+    downloadsOnlyInfoLabel->setFontSize(14);
+    downloadsOnlyInfoLabel->setMarginLeft(16);
+    downloadsOnlyInfoLabel->setMarginTop(4);
+    downloadsOnlyInfoLabel->setMarginBottom(8);
+    m_contentBox->addView(downloadsOnlyInfoLabel);
+
     // Library Updates header
     auto* updatesHeader = new brls::Header();
     updatesHeader->setTitle("Library Updates");

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -8,6 +8,7 @@
 #include "app/suwayomi_client.hpp"
 #include "app/downloads_manager.hpp"
 #include "utils/library_cache.hpp"
+#include "utils/async.hpp"
 #include "utils/http_client.hpp"
 #include <algorithm>
 #include <chrono>
@@ -171,6 +172,51 @@ void SettingsTab::createAccountSection() {
         return true;
     });
     m_contentBox->addView(networkTestCell);
+
+    // Connection status indicator
+    bool isOnline = Application::getInstance().isConnected();
+    auto* connectionStatusLabel = new brls::Label();
+    connectionStatusLabel->setText(isOnline ? "Status: Connected" : "Status: Offline");
+    connectionStatusLabel->setFontSize(16);
+    connectionStatusLabel->setMarginLeft(16);
+    connectionStatusLabel->setMarginBottom(8);
+    m_contentBox->addView(connectionStatusLabel);
+
+    // Reconnect button (try to connect to saved server)
+    auto* reconnectCell = new brls::DetailCell();
+    reconnectCell->setText("Reconnect");
+    reconnectCell->setDetailText("Try to connect to server");
+    reconnectCell->registerClickAction([this, connectionStatusLabel](brls::View* view) {
+        Application& app = Application::getInstance();
+        std::string url = app.getActiveServerUrl();
+        if (url.empty()) {
+            brls::Application::notify("No server URL configured");
+            return true;
+        }
+
+        brls::Application::notify("Connecting to " + url + "...");
+
+        asyncRun([url, connectionStatusLabel]() {
+            SuwayomiClient& client = SuwayomiClient::getInstance();
+            client.setServerUrl(url);
+
+            bool success = client.testConnection();
+
+            brls::sync([success, connectionStatusLabel]() {
+                if (success) {
+                    Application::getInstance().setConnected(true);
+                    brls::Application::notify("Connected!");
+                    if (connectionStatusLabel) {
+                        connectionStatusLabel->setText("Status: Connected");
+                    }
+                } else {
+                    brls::Application::notify("Connection failed");
+                }
+            });
+        });
+        return true;
+    });
+    m_contentBox->addView(reconnectCell);
 
     // Disconnect button
     auto* disconnectCell = new brls::DetailCell();


### PR DESCRIPTION
Wires up the login-page Offline button and a reconnect option in settings, and adds a downloads-only offline mode: chapter caching, skipping server calls and reader errors for local files, and inline offline messages.

---
_Generated by [Claude Code](https://claude.ai/code)_