### PR TITLE
Add infinite scroll for browse/history tabs + tracker login in settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/testing-checklist-v2.md
+++ b/.github/ISSUE_TEMPLATE/testing-checklist-v2.md
@@ -439,6 +439,232 @@ assignees: ''
 
 ---
 
+## Offline Mode - Login & Reconnect
+
+### Offline Button on Login Page
+- [ ] "Offline" button visible on login page
+- [ ] Tapping Offline saves entered server URL / credentials
+- [ ] Tapping Offline marks app as disconnected
+- [ ] App navigates to main activity in offline mode
+- [ ] Login page pre-fills saved connection details on next launch (URL, username, auth mode)
+
+### Reconnect in Settings
+- [ ] Connection status indicator shows "Connected" or "Offline"
+- [ ] "Reconnect" button appears in settings
+- [ ] Reconnect attempts to connect to saved server URL asynchronously
+- [ ] Status label updates on successful reconnect
+- [ ] Reconnect failure doesn't crash app
+
+---
+
+## Chapter Caching & Downloads-Only Mode
+
+### Chapter Caching
+- [ ] Chapter list cached after fetch from server
+- [ ] Chapter list loads from cache before server request (faster display)
+- [ ] Cached chapters available when offline
+- [ ] Cache updates after fresh server fetch
+
+### Downloads-Only Mode
+- [ ] "Downloads Only Mode" toggle in library settings works
+- [ ] When enabled + offline, library shows only manga with local downloads
+- [ ] When enabled + offline, chapter list in detail view filters to downloaded chapters
+- [ ] When online, all manga and chapters show normally (setting ignored)
+- [ ] Setting persists across restarts
+
+---
+
+## Offline Mode - Reader
+
+### Offline Reading
+- [ ] Locally downloaded chapters load from disk when offline
+- [ ] No 15s timeout error overlay for locally downloaded pages
+- [ ] Chapter progress saved to DownloadsManager when offline (not server)
+- [ ] Reader shows "App is offline" on retry button when offline
+- [ ] Per-manga reader settings load from local cache when offline
+- [ ] Skip fetchMangaMeta, fetchManga, fetchChapter, fetchChapters when offline
+- [ ] Skip markChapterAsRead when offline
+
+### Chapter ID Matching
+- [ ] Downloaded chapters found by both chapterIndex and chapterId
+- [ ] isChapterDownloaded matches on both identifiers
+- [ ] getChapterPages matches on both identifiers
+- [ ] getPagePath matches on both identifiers
+- [ ] queueChapterDownload duplicate check uses both identifiers
+- [ ] cancelChapterDownload uses both identifiers
+- [ ] deleteChapterDownload uses both identifiers
+
+---
+
+## Offline Mode - Library
+
+### Library Offline Behavior
+- [ ] Library falls back to cached data when server unreachable
+- [ ] Connection failure detected and isConnected set to false
+- [ ] No cascading retry loops when offline
+- [ ] Skip network fetch when offline and cached data available
+
+### Library Grouping Offline
+- [ ] "No Grouping" mode aggregates all cached category manga when offline
+- [ ] "By Source" mode groups cached manga by source name when offline
+- [ ] "By Category" loads categories from cache when offline
+- [ ] Manga deduplicated across categories (std::set)
+- [ ] sourceName field cached in manga serialization (field 12)
+- [ ] By Source shows correct source names (not "Unknown") offline
+
+### Category Visibility Offline
+- [ ] Empty categories hidden when offline in downloads-only mode
+- [ ] Categories with no locally downloaded manga hidden when offline
+- [ ] Categories with no cached data hidden when offline
+
+---
+
+## Offline Mode - Browse & Extensions
+
+### Browse Tab Offline
+- [ ] Shows "App is offline" message instead of attempting server fetch
+- [ ] No crash when navigating browse tab offline
+
+### Extensions Tab Offline
+- [ ] Shows inline "App is offline" message on extensions page
+- [ ] Recycler hidden, message shown directly in content area
+
+---
+
+## Offline Mode - UI Element Hiding
+
+### Library View When Offline
+- [ ] Update/refresh button hidden when offline
+- [ ] Select button hint icon hidden when offline (entire container)
+- [ ] Update button hidden at construction time if starting offline
+- [ ] Update button and hint restore when back online (onFocusGained)
+- [ ] triggerLibraryUpdate() shows notification and returns early when offline
+- [ ] START button context menu blocked entirely when offline
+- [ ] Long-press context menu blocked entirely when offline
+- [ ] Select button (BUTTON_BACK) action disabled when offline
+
+### Book Detail View When Offline
+- [ ] "Add/Remove from Library" button hidden when offline
+- [ ] "Tracking" button hidden when offline
+- [ ] Options menu: Download all, Download unread, Cancel downloading, Reset cover hidden offline
+- [ ] Options menu: "Remove all chapters" still visible offline
+- [ ] Chapter menu: "Mark Read/Unread" hidden when offline
+- [ ] Chapter menu: "Download" hidden when offline
+- [ ] Chapter menu: "Delete Download" still visible for downloaded chapters offline
+- [ ] Action-ID mapping ensures menu dispatch works with hidden items
+
+---
+
+## Offline Progress Sync
+
+### Save Progress Offline
+- [ ] updateProgress() saves to DownloadsManager when offline (not server)
+- [ ] Reading progress persists to disk via DownloadsManager
+- [ ] Chapter lastPageRead and lastReadAt stored locally
+
+### Sync on Reconnect
+- [ ] App boot: syncs all local reading progress to server when connection restored
+- [ ] Bidirectional sync: compares local vs server progress, takes more advanced position
+- [ ] Local-ahead progress pushed to server
+- [ ] Server-ahead progress pulled to local downloads
+- [ ] Chapters marked read on server when user reached last page offline
+- [ ] Uses chapterId (not chapterIndex) for API calls
+
+### Settings Sync
+- [ ] "Sync Progress Now" button in settings runs async (non-blocking)
+- [ ] Uses bidirectional syncProgressFromServer
+- [ ] Notification shows when sync completes
+
+### Per-Book Sync
+- [ ] Opening a book online triggers progress comparison
+- [ ] Local-ahead progress pushed to server per chapter
+- [ ] Server-ahead progress pulled to local per chapter
+
+---
+
+## Continue Reading Improvements
+
+### Chapter Progress Preservation
+- [ ] Clicking a chapter resumes from lastPageRead (not page 0)
+- [ ] Also checks DownloadsManager for more recent offline progress
+- [ ] Reader saves state (chapter ID, page, read status) to ReaderResult on close
+- [ ] MangaDetailView::willAppear consumes ReaderResult to update UI immediately
+- [ ] Continue reading button reflects just-finished session without server refresh
+
+### Offline Continue Reading
+- [ ] loadChapters offline path merges local progress from DownloadsManager
+- [ ] Continue reading button updates correctly when offline
+- [ ] onRead falls back to DownloadsManager progress when m_chapters empty + offline
+
+---
+
+## Infinite Scroll
+
+### Browse Tab (SearchTab)
+- [ ] No "Load More" button visible
+- [ ] Auto-loads next page when scrolling near end of grid
+- [ ] m_isLoadingPage guard prevents concurrent page loads
+- [ ] Works for Popular mode
+- [ ] Works for Latest mode
+- [ ] Works for Search Results mode
+- [ ] New items appended without full grid rebuild (appendItems)
+
+### History Tab
+- [ ] No "Load More" button visible
+- [ ] Auto-loads more items when focus reaches within 5 items of end
+- [ ] m_isLoadingMore guard prevents concurrent loads
+- [ ] New items appear seamlessly
+
+### RecyclingGrid onEndReached
+- [ ] Callback fires when focus is within 2 rows of end
+- [ ] m_endReachedFired flag prevents repeated firing
+- [ ] Flag resets on setDataSource() or appendItems()
+
+---
+
+## Tracker Login in Settings
+
+### Tracking Section
+- [ ] "Tracking" section appears in settings
+- [ ] "Tracker Accounts" cell opens tracker list
+- [ ] All trackers fetched from server and listed
+- [ ] Login status shown per tracker (logged in / not logged in)
+
+### Login Flow
+- [ ] Not-logged-in tracker: opens username IME dialog
+- [ ] After username: opens password IME dialog
+- [ ] Credential login sends to server (loginTrackerCredentials)
+- [ ] Success: shows notification and refreshes tracker list
+- [ ] Failure: shows error notification
+
+### Logout Flow
+- [ ] Logged-in tracker: offers Logout option
+- [ ] Logout sends logoutTracker to server
+- [ ] Success: shows notification and refreshes list
+- [ ] authUrl field fetched for each tracker (for OAuth trackers)
+
+---
+
+## Chapter Loading Performance
+
+### Incremental Chapter Building
+- [ ] Chapter list builds incrementally (not all at once)
+- [ ] First 10 chapters appear immediately
+- [ ] Remaining chapters build in batches of 10 per frame via brls::sync()
+- [ ] No 30-40 second UI freeze on large chapter lists (300+ chapters)
+- [ ] D-pad navigation set up after all chapters are built
+- [ ] Incremental build cancels on view destruction (no dangling callbacks)
+- [ ] Re-calling populateChaptersList cancels previous incremental build
+
+### Browser Append Without Rebuild
+- [ ] RecyclingGrid::appendItems() adds items without destroying existing cells
+- [ ] Existing manga thumbnails preserved during load-more
+- [ ] Partial last row rebuilt correctly when appending
+- [ ] Focus maintained on first new item after append
+- [ ] No visible flicker or full grid rebuild on load-more
+
+---
+
 ## Smoke Test - V2 Features
 
 ### Library Grouping Quick Test
