### PR TITLE
Add virtual rendering optimizations to library view for improved performance

### DIFF
--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -18,6 +18,8 @@ public:
     void setMangaDeferred(const Manga& manga);  // Set data without loading image
     void updateMangaData(const Manga& manga);   // Update data in place without reloading thumbnail
     void loadThumbnailIfNeeded();  // Load image if not already loaded
+    void unloadThumbnail();        // Free GPU texture for off-screen cells (can reload later)
+    bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
     // Display mode

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -69,6 +69,9 @@ public:
     // Load thumbnails around a specific cell index (called on focus change)
     void loadThumbnailsNearIndex(int index);
 
+    // Override draw to check scroll position and load visible thumbnails
+    void draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) override;
+
     static brls::View* create();
 
 private:
@@ -76,6 +79,7 @@ private:
     void createRowRange(int startRow, int endRow);  // Create rows [startRow, endRow)
     void buildNextRowBatch();  // Continue incremental grid building
     void updateVisibleCells();
+    void loadThumbnailsForScrollPosition();  // Scroll-position-based thumbnail loading
     void onItemClicked(int index);
 
     std::vector<Manga> m_items;
@@ -114,6 +118,7 @@ private:
     int m_visibleStartRow = 0;
     int m_lastScrollY = 0;
     bool m_needsUpdate = false;
+    float m_lastScrollLoadY = 0.0f;  // Last scroll Y where we triggered thumbnail loading
 
     // Long-press tracking - when true, the next click should be skipped
     bool m_longPressTriggered = false;

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -293,6 +293,21 @@ void MangaItemCell::loadThumbnailIfNeeded() {
     }
 }
 
+void MangaItemCell::unloadThumbnail() {
+    if (!m_thumbnailLoaded || !m_thumbnailImage) return;
+
+    // Clear the GPU texture by setting a tiny 1x1 transparent TGA image
+    // This frees VRAM on the Vita's limited 128MB while keeping the cell structure intact
+    // The thumbnail can be reloaded later via loadThumbnailIfNeeded() when scrolled back
+    static const unsigned char s_clearPixel[] = {
+        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // TGA header
+        1, 0, 1, 0, 32, 0,                      // 1x1, 32bpp
+        0, 0, 0, 0                               // 1 transparent pixel (BGRA)
+    };
+    m_thumbnailImage->setImageFromMem(s_clearPixel, sizeof(s_clearPixel));
+    m_thumbnailLoaded = false;
+}
+
 void MangaItemCell::loadThumbnail() {
     if (!m_thumbnailImage || m_thumbnailLoaded) return;
 


### PR DESCRIPTION
Add virtual rendering optimizations to library view for improved performance

- Parallel API calls: When combined query fails, fetch categories and
  default category manga simultaneously in two threads instead of
  sequentially, saving a full network round-trip on library load
- Texture recycling: Unload GPU textures for covers >12 rows from
  visible area to free VRAM on Vita's limited 128MB RAM. Thumbnails
  reload from ImageLoader's LRU cache when scrolled back (no network hit)
- Scroll-position-based loading: Override draw() to detect touch scroll
  position changes and load/unload thumbnails for visible rows. Previously
  only D-pad focus changes triggered thumbnail loading, leaving blank
  covers during touch scrolling

---
_Generated by [Claude Code](https://claude.ai/code)_