### PR TITLE
Fix downloads not restarting on app start and not showing after reboot

### DIFF
--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -160,6 +160,9 @@ public:
     // Resume incomplete downloads (queues PAUSED/FAILED/interrupted chapters)
     void resumeIncompleteDownloads();
 
+    // Auto-resume downloads if setting enabled and connected (called after connection established)
+    void resumeDownloadsIfNeeded();
+
     // Check if there are any incomplete downloads
     bool hasIncompleteDownloads() const;
 

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -215,6 +215,7 @@ private:
     std::vector<DownloadItem> m_downloads;
     mutable std::mutex m_mutex;
     std::atomic<bool> m_downloading{false};
+    std::atomic<bool> m_downloadThreadActive{false};  // True while download thread is running
     bool m_initialized = false;
     DownloadProgressCallback m_progressCallback;
     ChapterCompletionCallback m_chapterCompletionCallback;

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -188,6 +188,9 @@ public:
     int getTotalDownloadedChapters() const;
     int64_t getTotalDownloadSize() const;
 
+    // Wait for the download thread to fully exit (call after pauseDownloads)
+    void waitForDownloadThread(int timeoutMs = 2000);
+
 private:
     DownloadsManager() = default;
     ~DownloadsManager() = default;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -107,6 +107,10 @@ void Application::run() {
                 });
             }
 
+            // Now that connection is confirmed, auto-resume incomplete downloads
+            // This must happen AFTER connection test - otherwise downloads fail immediately
+            dm.resumeDownloadsIfNeeded();
+
             pushMainActivity();
         } else {
             // Connection failed - could be offline or auth expired

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -331,6 +331,21 @@ void DownloadsManager::pauseDownloads() {
     saveStateUnlocked();
 }
 
+void DownloadsManager::waitForDownloadThread(int timeoutMs) {
+    if (!m_downloadThreadActive.load()) return;
+
+    const int sleepMs = 10;
+    int elapsed = 0;
+    while (m_downloadThreadActive.load() && elapsed < timeoutMs) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+        elapsed += sleepMs;
+    }
+
+    if (m_downloadThreadActive.load()) {
+        brls::Logger::warning("DownloadsManager: Download thread did not exit within {}ms", timeoutMs);
+    }
+}
+
 bool DownloadsManager::cancelDownload(int mangaId) {
     std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -356,8 +356,7 @@ bool DownloadsManager::cancelChapterDownload(int mangaId, int chapterIndex) {
         if (manga.mangaId == mangaId) {
             for (auto it = manga.chapters.begin(); it != manga.chapters.end(); ++it) {
                 if (it->chapterIndex == chapterIndex || it->chapterId == chapterIndex) {
-                    if (it->state == LocalDownloadState::QUEUED ||
-                        it->state == LocalDownloadState::DOWNLOADING) {
+                    if (it->state != LocalDownloadState::COMPLETED) {
                         // Delete any partial download files
                         for (auto& page : it->pages) {
                             if (!page.localPath.empty()) {


### PR DESCRIPTION
Fixes downloads not restarting on app start or showing after reboot, a crash when the queue empties with focus inside, `cancelChapterDownload` handling of PAUSED/FAILED states, a use-after-free when clearing an active queue, and the clear button needing two presses.

---
_Generated by [Claude Code](https://claude.ai/code)_