@@ -467,6 +693,26 @@ assignees: ''
 - [ ] Verify library loads instantly from cache
 - [ ] Disable cache, reopen - verify fresh server fetch
 
+### Offline Mode Quick Test
+- [ ] From login page, tap Offline - app enters main screen
+- [ ] Library loads cached data, update button is hidden
+- [ ] Open a downloaded manga - chapter list loads from cache
+- [ ] Read a downloaded chapter - pages load from disk, no errors
+- [ ] Go to settings, tap Reconnect - status changes to Connected
+- [ ] Library update button reappears after reconnect
+
+### Infinite Scroll Quick Test
+- [ ] Browse a source, scroll to bottom - more manga loads automatically
+- [ ] No "Load More" button visible
+- [ ] Existing covers not reloaded during append
+- [ ] Open History tab, scroll to bottom - more items load automatically
+
+### Chapter Loading Quick Test
+- [ ] Open a manga with 100+ chapters
+- [ ] First chapters appear within 1-2 seconds
+- [ ] Remaining chapters populate progressively (no long freeze)
+- [ ] Can scroll and interact while chapters are still building
+
 ---
 
 ## Regression Tests - V2 Edge Cases
@@ -494,3 +740,28 @@ assignees: ''
 - [ ] JWT token expired - handles refresh or re-login
 - [ ] Switch auth mode while connected - reconnects
 - [ ] Server changes auth requirement - detected on next request
