### PR TITLE
Fix library grouping offline + auto-rebuild when back online

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -150,6 +150,7 @@ private:
     bool m_categoriesLoaded = false;
     bool m_focusGridAfterLoad = false;  // Focus first grid item after loading new category
     int m_combinedQueryCategoryId = -1; // Category being fetched by combined query (skip redundant fetch)
+    bool m_wasOffline = false;          // Track offline→online transitions for auto-rebuild
 
     // Shared pointer to track if this object is still alive
     std::shared_ptr<bool> m_alive;

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -150,7 +150,6 @@ private:
     bool m_categoriesLoaded = false;
     bool m_focusGridAfterLoad = false;  // Focus first grid item after loading new category
     int m_combinedQueryCategoryId = -1; // Category being fetched by combined query (skip redundant fetch)
-    bool m_wasOffline = false;          // Track offline→online transitions for auto-rebuild
 
     // Shared pointer to track if this object is still alive
     std::shared_ptr<bool> m_alive;

--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -108,7 +108,7 @@ bool LibraryCache::ensureDirectoryExists(const std::string& path) {
 
 std::string LibraryCache::serializeManga(const Manga& manga) {
     std::ostringstream ss;
-    // Format: id|title|author|artist|description|thumbnailUrl|status|inLibrary|chapterCount|unreadCount|downloadCount
+    // Format: id|title|author|artist|description|thumbnailUrl|status|inLibrary|chapterCount|unreadCount|downloadCount|sourceName
     ss << manga.id << "|"
        << manga.title << "|"
        << manga.author << "|"
@@ -119,7 +119,8 @@ std::string LibraryCache::serializeManga(const Manga& manga) {
        << (manga.inLibrary ? 1 : 0) << "|"
        << manga.chapterCount << "|"
        << manga.unreadCount << "|"
-       << manga.downloadedCount;
+       << manga.downloadedCount << "|"
+       << manga.sourceName;
     return ss.str();
 }
 
@@ -146,6 +147,8 @@ bool LibraryCache::deserializeManga(const std::string& line, Manga& manga) {
         manga.chapterCount = std::stoi(parts[8]);
         manga.unreadCount = std::stoi(parts[9]);
         manga.downloadedCount = std::stoi(parts[10]);
+        // sourceName added later; old caches have only 11 fields
+        if (parts.size() > 11) manga.sourceName = parts[11];
         return true;
     } catch (...) {
         return false;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -375,9 +375,6 @@ LibrarySectionTab::LibrarySectionTab() {
         return true;
     });
 
-    // Track initial connectivity for offline→online rebuild detection
-    m_wasOffline = !Application::getInstance().isConnected();
-
     // Load categories first, then create tabs
     loadCategories();
 }
@@ -392,24 +389,10 @@ LibrarySectionTab::~LibrarySectionTab() {
 void LibrarySectionTab::onFocusGained() {
     brls::Box::onFocusGained();
 
-    bool online = Application::getInstance().isConnected();
-
     // Show/hide update button + hint icon based on connectivity
     if (m_updateContainer) {
-        m_updateContainer->setVisibility(online
+        m_updateContainer->setVisibility(Application::getInstance().isConnected()
             ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-
-    // Detect offline→online transition: full rebuild when reconnected
-    if (online && m_wasOffline) {
-        brls::Logger::info("LibrarySectionTab: Back online, rebuilding library");
-        m_wasOffline = false;
-        refresh();
-        loadCategories();
-        return;
-    }
-    if (!online) {
-        m_wasOffline = true;
     }
 
     // Check if group mode was changed externally (e.g. from settings tab)


### PR DESCRIPTION
Fixes library grouping when offline (including by-source grouping from cached data) and removes the auto-rebuild on reconnect.

---
_Generated by [Claude Code](https://claude.ai/code)_