### PR TITLE
Fix crash when switching tabs while cover images are still loading

### DIFF
--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -7,12 +7,14 @@
 
 #include <borealis.hpp>
 #include "app/suwayomi_client.hpp"
+#include <memory>
 
 namespace vitasuwayomi {
 
 class MangaItemCell : public brls::Box {
 public:
     MangaItemCell();
+    ~MangaItemCell() override;
 
     void setManga(const Manga& manga);
     void setMangaDeferred(const Manga& manga);  // Set data without loading image
@@ -68,6 +70,10 @@ private:
     brls::Label* m_newBadge = nullptr;  // NEW indicator for recently updated
     brls::Image* m_startHintIcon = nullptr;  // Start button hint shown on focus
     brls::Image* m_starBadge = nullptr;  // Star icon for manga in library
+
+    // Shared flag for async callback safety - set to false in destructor
+    // so pending ImageLoader callbacks skip writing to our destroyed m_thumbnailImage
+    std::shared_ptr<bool> m_alive;
 };
 
 // Alias for backward compatibility


### PR DESCRIPTION
Fix crash when switching tabs while cover images are still loading

Root cause: ImageLoader worker threads download cover images async and
queue texture updates with raw brls::Image* pointers. When user switches
tabs during loading, RecyclingGrid is destroyed (freeing all cells and
their m_thumbnailImage pointers), but pending texture updates still
reference the freed pointers. processPendingTextures() then calls
setImageFromMem() on dangling pointers → use-after-free crash.

Fix: Add a shared_ptr<bool> alive flag to MangaItemCell that is set to
false in the destructor. The flag is threaded through the entire
ImageLoader pipeline (LoadRequest → executeLoad → queueTextureUpdate →
PendingTextureUpdate). processPendingTextures() checks the flag before
writing to the target, skipping updates for destroyed cells. This closes
the race window that exists even after cancelAll() clears the queues
(workers that already popped requests continue executing).

---
_Generated by [Claude Code](https://claude.ai/code)_