### PR TITLE
Fix download progress text clipping in chapter cells

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -103,6 +103,7 @@ private:
     void showPageCounter();
     void hidePageCounter();
     void schedulePageCounterHide();
+    int m_pageCounterHideGeneration = 0;  // Generation counter to cancel stale auto-hide
 
     // Update page counter rotation/position
     void updatePageCounterRotation();
@@ -175,8 +176,7 @@ private:
     // Image caching (preloaded pages)
     std::map<int, std::string> m_cachedImages;
 
-    // Dark mode support
-    bool m_isDarkMode = true;
+    // Reader background color support
     void updateMarginColors();
 
     // Touch gesture tracking

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -94,10 +94,7 @@ private:
     void applySettings();
     void saveSettingsToApp();  // Persist settings to AppSettings
 
-    // Touch handling
-    void handleTouch(brls::Point point);
-    void handleTouchNavigation(float x, float screenWidth);
-    void handleSwipe(brls::Point delta);
+    // Touch handling (implemented inline in gesture recognizers)
 
     // Page counter auto-hide
     void showPageCounter();
@@ -173,9 +170,6 @@ private:
     bool m_nextChapterLoaded = false;
     void preloadNextChapter();
 
-    // Image caching (preloaded pages)
-    std::map<int, std::string> m_cachedImages;
-
     // Reader background color support
     void updateMarginColors();
 
@@ -221,7 +215,8 @@ private:
     brls::Box* m_errorOverlay = nullptr;
     brls::Label* m_errorLabel = nullptr;
     brls::Button* m_retryButton = nullptr;
-    int m_pageLoadGeneration = 0;  // Track current load to detect stale timeouts
+    int m_pageLoadGeneration = 0;   // Track current load to detect stale timeouts
+    bool m_pageLoadSucceeded = false; // Set true when current page loads successfully
     bool m_loadedFromLocal = false;  // True when current chapter was loaded from local downloads
     void showPageError(const std::string& message);
     void hidePageError();

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -123,11 +123,6 @@ struct AppSettings {
     bool webtoonDetection = true;       // Auto-detect webtoon format (aspect ratio based)
     int webtoonSidePadding = 0;         // Side padding percentage (0-20%)
 
-    // Auto-Chapter Advance
-    bool autoChapterAdvance = false;    // Automatically advance to next chapter
-    int autoAdvanceDelay = 3;           // Seconds to wait before advancing (0-10)
-    bool showAdvanceCountdown = true;   // Show countdown before advancing
-
     // Library Settings
     bool updateOnStart = false;
     bool updateOnlyWifi = true;

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -74,6 +74,11 @@ public:
     void setSidePadding(int percent);
 
     /**
+     * Set background color (visible in margins and between pages)
+     */
+    void setBackgroundColor(NVGcolor color);
+
+    /**
      * Set rotation for all page images (0, 90, 180, 270 degrees)
      */
     void setRotation(float degrees);
@@ -150,6 +155,7 @@ private:
     std::set<int> m_loadingPages;     // Pages currently being loaded
 
     // Layout
+    NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Background color (default dark)
     float m_sidePadding = 0.0f;       // Padding on each side
     float m_pageGap = 0.0f;           // Gap between pages (0 for seamless webtoon)
     std::vector<float> m_pageHeights; // Height of each page

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -590,7 +590,33 @@ void ReaderActivity::onContentAvailable() {
                     } else {
                         m_lastTapTime = now;
                         m_lastTapPosition = status.position;
-                        toggleControls();
+
+                        // Same tap-to-navigate logic as pageImage
+                        AppSettings& appSettings = Application::getInstance().getSettings();
+                        if (appSettings.tapToNavigate && !m_isZoomed && !m_continuousScrollMode) {
+                            const float SCREEN_WIDTH = 960.0f;
+                            float tapX = status.position.x;
+                            float leftZone = SCREEN_WIDTH / 3.0f;
+                            float rightZone = SCREEN_WIDTH * 2.0f / 3.0f;
+
+                            if (tapX < leftZone) {
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                                    nextPage();
+                                } else {
+                                    previousPage();
+                                }
+                            } else if (tapX > rightZone) {
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                                    previousPage();
+                                } else {
+                                    nextPage();
+                                }
+                            } else {
+                                toggleControls();
+                            }
+                        } else {
+                            toggleControls();
+                        }
                     }
                 }
             }));

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -351,14 +351,6 @@ bool Application::loadSettings() {
         m_settings.webtoonSidePadding = 0;
     }
 