+
+### Offline Mode Edge Cases
+- [ ] Start offline, browse library, then reconnect - UI restores all buttons
+- [ ] Start offline with no cached data - no crash, shows empty state
+- [ ] Read chapter offline, close reader, reopen same chapter - progress preserved
+- [ ] Sync progress with conflicting server data - bidirectional merge works
+- [ ] Downloads-only mode with zero local downloads - empty library, no crash
+- [ ] Rapidly toggle online/offline (reconnect/disconnect) - no crash
+- [ ] Open manga detail offline, then reconnect mid-view - buttons remain hidden until next focus
+
+### Infinite Scroll Edge Cases
+- [ ] Scroll to end with no more pages (hasNextPage=false) - no extra load triggered
+- [ ] Navigate away and back during load-more - no duplicate items
+- [ ] Load-more with exactly a full last row (e.g., 24 items, 6 columns) - append starts new row
+- [ ] Load-more with partial last row (e.g., 22 items, 6 columns) - partial row rebuilt correctly
+- [ ] Rapid scroll past end - only one load-more fires (guard flag works)
+
+### Chapter Loading Edge Cases
+- [ ] Open manga with 0 chapters - no crash, empty list
+- [ ] Open manga with 1 chapter - builds immediately, navigation works
+- [ ] Open manga with 500+ chapters - builds incrementally, no freeze
+- [ ] Navigate away during incremental build - build cancels safely
+- [ ] Re-sort chapters during incremental build - old build cancels, new one starts
+- [ ] Filter chapters during incremental build - restarts correctly
+- [ ] D-pad navigation works after incremental build completes

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -311,6 +311,7 @@ struct Tracker {
     int id = 0;
     std::string name;
     std::string iconUrl;
+    std::string authUrl;              // OAuth authorization URL (empty when logged in)
     bool isLoggedIn = false;
     bool isTokenExpired = false;
     std::vector<std::string> statuses;    // Status options (e.g., "Reading", "Completed")

--- a/include/view/history_tab.hpp
+++ b/include/view/history_tab.hpp
@@ -37,7 +37,7 @@ private:
     brls::Box* m_contentBox = nullptr;
     brls::Box* m_emptyStateBox = nullptr;
     brls::Label* m_loadingLabel = nullptr;
-    brls::Button* m_loadMoreBtn = nullptr;
+    bool m_isLoadingMore = false;  // Guard against concurrent load-more
     brls::Button* m_refreshBtn = nullptr;
     std::vector<brls::Box*> m_itemRows;
     int m_focusIndexAfterRebuild = -1;

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -62,6 +62,9 @@ private:
 
     // Chapter list display
     void populateChaptersList();
+    void createChapterRow(const Chapter& chapter);
+    void buildNextChapterBatch();
+    void setupChapterNavigation();
     void onChapterSelected(const Chapter& chapter);
     void markChapterRead(const Chapter& chapter);
     void downloadChapter(const Chapter& chapter);
@@ -131,6 +134,11 @@ private:
 
     // Currently visible chapter action icon (shown on focused row)
     brls::Image* m_currentFocusedIcon = nullptr;
+
+    // Incremental chapter building state (prevents 30-40s freeze on large chapter lists)
+    std::vector<Chapter> m_sortedFilteredChapters;
+    int m_chapterBuildIndex = 0;
+    bool m_chapterBuildActive = false;
 
     // Description expand/collapse
     bool m_descriptionExpanded = false;

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -22,6 +22,7 @@ public:
     ~RecyclingGrid();
 
     void setDataSource(const std::vector<Manga>& items);
+    void appendItems(const std::vector<Manga>& newItems);   // Append items without rebuilding existing cells
     void updateDataOrder(const std::vector<Manga>& items);  // Update cell data in place without rebuilding grid
     void updateCellData(const std::vector<Manga>& items);   // Update cell metadata in place (unread counts, etc.)
     void removeItems(const std::vector<int>& mangaIdsToRemove);  // Remove specific items without full rebuild

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -29,6 +29,7 @@ public:
     void setOnItemLongPressed(std::function<void(const Manga&, int index)> callback);
     void setOnPullToRefresh(std::function<void()> callback);
     void setOnBackPressed(std::function<bool()> callback);
+    void setOnEndReached(std::function<void()> callback);  // Fires when focus nears the last row
     void clearViews();
 
     // Grid customization
@@ -81,6 +82,8 @@ private:
     std::function<void(const Manga&, int index)> m_onItemLongPressed;
     std::function<void()> m_onPullToRefresh;
     std::function<bool()> m_onBackPressed;
+    std::function<void()> m_onEndReached;
+    bool m_endReachedFired = false;  // Prevent repeated firing until new data is loaded
     std::function<void(int count)> m_onSelectionChanged;
 
     // Pull-to-refresh state

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -71,8 +71,7 @@ private:
     // Main content grid (for single source browsing)
     RecyclingGrid* m_contentGrid = nullptr;
 
-    // Load more button for pagination
-    brls::Button* m_loadMoreBtn = nullptr;
+    bool m_isLoadingPage = false;  // Guard against concurrent page loads
 
     // Search results by source (grouped horizontal rows)
     brls::ScrollingFrame* m_searchResultsScrollView = nullptr;

--- a/include/view/settings_tab.hpp
+++ b/include/view/settings_tab.hpp
@@ -17,6 +17,7 @@ public:
 
 private:
     void createAccountSection();
+    void createTrackingSection();
     void createUISection();
     void createLibrarySection();
     void createReaderSection();

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -4051,6 +4051,7 @@ Tracker SuwayomiClient::parseTrackerFromGraphQL(const std::string& json) {
     tracker.id = extractJsonInt(json, "id");
     tracker.name = extractJsonValue(json, "name");
     tracker.iconUrl = extractJsonValue(json, "icon");
+    tracker.authUrl = extractJsonValue(json, "authUrl");
     tracker.isLoggedIn = extractJsonBool(json, "isLoggedIn");
     tracker.isTokenExpired = extractJsonBool(json, "isTokenExpired");
     tracker.supportsTrackDeletion = extractJsonBool(json, "supportsTrackDeletion");
@@ -4143,6 +4144,7 @@ bool SuwayomiClient::fetchTrackersGraphQL(std::vector<Tracker>& trackers) {
                     id
                     name
                     icon
+                    authUrl
                     isLoggedIn
                     isTokenExpired
                     supportsTrackDeletion
@@ -4202,6 +4204,7 @@ bool SuwayomiClient::fetchTrackerGraphQL(int trackerId, Tracker& tracker) {
                 id
                 name
                 icon
+                authUrl
                 isLoggedIn
                 isTokenExpired
                 supportsTrackDeletion

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -1102,7 +1102,7 @@ void SearchTab::loadNextPage() {
                     m_mangaList.push_back(m);
                 }
                 m_hasNextPage = hasNextPage;
-                m_contentGrid->setDataSource(m_mangaList);
+                m_contentGrid->appendItems(manga);
                 m_resultsLabel->setText(std::to_string(m_mangaList.size()) + " manga");
 
                 // Focus on first newly loaded item so user can continue browsing

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -291,19 +291,14 @@ SearchTab::SearchTab() {
         return false;
     });
 
-    this->addView(m_contentGrid);
-
-    // Load more button (hidden initially)
-    m_loadMoreBtn = new brls::Button();
-    m_loadMoreBtn->setText("Load More");
-    m_loadMoreBtn->setMarginTop(10);
-    m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
-    m_loadMoreBtn->registerClickAction([this](brls::View*) {
-        loadNextPage();
-        return true;
+    // Infinite scroll: auto-load next page when nearing the end
+    m_contentGrid->setOnEndReached([this]() {
+        if (m_hasNextPage && !m_isLoadingPage) {
+            loadNextPage();
+        }
     });
-    m_loadMoreBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_loadMoreBtn));
-    this->addView(m_loadMoreBtn);
+
+    this->addView(m_contentGrid);
 
     // Load sources initially
     loadSources();
@@ -503,7 +498,7 @@ void SearchTab::showSources() {
     m_mangaList.clear();
     m_resultsBySource.clear();
     m_contentGrid->setDataSource(m_mangaList);
-    m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
+    m_hasNextPage = false;
     if (m_searchResultsScrollView) {
         m_searchResultsScrollView->setVisibility(brls::Visibility::GONE);
     }
@@ -710,7 +705,6 @@ void SearchTab::loadPopularManga(int64_t sourceId) {
                 m_hasNextPage = hasNextPage;
                 m_contentGrid->setDataSource(m_mangaList);
                 m_resultsLabel->setText(std::to_string(manga.size()) + " manga found");
-                m_loadMoreBtn->setVisibility(hasNextPage ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 
                 // Transfer focus to first cell in content grid after loading
                 if (!manga.empty()) {
@@ -725,7 +719,6 @@ void SearchTab::loadPopularManga(int64_t sourceId) {
             brls::sync([this, gen]() {
                 if (gen != m_loadGeneration) return;
                 m_resultsLabel->setText("Failed to load popular manga");
-                m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
                 // Focus on Popular button so user can retry
                 brls::Application::giveFocus(m_popularBtn);
             });
@@ -753,7 +746,6 @@ void SearchTab::loadLatestManga(int64_t sourceId) {
                 m_hasNextPage = hasNextPage;
                 m_contentGrid->setDataSource(m_mangaList);
                 m_resultsLabel->setText(std::to_string(manga.size()) + " manga found");
-                m_loadMoreBtn->setVisibility(hasNextPage ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 
                 // Transfer focus to first cell in content grid after loading
                 if (!manga.empty()) {
@@ -768,7 +760,6 @@ void SearchTab::loadLatestManga(int64_t sourceId) {
             brls::sync([this, gen]() {
                 if (gen != m_loadGeneration) return;
                 m_resultsLabel->setText("Failed to load latest manga");
-                m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
                 // Focus on Latest button so user can retry
                 brls::Application::giveFocus(m_latestBtn);
             });
@@ -920,7 +911,6 @@ void SearchTab::performSourceSearch(int64_t sourceId, const std::string& query) 
                 m_hasNextPage = hasNextPage;
                 m_contentGrid->setDataSource(m_mangaList);
                 m_resultsLabel->setText(std::to_string(manga.size()) + " results");
-                m_loadMoreBtn->setVisibility(hasNextPage ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 
                 // Transfer focus to first cell in content grid after search results load
                 if (!manga.empty()) {
@@ -938,7 +928,6 @@ void SearchTab::performSourceSearch(int64_t sourceId, const std::string& query) 
             brls::sync([this, gen]() {
                 if (gen != m_loadGeneration) return;
                 m_resultsLabel->setText("Search failed");
-                m_loadMoreBtn->setVisibility(brls::Visibility::GONE);
                 // Focus on back button so user can go back
                 brls::Application::giveFocus(m_backBtn);
             });
@@ -1080,13 +1069,11 @@ brls::View* SearchTab::createSourceRow(const std::string& sourceName, const std:
 }
 
 void SearchTab::loadNextPage() {
-    if (!m_hasNextPage) return;
+    if (!m_hasNextPage || m_isLoadingPage) return;
 
+    m_isLoadingPage = true;
     m_currentPage++;
     brls::Logger::debug("SearchTab: Loading page {}", m_currentPage);
-
-    // Show loading state on button
-    m_loadMoreBtn->setText("Loading...");
 
     // Remember the index of first new item (current list size)
     int firstNewItemIndex = static_cast<int>(m_mangaList.size());
@@ -1117,18 +1104,15 @@ void SearchTab::loadNextPage() {
                 m_hasNextPage = hasNextPage;
                 m_contentGrid->setDataSource(m_mangaList);
                 m_resultsLabel->setText(std::to_string(m_mangaList.size()) + " manga");
-                m_loadMoreBtn->setText("Load More");
-                m_loadMoreBtn->setVisibility(hasNextPage ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 
                 // Focus on first newly loaded item so user can continue browsing
                 m_contentGrid->focusIndex(firstNewItemIndex);
+                m_isLoadingPage = false;
             });
         } else {
             brls::sync([this, gen]() {
                 if (gen != m_loadGeneration) return;
-                m_loadMoreBtn->setText("Load More");
-                // Keep focus on Load More button after failure
-                brls::Application::giveFocus(m_loadMoreBtn);
+                m_isLoadingPage = false;
             });
         }
     });


### PR DESCRIPTION
Adds infinite scroll to the Browse/History tabs and tracker login in settings, and fixes a chapter-loading freeze and a full browser rebuild on load-more.

---
_Generated by [Claude Code](https://claude.ai/code)_