### PR TITLE
Fix dlLabel not rendering in chapter download button

### DIFF
--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -30,7 +30,7 @@ public:
     brls::Label* titleLabel = nullptr;
     brls::Label* subtitleLabel = nullptr;
     brls::Label* readLabel = nullptr;
-    brls::Button* dlBtn = nullptr;
+    brls::Box* dlBtn = nullptr;
     brls::Image* dlIcon = nullptr;
     brls::Label* dlLabel = nullptr;
     brls::Image* xButtonIcon = nullptr;

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -76,8 +76,9 @@ ChapterCell::ChapterCell() {
     readLabel->setVisibility(brls::Visibility::GONE);
     statusBox->addView(readLabel);
 
-    // Download button
-    dlBtn = new brls::Button();
+    // Download button (Box instead of Button to avoid Button's internal XML
+    // layout which adds padding and an internal Label that hides our children)
+    dlBtn = new brls::Box();
     dlBtn->setWidth(40);
     dlBtn->setHeight(36);
     dlBtn->setCornerRadius(18);

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -92,9 +92,10 @@ ChapterCell::ChapterCell() {
     dlBtn->addView(dlIcon);
 
     dlLabel = new brls::Label();
-    dlLabel->setFontSize(9);
+    dlLabel->setFontSize(10);
     dlLabel->setTextColor(nvgRGB(255, 255, 255));
     dlLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
+    dlLabel->setWidthPercentage(100);
     dlLabel->setVisibility(brls::Visibility::GONE);
     dlBtn->addView(dlLabel);
 
@@ -420,20 +421,24 @@ void ChaptersDataSource::applyDownloadState(ChapterCell* cell, int dlState, int 
     } else if (isLocallyDownloaded) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
         cell->dlIcon->setImageFromFile("app0:resources/icons/checkbox_checked.png");
+        cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(46, 204, 113, 200));
     } else if (isLocallyQueued) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
         cell->dlIcon->setImageFromFile("app0:resources/icons/refresh.png");
+        cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(241, 196, 15, 200));
     } else if (isLocallyFailed) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
         cell->dlIcon->setImageFromFile("app0:resources/icons/cross.png");
+        cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(231, 76, 60, 200));
     } else {
         // Default "not downloaded" state - show download arrow icon.
         // With RecyclerFrame only ~8 cells exist, so loading icons is cheap.
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
         cell->dlIcon->setImageFromFile("app0:resources/icons/download.png");
+        cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(60, 60, 60, 200));
     }
 }
@@ -1560,6 +1565,7 @@ void MangaDetailView::refreshVisibleDownloadIcons() {
                     cell->dlLabel->setText("...");
                 }
                 cell->dlBtn->setBackgroundColor(nvgRGBA(52, 152, 219, 200));
+                cell->dlBtn->invalidate();
             } else if (isDownloaded) {
                 cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
                 cell->dlIcon->setImageFromFile("app0:resources/icons/checkbox_checked.png");


### PR DESCRIPTION
Fixes the download-progress label not rendering in the chapter download button (it was hidden by the Button's internal XML layout).

---
_Generated by [Claude Code](https://claude.ai/code)_