-    // Load auto-chapter advance settings
-    m_settings.autoChapterAdvance = extractBool("autoChapterAdvance", false);
-    m_settings.autoAdvanceDelay = extractInt("autoAdvanceDelay");
-    if (m_settings.autoAdvanceDelay < 0 || m_settings.autoAdvanceDelay > 10) {
-        m_settings.autoAdvanceDelay = 3;
-    }
-    m_settings.showAdvanceCountdown = extractBool("showAdvanceCountdown", true);
-
     // Load library settings
     m_settings.updateOnStart = extractBool("updateOnStart", false);
     m_settings.updateOnlyWifi = extractBool("updateOnlyWifi", true);
@@ -748,11 +740,6 @@ bool Application::saveSettings() {
     json += "  \"cropBorders\": " + std::string(m_settings.cropBorders ? "true" : "false") + ",\n";
     json += "  \"webtoonDetection\": " + std::string(m_settings.webtoonDetection ? "true" : "false") + ",\n";
     json += "  \"webtoonSidePadding\": " + std::to_string(m_settings.webtoonSidePadding) + ",\n";
-
-    // Auto-chapter advance settings
-    json += "  \"autoChapterAdvance\": " + std::string(m_settings.autoChapterAdvance ? "true" : "false") + ",\n";
-    json += "  \"autoAdvanceDelay\": " + std::to_string(m_settings.autoAdvanceDelay) + ",\n";
-    json += "  \"showAdvanceCountdown\": " + std::string(m_settings.showAdvanceCountdown ? "true" : "false") + ",\n";
 
     // Library settings
     json += "  \"updateOnStart\": " + std::string(m_settings.updateOnStart ? "true" : "false") + ",\n";

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -79,10 +79,11 @@ ChapterCell::ChapterCell() {
     // Download button (Box instead of Button to avoid Button's internal XML
     // layout which adds padding and an internal Label that hides our children)
     dlBtn = new brls::Box();
-    dlBtn->setWidth(40);
+    dlBtn->setWidth(55);
     dlBtn->setHeight(36);
     dlBtn->setCornerRadius(18);
     dlBtn->setFocusable(true);
+    dlBtn->setAxis(brls::Axis::COLUMN);
     dlBtn->setJustifyContent(brls::JustifyContent::CENTER);
     dlBtn->setAlignItems(brls::AlignItems::CENTER);
 
@@ -96,7 +97,6 @@ ChapterCell::ChapterCell() {
     dlLabel->setFontSize(10);
     dlLabel->setTextColor(nvgRGB(255, 255, 255));
     dlLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
-    dlLabel->setWidthPercentage(100);
     dlLabel->setVisibility(brls::Visibility::GONE);
     dlBtn->addView(dlLabel);
 

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -143,7 +143,7 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
         pageImg->setWidth(availableWidth);
         pageImg->setHeight(defaultHeight);  // Will be adjusted when image loads
         pageImg->setScalingType(brls::ImageScalingType::FIT);
-        pageImg->setBackgroundFillColor(nvgRGBA(26, 26, 46, 255));
+        pageImg->setBackgroundFillColor(m_bgColor);
         pageImg->setRotation(imageRotation);  // Apply corrected rotation for webtoon mode
 
         m_pageImages.push_back(pageImg);
@@ -216,6 +216,17 @@ float WebtoonScrollView::getScrollProgress() const {
     }
     float scrollable = totalContentSize - viewSize;
     return std::min(1.0f, std::max(0.0f, -m_scrollY / scrollable));
+}
+
+void WebtoonScrollView::setBackgroundColor(NVGcolor color) {
+    m_bgColor = color;
+
+    // Update background on all existing page images
+    for (auto& img : m_pageImages) {
+        if (img) {
+            img->setBackgroundFillColor(color);
+        }
+    }
 }
 
 void WebtoonScrollView::setSidePadding(int percent) {
@@ -514,7 +525,7 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
     // Draw background
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
-    nvgFillColor(vg, nvgRGBA(26, 26, 46, 255));
+    nvgFillColor(vg, m_bgColor);
     nvgFill(vg);
 
     // Save state and set scissor for clipping


### PR DESCRIPTION
Fixes download-progress text clipping in chapter cells and cleans up the reader — makes previously-dead reader settings work, adds D-pad navigation, and fixes the background, offline preload and tap-to-navigate zones.

---
_Generated by [Claude Code](https://claude.ai/code)_