### PR TITLE
Hide server-only buttons and menu options when offline

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -114,6 +114,7 @@ private:
     float m_categoryScrollOffset = 0.0f;           // Current scroll offset
 
     // Action buttons
+    brls::Box* m_updateContainer = nullptr;
     brls::Button* m_updateBtn = nullptr;
     brls::Button* m_sortBtn = nullptr;
     brls::Image* m_sortIcon = nullptr;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -136,17 +136,17 @@ LibrarySectionTab::LibrarySectionTab() {
     updateSortButtonText();
 
     // Update button container with Select button hint
-    auto* updateContainer = new brls::Box();
-    updateContainer->setAxis(brls::Axis::COLUMN);
-    updateContainer->setAlignItems(brls::AlignItems::CENTER);
-    updateContainer->setMarginLeft(8);
+    m_updateContainer = new brls::Box();
+    m_updateContainer->setAxis(brls::Axis::COLUMN);
+    m_updateContainer->setAlignItems(brls::AlignItems::CENTER);
+    m_updateContainer->setMarginLeft(8);
 
     auto* updateHintIcon = new brls::Image();
     updateHintIcon->setHeight(16);
     updateHintIcon->setScalingType(brls::ImageScalingType::FIT);
     updateHintIcon->setImageFromFile("app0:resources/images/select_button.png");
     updateHintIcon->setMarginBottom(2);
-    updateContainer->addView(updateHintIcon);
+    m_updateContainer->addView(updateHintIcon);
 
     m_updateBtn = new brls::Button();
     m_updateBtn->setWidth(44);
@@ -166,12 +166,12 @@ LibrarySectionTab::LibrarySectionTab() {
         triggerLibraryUpdate();
         return true;
     });
-    // Hide at construction if already offline
+    // Hide entire container (button + hint icon) at construction if already offline
     if (!Application::getInstance().isConnected()) {
-        m_updateBtn->setVisibility(brls::Visibility::GONE);
+        m_updateContainer->setVisibility(brls::Visibility::GONE);
     }
-    updateContainer->addView(m_updateBtn);
-    buttonBox->addView(updateContainer);
+    m_updateContainer->addView(m_updateBtn);
+    buttonBox->addView(m_updateContainer);
 
     // Grouping button container with Square button hint
     auto* groupContainer = new brls::Box();
@@ -387,9 +387,9 @@ LibrarySectionTab::~LibrarySectionTab() {
 void LibrarySectionTab::onFocusGained() {
     brls::Box::onFocusGained();
 
-    // Show/hide update button based on connectivity
-    if (m_updateBtn) {
-        m_updateBtn->setVisibility(Application::getInstance().isConnected()
+    // Show/hide update button + hint icon based on connectivity
+    if (m_updateContainer) {
+        m_updateContainer->setVisibility(Application::getInstance().isConnected()
             ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -166,6 +166,10 @@ LibrarySectionTab::LibrarySectionTab() {
         triggerLibraryUpdate();
         return true;
     });
+    // Hide at construction if already offline
+    if (!Application::getInstance().isConnected()) {
+        m_updateBtn->setVisibility(brls::Visibility::GONE);
+    }
     updateContainer->addView(m_updateBtn);
     buttonBox->addView(updateContainer);
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -355,8 +355,9 @@ LibrarySectionTab::LibrarySectionTab() {
         return true;
     });
 
-    // Register Select button to refresh/update current category
+    // Register Select button to refresh/update current category (disabled when offline)
     this->registerAction("Update Category", brls::ControllerButton::BUTTON_BACK, [this](brls::View*) {
+        if (!Application::getInstance().isConnected()) return true;
         triggerLibraryUpdate();
         return true;
     });


### PR DESCRIPTION
Hides server-only buttons and menu options when offline — the update button and its hint icon at construction time, and the library Select action.

---
_Generated by [Claude Code](https://claude.ai/code)_