### PR TITLE
Mark read/unread now clears reading progress; cancel image loads on tab leave

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -213,6 +213,14 @@ private:
     void completeSwipeAnimation(bool turnPage);
     void resetSwipeState();
 
+    // Smooth slide completion animation (runs after finger lifts)
+    bool m_completionAnimating = false;   // true while slide-to-finish is running
+    float m_completionOffset = 0.0f;      // current animated offset
+    float m_completionTarget = 0.0f;      // target offset (screen width or 0 for snap-back)
+    bool m_completionTurnPage = false;    // whether to finalize page turn at end
+    void animateSwipeCompletion();        // per-frame step, called via brls::sync
+    void finalizePageTurn();              // called when animation reaches target
+
     // NOBORU-style touch controls
     // Double-tap detection
     std::chrono::steady_clock::time_point m_lastTapTime;

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -149,6 +149,9 @@ public:
     // Update reading progress
     void updateReadingProgress(int mangaId, int chapterIndex, int lastPageRead);
 
+    // Clear all reading progress for a manga (used by mark as read/unread)
+    void clearReadingProgress(int mangaId);
+
     // Sync progress to/from server
     void syncProgressToServer();
     void syncProgressFromServer();

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -101,6 +101,7 @@ private:
     // UI element tracking for incremental updates (avoid full rebuilds)
     struct LocalRowElements {
         brls::Box* row = nullptr;
+        brls::Box* contentBox = nullptr;  // Inner content layer (slides on swipe)
         brls::Label* progressLabel = nullptr;
         brls::Image* xButtonIcon = nullptr;
         int mangaId = 0;
@@ -110,6 +111,7 @@ private:
 
     struct ServerRowElements {
         brls::Box* row = nullptr;
+        brls::Box* contentBox = nullptr;  // Inner content layer (slides on swipe)
         brls::Label* progressLabel = nullptr;
         brls::Image* xButtonIcon = nullptr;
         int chapterId = 0;
@@ -127,14 +129,16 @@ private:
     brls::Box* createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
                               const std::string& chapterName, float chapterNumber,
                               int downloadedPages, int pageCount, int state,
-                              brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon);
+                              brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
+                              brls::Box*& outContentBox);
 
     // Helper methods for incremental updates (server queue)
     brls::Box* createServerRow(int chapterId, int mangaId, const std::string& mangaTitle,
                                const std::string& chapterName, float chapterNumber,
                                int downloadedPages, int pageCount, int state,
                                int currentIndex, int queueSize,
-                               brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon);
+                               brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
+                               brls::Box*& outContentBox);
     void addServerItem(int chapterId, int mangaId, const std::string& mangaTitle,
                        const std::string& chapterName, float chapterNumber,
                        int downloadedPages, int pageCount, int state,

--- a/include/view/downloads_tab.hpp
+++ b/include/view/downloads_tab.hpp
@@ -101,7 +101,6 @@ private:
     // UI element tracking for incremental updates (avoid full rebuilds)
     struct LocalRowElements {
         brls::Box* row = nullptr;
-        brls::Box* contentBox = nullptr;  // Inner content layer (slides on swipe)
         brls::Label* progressLabel = nullptr;
         brls::Image* xButtonIcon = nullptr;
         int mangaId = 0;
@@ -111,7 +110,6 @@ private:
 
     struct ServerRowElements {
         brls::Box* row = nullptr;
-        brls::Box* contentBox = nullptr;  // Inner content layer (slides on swipe)
         brls::Label* progressLabel = nullptr;
         brls::Image* xButtonIcon = nullptr;
         int chapterId = 0;
@@ -129,16 +127,14 @@ private:
     brls::Box* createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
                               const std::string& chapterName, float chapterNumber,
                               int downloadedPages, int pageCount, int state,
-                              brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
-                              brls::Box*& outContentBox);
+                              brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon);
 
     // Helper methods for incremental updates (server queue)
     brls::Box* createServerRow(int chapterId, int mangaId, const std::string& mangaTitle,
                                const std::string& chapterName, float chapterNumber,
                                int downloadedPages, int pageCount, int state,
                                int currentIndex, int queueSize,
-                               brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
-                               brls::Box*& outContentBox);
+                               brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon);
     void addServerItem(int chapterId, int mangaId, const std::string& mangaTitle,
                        const std::string& chapterName, float chapterNumber,
                        int downloadedPages, int pageCount, int state,

--- a/include/view/settings_tab.hpp
+++ b/include/view/settings_tab.hpp
@@ -17,6 +17,8 @@ public:
     SettingsTab();
     ~SettingsTab();
 
+    void willDisappear(bool resetState) override;
+
 private:
     void createAccountSection();
     void createTrackingSection();

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -450,6 +450,11 @@ void ReaderActivity::onContentAvailable() {
                                         m_settings.rotation == ImageRotation::ROTATE_270);
 
                 if (status.state == brls::GestureState::START) {
+                    // Cancel any running slide-completion animation
+                    if (m_completionAnimating) {
+                        m_completionAnimating = false;
+                        resetSwipeState();
+                    }
                     m_isPanning = false;
                     m_isSwipeAnimating = false;
                     m_touchStart = status.position;
@@ -665,6 +670,10 @@ void ReaderActivity::onContentAvailable() {
                                         m_settings.rotation == ImageRotation::ROTATE_270);
 
                 if (status.state == brls::GestureState::START) {
+                    if (m_completionAnimating) {
+                        m_completionAnimating = false;
+                        resetSwipeState();
+                    }
                     m_isPanning = false;
                     m_isSwipeAnimating = false;
                     m_touchStart = status.position;
@@ -2578,8 +2587,7 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
 
     if (turnPage && m_swipeToChapter) {
         // Swiped on a transition page showing a chapter page preview —
-        // navigate to that chapter directly.
-        // Hide everything cleanly BEFORE navigating to avoid visual snap-back.
+        // navigate to that chapter directly (instant, chapter reloads everything).
         brls::Logger::info("COMPLETE: taking CHAPTER path, swipingToNext={}", m_swipingToNext);
         m_swipeToChapter = false;
         m_previewIsTransition = false;
@@ -2610,37 +2618,30 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
             return;
         }
     }
-    if (turnPage && m_previewIsTransition && m_previewPageIndex >= 0) {
-        // Swiped from a real page into a transition page — navigate there normally
-        brls::Logger::info("COMPLETE: taking TRANSITION_PREVIEW path, going to page {}", m_previewPageIndex);
-        m_previewIsTransition = false;
-        m_currentPage = m_previewPageIndex;
-        updatePageDisplay();
-        loadPage(m_currentPage);
-        resetSwipeState();
+
+    // Determine target offset for slide animation
+    bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
+                             m_settings.rotation == ImageRotation::ROTATE_270);
+    float screenExtent = useVerticalSwipe ? 544.0f : 960.0f;
+
+    if (turnPage && (m_previewIsTransition || (m_previewPageIndex >= 0 &&
+        m_previewPageIndex < static_cast<int>(m_pages.size())))) {
+        // Animate slide to full screen extent, then finalize page turn
+        float target = (m_swipeOffset > 0) ? screenExtent : -screenExtent;
+        m_completionOffset = m_swipeOffset;
+        m_completionTarget = target;
+        m_completionTurnPage = true;
+        m_completionAnimating = true;
+        animateSwipeCompletion();
         return;
     }
-    if (turnPage && m_previewPageIndex >= 0 &&
-        m_previewPageIndex < static_cast<int>(m_pages.size())) {
-        // Turn to the preview page (must be a valid in-bounds index)
-        brls::Logger::info("COMPLETE: taking NORMAL_PAGE path, going to page {}", m_previewPageIndex);
-        m_currentPage = m_previewPageIndex;
-        updatePageDisplay();
-        loadPage(m_currentPage);
-        updateProgress();
 
-        // Preload next chapter if near end
-        if (m_currentPage >= static_cast<int>(m_pages.size()) - 3) {
-            preloadNextChapter();
-        }
-    } else if (turnPage && isTransitionPage(m_currentPage)) {
+    if (turnPage && isTransitionPage(m_currentPage)) {
         // Swiped past a transition page boundary with no preview page available.
         // Trigger the same chapter navigation as nextPage()/previousPage().
-        // Hide everything cleanly to avoid visual snap-back.
         const std::string& url = m_pages[m_currentPage].imageUrl;
         brls::Logger::info("COMPLETE: taking FALLBACK path, url={} swipingToNext={}", url, m_swipingToNext);
 
-        // Clean hide before navigating (same as swipeToChapter path)
         m_isSwipeAnimating = false;
         m_swipeOffset = 0.0f;
         m_previewPageIndex = -1;
@@ -2663,29 +2664,81 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
 
         if (m_swipingToNext) {
             if (url == TRANSITION_NEXT) {
-                brls::Logger::info("COMPLETE: FALLBACK → nextChapter()");
                 nextChapter();
                 return;
             } else if (url == TRANSITION_PREV) {
-                brls::Logger::info("COMPLETE: FALLBACK → previousChapter() (from PREV, swipingToNext)");
                 previousChapter();
                 return;
             }
         } else {
             if (url == TRANSITION_PREV) {
-                brls::Logger::info("COMPLETE: FALLBACK → previousChapter() (from PREV, swiping back)");
                 previousChapter();
                 return;
             } else if (url == TRANSITION_NEXT) {
-                brls::Logger::info("COMPLETE: FALLBACK → back to real page (from NEXT, swiping back)");
-                // Swiping back from TRANSITION_NEXT → go to nearest real page
                 previousPage();
                 return;
             }
         }
     }
 
-    // Reset positions
+    // Snap back — animate smoothly to 0
+    m_completionOffset = m_swipeOffset;
+    m_completionTarget = 0.0f;
+    m_completionTurnPage = false;
+    m_completionAnimating = true;
+    animateSwipeCompletion();
+}
+
+void ReaderActivity::animateSwipeCompletion() {
+    if (!m_completionAnimating) return;
+    if (m_alive && !*m_alive) { m_completionAnimating = false; return; }
+
+    float diff = m_completionTarget - m_completionOffset;
+    if (std::abs(diff) < 3.0f) {
+        // Close enough to target — finalize
+        m_completionAnimating = false;
+        if (m_completionTurnPage) {
+            finalizePageTurn();
+        } else {
+            resetSwipeState();
+        }
+        return;
+    }
+
+    // Ease toward target (~30% of remaining distance per frame)
+    m_completionOffset += diff * 0.3f;
+    updateSwipePreview(m_completionOffset);
+
+    // Schedule next frame
+    std::weak_ptr<bool> aliveWeak = m_alive;
+    brls::sync([this, aliveWeak]() {
+        auto alive = aliveWeak.lock();
+        if (!alive || !*alive) return;
+        animateSwipeCompletion();
+    });
+}
+
+void ReaderActivity::finalizePageTurn() {
+    brls::Logger::info("FINALIZE: previewIdx={} previewIsTransition={}",
+        m_previewPageIndex, m_previewIsTransition);
+
+    if (m_previewIsTransition) {
+        m_previewIsTransition = false;
+        m_currentPage = m_previewPageIndex;
+        updatePageDisplay();
+        loadPage(m_currentPage);
+    } else if (m_previewPageIndex >= 0 &&
+               m_previewPageIndex < static_cast<int>(m_pages.size())) {
+        m_currentPage = m_previewPageIndex;
+        updatePageDisplay();
+        loadPage(m_currentPage);
+        updateProgress();
+
+        if (m_currentPage >= static_cast<int>(m_pages.size()) - 3) {
+            preloadNextChapter();
+        }
+    }
+
     resetSwipeState();
 }
 

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -704,6 +704,26 @@ void DownloadsManager::updateReadingProgress(int mangaId, int chapterIndex, int 
     }
 }
 
+void DownloadsManager::clearReadingProgress(int mangaId) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    for (auto& manga : m_downloads) {
+        if (manga.mangaId == mangaId) {
+            manga.lastChapterRead = 0;
+            manga.lastPageRead = 0;
+            manga.lastReadTime = 0;
+
+            for (auto& chapter : manga.chapters) {
+                chapter.lastPageRead = 0;
+                chapter.lastReadTime = 0;
+            }
+
+            saveStateUnlocked();
+            break;
+        }
+    }
+}
+
 void DownloadsManager::syncProgressToServer() {
     // Sync local reading progress to Suwayomi server
     SuwayomiClient& client = SuwayomiClient::getInstance();

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -726,27 +726,44 @@ void DownloadsManager::clearReadingProgress(int mangaId) {
 
 void DownloadsManager::syncProgressToServer() {
     // Sync local reading progress to Suwayomi server
+    // Copy data under lock, then release lock before making network calls
+    // to avoid blocking the main thread (getDownloads, etc.)
+    struct SyncItem {
+        int mangaId;
+        int chapterId;
+        int lastPageRead;
+        int pageCount;
+    };
+    std::vector<SyncItem> items;
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& manga : m_downloads) {
+            for (const auto& chapter : manga.chapters) {
+                if (chapter.lastPageRead > 0) {
+                    SyncItem item;
+                    item.mangaId = manga.mangaId;
+                    item.chapterId = chapter.chapterId > 0 ? chapter.chapterId : chapter.chapterIndex;
+                    item.lastPageRead = chapter.lastPageRead;
+                    item.pageCount = chapter.pageCount;
+                    items.push_back(item);
+                }
+            }
+        }
+    }
+
+    // Network calls outside the mutex
     SuwayomiClient& client = SuwayomiClient::getInstance();
-
-    std::lock_guard<std::mutex> lock(m_mutex);
-
     int syncedCount = 0;
     int markedReadCount = 0;
 
-    for (const auto& manga : m_downloads) {
-        for (const auto& chapter : manga.chapters) {
-            if (chapter.lastPageRead > 0) {
-                // Use chapterId (not chapterIndex) for server API calls
-                int id = chapter.chapterId > 0 ? chapter.chapterId : chapter.chapterIndex;
-                if (client.updateChapterProgress(manga.mangaId, id, chapter.lastPageRead)) {
-                    syncedCount++;
-                }
-                // Mark as read on server if user reached the last page
-                if (chapter.pageCount > 0 && chapter.lastPageRead >= chapter.pageCount - 1) {
-                    if (client.markChapterRead(manga.mangaId, id)) {
-                        markedReadCount++;
-                    }
-                }
+    for (const auto& item : items) {
+        if (client.updateChapterProgress(item.mangaId, item.chapterId, item.lastPageRead)) {
+            syncedCount++;
+        }
+        if (item.pageCount > 0 && item.lastPageRead >= item.pageCount - 1) {
+            if (client.markChapterRead(item.mangaId, item.chapterId)) {
+                markedReadCount++;
             }
         }
     }
@@ -757,39 +774,80 @@ void DownloadsManager::syncProgressToServer() {
 
 void DownloadsManager::syncProgressFromServer() {
     // Bidirectional sync: compare local vs server, take the more advanced progress
+    // Step 1: Copy local state under lock
+    struct LocalChapterInfo {
+        int mangaId;
+        int chapterId;
+        int chapterIndex;
+        int lastPageRead;
+        int pageCount;
+    };
+    struct MangaFetchInfo {
+        int mangaId;
+        std::vector<LocalChapterInfo> chapters;
+    };
+    std::vector<MangaFetchInfo> mangaList;
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& manga : m_downloads) {
+            MangaFetchInfo info;
+            info.mangaId = manga.mangaId;
+            for (const auto& ch : manga.chapters) {
+                LocalChapterInfo lci;
+                lci.mangaId = manga.mangaId;
+                lci.chapterId = ch.chapterId;
+                lci.chapterIndex = ch.chapterIndex;
+                lci.lastPageRead = ch.lastPageRead;
+                lci.pageCount = ch.pageCount;
+                info.chapters.push_back(lci);
+            }
+            mangaList.push_back(std::move(info));
+        }
+    }
+
+    // Step 2: Fetch from server and compute updates (no mutex held)
     SuwayomiClient& client = SuwayomiClient::getInstance();
-
-    std::lock_guard<std::mutex> lock(m_mutex);
-
     int updatedLocal = 0;
     int updatedServer = 0;
 
-    for (auto& manga : m_downloads) {
+    struct LocalUpdate {
+        int mangaId;
+        int chapterId;
+        int chapterIndex;
+        int lastPageRead;
+        time_t lastReadTime;
+    };
+    std::vector<LocalUpdate> localUpdates;
+
+    for (auto& manga : mangaList) {
         std::vector<Chapter> serverChapters;
         if (!client.fetchChapters(manga.mangaId, serverChapters)) {
             continue;
         }
 
-        for (auto& localChapter : manga.chapters) {
-            for (const auto& serverChapter : serverChapters) {
-                if (serverChapter.id == localChapter.chapterId ||
-                    serverChapter.index == localChapter.chapterIndex) {
-                    // Compare progress — take the more advanced position
-                    if (serverChapter.lastPageRead > localChapter.lastPageRead) {
-                        // Server is ahead — update local
-                        localChapter.lastPageRead = serverChapter.lastPageRead;
-                        if (serverChapter.lastReadAt > 0) {
-                            localChapter.lastReadTime = static_cast<time_t>(serverChapter.lastReadAt / 1000);
-                        }
+        for (auto& localCh : manga.chapters) {
+            for (const auto& serverCh : serverChapters) {
+                if (serverCh.id == localCh.chapterId ||
+                    serverCh.index == localCh.chapterIndex) {
+                    if (serverCh.lastPageRead > localCh.lastPageRead) {
+                        // Server is ahead — queue local update
+                        LocalUpdate upd;
+                        upd.mangaId = localCh.mangaId;
+                        upd.chapterId = localCh.chapterId;
+                        upd.chapterIndex = localCh.chapterIndex;
+                        upd.lastPageRead = serverCh.lastPageRead;
+                        upd.lastReadTime = serverCh.lastReadAt > 0
+                            ? static_cast<time_t>(serverCh.lastReadAt / 1000) : 0;
+                        localUpdates.push_back(upd);
                         updatedLocal++;
-                    } else if (localChapter.lastPageRead > serverChapter.lastPageRead &&
-                               localChapter.lastPageRead > 0) {
+                    } else if (localCh.lastPageRead > serverCh.lastPageRead &&
+                               localCh.lastPageRead > 0) {
                         // Local is ahead — push to server
-                        int id = localChapter.chapterId > 0 ? localChapter.chapterId : localChapter.chapterIndex;
-                        client.updateChapterProgress(manga.mangaId, id, localChapter.lastPageRead);
-                        // Mark as read if at end
-                        if (localChapter.pageCount > 0 && localChapter.lastPageRead >= localChapter.pageCount - 1) {
-                            client.markChapterRead(manga.mangaId, id);
+                        int id = localCh.chapterId > 0 ? localCh.chapterId : localCh.chapterIndex;
+                        client.updateChapterProgress(localCh.mangaId, id, localCh.lastPageRead);
+                        if (localCh.pageCount > 0 && localCh.lastPageRead >= localCh.pageCount - 1) {
+                            client.markChapterRead(localCh.mangaId, id);
                         }
                         updatedServer++;
                     }
@@ -799,7 +857,25 @@ void DownloadsManager::syncProgressFromServer() {
         }
     }
 
-    saveStateUnlocked();
+    // Step 3: Apply local updates under lock
+    if (!localUpdates.empty()) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& upd : localUpdates) {
+            for (auto& manga : m_downloads) {
+                if (manga.mangaId != upd.mangaId) continue;
+                for (auto& ch : manga.chapters) {
+                    if (ch.chapterId == upd.chapterId || ch.chapterIndex == upd.chapterIndex) {
+                        ch.lastPageRead = upd.lastPageRead;
+                        if (upd.lastReadTime > 0) ch.lastReadTime = upd.lastReadTime;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+        saveStateUnlocked();
+    }
+
     brls::Logger::info("DownloadsManager: Bidirectional sync - {} local updates, {} server updates",
                       updatedLocal, updatedServer);
 }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3071,25 +3071,24 @@ bool SuwayomiClient::markChaptersUnread(int mangaId, const std::vector<int>& cha
 }
 
 bool SuwayomiClient::markAllChaptersRead(int mangaId) {
-    // Fetch all chapters, then mark them all read via GraphQL
+    // Fetch all chapters, then mark them all read and clear progress via GraphQL
     std::vector<Chapter> chapters;
     if (!fetchChapters(mangaId, chapters)) return false;
 
     std::vector<int> chapterIds;
     for (const auto& ch : chapters) {
-        if (!ch.read) {
-            chapterIds.push_back(ch.id);
-        }
+        chapterIds.push_back(ch.id);
     }
     if (chapterIds.empty()) return true;
 
-    // Use GraphQL batch update
+    // Use GraphQL batch update - also clear lastPageRead
     const char* query = R"(
-        mutation UpdateChapters($ids: [Int!]!, $isRead: Boolean!) {
-            updateChapters(input: { ids: $ids, patch: { isRead: $isRead } }) {
+        mutation UpdateChapters($ids: [Int!]!) {
+            updateChapters(input: { ids: $ids, patch: { isRead: true, lastPageRead: 0 } }) {
                 chapters {
                     id
                     isRead
+                    lastPageRead
                 }
             }
         }
@@ -3102,29 +3101,30 @@ bool SuwayomiClient::markAllChaptersRead(int mangaId) {
     }
     idList += "]";
 
-    std::string variables = "{\"ids\":" + idList + ",\"isRead\":true}";
+    std::string variables = "{\"ids\":" + idList + "}";
     std::string response = executeGraphQL(query, variables);
     return !response.empty();
 }
 
 bool SuwayomiClient::markAllChaptersUnread(int mangaId) {
+    // Fetch all chapters, then mark them all unread and clear progress via GraphQL
     std::vector<Chapter> chapters;
     if (!fetchChapters(mangaId, chapters)) return false;
 
     std::vector<int> chapterIds;
     for (const auto& ch : chapters) {
-        if (ch.read) {
-            chapterIds.push_back(ch.id);
-        }
+        chapterIds.push_back(ch.id);
     }
     if (chapterIds.empty()) return true;
 
+    // Use GraphQL batch update - also clear lastPageRead
     const char* query = R"(
-        mutation UpdateChapters($ids: [Int!]!, $isRead: Boolean!) {
-            updateChapters(input: { ids: $ids, patch: { isRead: $isRead } }) {
+        mutation UpdateChapters($ids: [Int!]!) {
+            updateChapters(input: { ids: $ids, patch: { isRead: false, lastPageRead: 0 } }) {
                 chapters {
                     id
                     isRead
+                    lastPageRead
                 }
             }
         }
@@ -3137,7 +3137,7 @@ bool SuwayomiClient::markAllChaptersUnread(int mangaId) {
     }
     idList += "]";
 
-    std::string variables = "{\"ids\":" + idList + ",\"isRead\":false}";
+    std::string variables = "{\"ids\":" + idList + "}";
     std::string response = executeGraphQL(query, variables);
     return !response.empty();
 }

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -641,16 +641,16 @@ void DownloadsTab::refreshQueue() {
                             }
                             progressLabel->setText(progressText);
 
-                            // Update background color
-                            if (m_serverRowElements[i].row) {
+                            // Update content box background color
+                            if (m_serverRowElements[i].contentBox) {
                                 if (newItem.state == static_cast<int>(DownloadState::DOWNLOADING)) {
-                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
                                 } else if (newItem.state == static_cast<int>(DownloadState::ERROR)) {
-                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
+                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
                                 } else if (newItem.state == static_cast<int>(DownloadState::DOWNLOADED)) {
-                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(30, 50, 60, 200));
+                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(30, 50, 60, 200));
                                 } else {
-                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
                                 }
                             }
                         }
@@ -1022,15 +1022,38 @@ void DownloadsTab::stopAutoRefresh() {
 brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
                                         const std::string& chapterName, float chapterNumber,
                                         int downloadedPages, int pageCount, int state,
-                                        brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon) {
+                                        brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
+                                        brls::Box*& outContentBox) {
+    // Outer container: clips children so the sliding content stays within bounds
     auto row = new brls::Box();
     row->setAxis(brls::Axis::ROW);
-    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-    row->setAlignItems(brls::AlignItems::CENTER);
-    row->setPadding(8);
     row->setMargins(0, 0, 8, 0);
     row->setCornerRadius(6);
     row->setFocusable(true);
+    row->setClipsToBounds(true);
+    row->setBackgroundColor(nvgRGBA(200, 60, 50, 255));  // Red delete background
+
+    // "Remove" label visible when content slides away
+    auto* deleteLabel = new brls::Label();
+    deleteLabel->setText("Remove");
+    deleteLabel->setFontSize(16);
+    deleteLabel->setTextColor(nvgRGB(255, 255, 255));
+    deleteLabel->setPositionType(brls::PositionType::ABSOLUTE);
+    deleteLabel->setPositionRight(20);
+    deleteLabel->setPositionTop(0);
+    deleteLabel->setPositionBottom(0);
+    deleteLabel->setVerticalAlign(brls::VerticalAlign::CENTER);
+    row->addView(deleteLabel);
+
+    // Content layer: holds all the actual row content, slides on swipe
+    // Not absolute — this child determines the row's natural height
+    auto contentBox = new brls::Box();
+    contentBox->setAxis(brls::Axis::ROW);
+    contentBox->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    contentBox->setAlignItems(brls::AlignItems::CENTER);
+    contentBox->setPadding(8);
+    contentBox->setGrow(1.0f);
+    contentBox->setCornerRadius(6);
 
     // Background color based on state
     NVGcolor originalBgColor;
@@ -1043,7 +1066,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     } else {
         originalBgColor = nvgRGBA(40, 40, 40, 200);
     }
-    row->setBackgroundColor(originalBgColor);
+    contentBox->setBackgroundColor(originalBgColor);
 
     // Info box
     auto infoBox = new brls::Box();
@@ -1075,7 +1098,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
     infoBox->addView(chapterLabel);
 
-    row->addView(infoBox);
+    contentBox->addView(infoBox);
 
     // Status box (progress + X button icon)
     auto statusBox = new brls::Box();
@@ -1121,7 +1144,10 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     outXButtonIcon = xButtonIcon;
     statusBox->addView(xButtonIcon);
 
-    row->addView(statusBox);
+    contentBox->addView(statusBox);
+
+    row->addView(contentBox);
+    outContentBox = contentBox;
 
     // Show X button icon when this row gets focus
     row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
@@ -1175,11 +1201,11 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
             return true;
         });
 
-    // Add swipe gesture for removal
+    // Add swipe gesture for removal - slides content to reveal red "Remove" background
     auto localSwipeState = std::make_shared<SwipeState>();
     row->addGestureRecognizer(new brls::PanGestureRecognizer(
-        [this, row, mangaId, chapterIndex, originalBgColor, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-            const float SWIPE_THRESHOLD = 60.0f;
+        [this, mangaId, chapterIndex, contentBox, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            const float SWIPE_THRESHOLD = 100.0f;
             const float TAP_THRESHOLD = 15.0f;
 
             if (status.state == brls::GestureState::START) {
@@ -1191,20 +1217,19 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
 
                 if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
                     localSwipeState->isValidSwipe = true;
-                    if (dx < -SWIPE_THRESHOLD * 0.5f) {
-                        row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
-                    } else {
-                        row->setBackgroundColor(originalBgColor);
-                    }
+                    // Slide content with finger (only leftward, clamped to 0)
+                    float offset = std::min(0.0f, dx);
+                    contentBox->setTranslationX(offset);
                 }
             } else if (status.state == brls::GestureState::END) {
-                row->setBackgroundColor(originalBgColor);
-
                 float dx = status.position.x - localSwipeState->touchStart.x;
                 if (localSwipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
                     DownloadsManager& mgr = DownloadsManager::getInstance();
                     mgr.cancelChapterDownload(mangaId, chapterIndex);
                     removeLocalItem(mangaId, chapterIndex);
+                } else {
+                    // Snap back
+                    contentBox->setTranslationX(0);
                 }
             }
         }, brls::PanAxis::HORIZONTAL));
@@ -1238,16 +1263,16 @@ void DownloadsTab::updateLocalProgress(int mangaId, int chapterIndex, int downlo
                 }
                 elem.progressLabel->setText(progressText);
 
-                // Update background color based on state
-                if (elem.row) {
+                // Update content box background color based on state
+                if (elem.contentBox) {
                     if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
-                        elem.row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                        elem.contentBox->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
                     } else if (state == static_cast<int>(LocalDownloadState::FAILED)) {
-                        elem.row->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
+                        elem.contentBox->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
                     } else if (state == static_cast<int>(LocalDownloadState::PAUSED)) {
-                        elem.row->setBackgroundColor(nvgRGBA(50, 50, 30, 200));
+                        elem.contentBox->setBackgroundColor(nvgRGBA(50, 50, 30, 200));
                     } else {
-                        elem.row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                        elem.contentBox->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
                     }
                 }
             }
@@ -1331,9 +1356,10 @@ void DownloadsTab::addLocalItem(int mangaId, int chapterIndex, const std::string
                                 int downloadedPages, int pageCount, int state) {
     brls::Label* progressLabel = nullptr;
     brls::Image* xButtonIcon = nullptr;
+    brls::Box* contentBox = nullptr;
 
     auto* row = createLocalRow(mangaId, chapterIndex, mangaTitle, chapterName, chapterNumber,
-                               downloadedPages, pageCount, state, progressLabel, xButtonIcon);
+                               downloadedPages, pageCount, state, progressLabel, xButtonIcon, contentBox);
 
     // Add to container
     m_localContainer->addView(row);
@@ -1341,6 +1367,7 @@ void DownloadsTab::addLocalItem(int mangaId, int chapterIndex, const std::string
     // Track the elements
     LocalRowElements elem;
     elem.row = row;
+    elem.contentBox = contentBox;
     elem.progressLabel = progressLabel;
     elem.xButtonIcon = xButtonIcon;
     elem.mangaId = mangaId;
@@ -1431,15 +1458,37 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
                                          const std::string& chapterName, float chapterNumber,
                                          int downloadedPages, int pageCount, int state,
                                          int currentIndex, int queueSize,
-                                         brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon) {
+                                         brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
+                                         brls::Box*& outContentBox) {
+    // Outer container: clips children so sliding content stays within bounds
     auto row = new brls::Box();
     row->setAxis(brls::Axis::ROW);
-    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-    row->setAlignItems(brls::AlignItems::CENTER);
-    row->setPadding(8);
     row->setMargins(0, 0, 8, 0);
     row->setCornerRadius(6);
     row->setFocusable(true);
+    row->setClipsToBounds(true);
+    row->setBackgroundColor(nvgRGBA(200, 60, 50, 255));  // Red delete background
+
+    // "Remove" label visible when content slides away
+    auto* deleteLabel = new brls::Label();
+    deleteLabel->setText("Remove");
+    deleteLabel->setFontSize(16);
+    deleteLabel->setTextColor(nvgRGB(255, 255, 255));
+    deleteLabel->setPositionType(brls::PositionType::ABSOLUTE);
+    deleteLabel->setPositionRight(20);
+    deleteLabel->setPositionTop(0);
+    deleteLabel->setPositionBottom(0);
+    deleteLabel->setVerticalAlign(brls::VerticalAlign::CENTER);
+    row->addView(deleteLabel);
+
+    // Content layer: slides on swipe to reveal the red background
+    auto contentBox = new brls::Box();
+    contentBox->setAxis(brls::Axis::ROW);
+    contentBox->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    contentBox->setAlignItems(brls::AlignItems::CENTER);
+    contentBox->setPadding(8);
+    contentBox->setGrow(1.0f);
+    contentBox->setCornerRadius(6);
 
     NVGcolor originalBgColor;
     if (state == static_cast<int>(DownloadState::DOWNLOADING)) {
@@ -1451,7 +1500,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     } else {
         originalBgColor = nvgRGBA(40, 40, 40, 200);
     }
-    row->setBackgroundColor(originalBgColor);
+    contentBox->setBackgroundColor(originalBgColor);
 
     auto infoBox = new brls::Box();
     infoBox->setAxis(brls::Axis::COLUMN);
@@ -1475,7 +1524,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
     infoBox->addView(chapterLabel);
 
-    row->addView(infoBox);
+    contentBox->addView(infoBox);
 
     auto statusBox = new brls::Box();
     statusBox->setAxis(brls::Axis::ROW);
@@ -1518,7 +1567,10 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     outXButtonIcon = xButtonIcon;
     statusBox->addView(xButtonIcon);
 
-    row->addView(statusBox);
+    contentBox->addView(statusBox);
+
+    row->addView(contentBox);
+    outContentBox = contentBox;
 
     // FIX 2: Focus handler with null-check validation to guard against dangling pointer
     row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
@@ -1592,10 +1644,11 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
             return true;
         });
 
+    // Swipe gesture - slides content to reveal red "Remove" background
     auto swipeState = std::make_shared<SwipeState>();
     row->addGestureRecognizer(new brls::PanGestureRecognizer(
-        [this, row, mangaId, chapterId, originalBgColor, swipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-            const float SWIPE_THRESHOLD = 60.0f;
+        [this, mangaId, chapterId, contentBox, swipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            const float SWIPE_THRESHOLD = 100.0f;
             const float TAP_THRESHOLD = 15.0f;
 
             if (status.state == brls::GestureState::START) {
@@ -1607,15 +1660,11 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
 
                 if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
                     swipeState->isValidSwipe = true;
-                    if (dx < -SWIPE_THRESHOLD * 0.5f) {
-                        row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
-                    } else {
-                        row->setBackgroundColor(originalBgColor);
-                    }
+                    // Slide content with finger (only leftward, clamped to 0)
+                    float offset = std::min(0.0f, dx);
+                    contentBox->setTranslationX(offset);
                 }
             } else if (status.state == brls::GestureState::END) {
-                row->setBackgroundColor(originalBgColor);
-
                 float dx = status.position.x - swipeState->touchStart.x;
                 if (swipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
                     asyncRun([this, mangaId, chapterId, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
@@ -1628,6 +1677,9 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
                             refreshQueue();
                         });
                     });
+                } else {
+                    // Snap back
+                    contentBox->setTranslationX(0);
                 }
             }
         }, brls::PanAxis::HORIZONTAL));
@@ -1642,15 +1694,17 @@ void DownloadsTab::addServerItem(int chapterId, int mangaId, const std::string& 
                                   int currentIndex, int queueSize) {
     brls::Label* progressLabel = nullptr;
     brls::Image* xButtonIcon = nullptr;
+    brls::Box* contentBox = nullptr;
 
     auto* row = createServerRow(chapterId, mangaId, mangaTitle, chapterName, chapterNumber,
                                 downloadedPages, pageCount, state, currentIndex, queueSize,
-                                progressLabel, xButtonIcon);
+                                progressLabel, xButtonIcon, contentBox);
 
     m_queueContainer->addView(row);
 
     ServerRowElements elem;
     elem.row = row;
+    elem.contentBox = contentBox;
     elem.progressLabel = progressLabel;
     elem.xButtonIcon = xButtonIcon;
     elem.chapterId = chapterId;

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -359,12 +359,26 @@ DownloadsTab::DownloadsTab() {
 void DownloadsTab::willAppear(bool resetState) {
     brls::Box::willAppear(resetState);
 
-    // Clear tracking vectors for fresh start
+    // Re-arm the alive flag so async callbacks work after tab revisit
+    // (willDisappear sets *m_alive = false to cancel pending callbacks)
+    m_alive = std::make_shared<bool>(true);
+
+    // Clear tracking vectors and stale UI children for fresh start
     m_currentFocusedIcon = nullptr;
     m_localRowElements.clear();
     m_serverRowElements.clear();
     m_lastLocalQueue.clear();
     m_lastServerQueue.clear();
+
+    // Remove stale row views from containers (tracking vectors were just cleared)
+    if (m_queueContainer) {
+        while (m_queueContainer->getChildren().size() > 0)
+            m_queueContainer->removeView(m_queueContainer->getChildren()[0]);
+    }
+    if (m_localContainer) {
+        while (m_localContainer->getChildren().size() > 0)
+            m_localContainer->removeView(m_localContainer->getChildren()[0]);
+    }
 
     // Initialize last progress refresh time
     m_lastProgressRefresh = std::chrono::steady_clock::now();
@@ -997,8 +1011,10 @@ void DownloadsTab::startAutoRefresh() {
 void DownloadsTab::stopAutoRefresh() {
     // Set to false - timer will stop on next iteration
     m_autoRefreshEnabled.store(false);
+    // Reset timer active flag so startAutoRefresh() can launch a new thread on next willAppear
+    m_autoRefreshTimerActive.store(false);
     // Note: We don't wait for the thread to stop here to avoid blocking the UI
-    // The atomic checks in the callbacks will prevent any issues
+    // The old thread will exit on its next loop iteration when it sees *m_alive == false
 }
 
 

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -423,17 +423,20 @@ DownloadsTab::~DownloadsTab() {
 void DownloadsTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 
+    // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
+    if (m_alive) *m_alive = false;
+
     // IMPORTANT: Stop auto-refresh FIRST to signal all callbacks to stop
     // This must happen before clearing callbacks to prevent race conditions
     stopAutoRefresh();
-
-    // Small delay to allow any pending brls::sync calls to complete
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     // Clear callbacks to avoid updates when tab is not visible
     DownloadsManager& mgr = DownloadsManager::getInstance();
     mgr.setProgressCallback(nullptr);
     mgr.setChapterCompletionCallback(nullptr);
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
 
     // Clear tracking vectors to free memory
     m_localRowElements.clear();

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -641,16 +641,16 @@ void DownloadsTab::refreshQueue() {
                             }
                             progressLabel->setText(progressText);
 
-                            // Update content box background color
-                            if (m_serverRowElements[i].contentBox) {
+                            // Update background color
+                            if (m_serverRowElements[i].row) {
                                 if (newItem.state == static_cast<int>(DownloadState::DOWNLOADING)) {
-                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
                                 } else if (newItem.state == static_cast<int>(DownloadState::ERROR)) {
-                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
                                 } else if (newItem.state == static_cast<int>(DownloadState::DOWNLOADED)) {
-                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(30, 50, 60, 200));
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(30, 50, 60, 200));
                                 } else {
-                                    m_serverRowElements[i].contentBox->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                                    m_serverRowElements[i].row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
                                 }
                             }
                         }
@@ -1022,38 +1022,15 @@ void DownloadsTab::stopAutoRefresh() {
 brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std::string& mangaTitle,
                                         const std::string& chapterName, float chapterNumber,
                                         int downloadedPages, int pageCount, int state,
-                                        brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
-                                        brls::Box*& outContentBox) {
-    // Outer container: clips children so the sliding content stays within bounds
+                                        brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon) {
     auto row = new brls::Box();
     row->setAxis(brls::Axis::ROW);
+    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    row->setAlignItems(brls::AlignItems::CENTER);
+    row->setPadding(8);
     row->setMargins(0, 0, 8, 0);
     row->setCornerRadius(6);
     row->setFocusable(true);
-    row->setClipsToBounds(true);
-    row->setBackgroundColor(nvgRGBA(200, 60, 50, 255));  // Red delete background
-
-    // "Remove" label visible when content slides away
-    auto* deleteLabel = new brls::Label();
-    deleteLabel->setText("Remove");
-    deleteLabel->setFontSize(16);
-    deleteLabel->setTextColor(nvgRGB(255, 255, 255));
-    deleteLabel->setPositionType(brls::PositionType::ABSOLUTE);
-    deleteLabel->setPositionRight(20);
-    deleteLabel->setPositionTop(0);
-    deleteLabel->setPositionBottom(0);
-    deleteLabel->setVerticalAlign(brls::VerticalAlign::CENTER);
-    row->addView(deleteLabel);
-
-    // Content layer: holds all the actual row content, slides on swipe
-    // Not absolute — this child determines the row's natural height
-    auto contentBox = new brls::Box();
-    contentBox->setAxis(brls::Axis::ROW);
-    contentBox->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-    contentBox->setAlignItems(brls::AlignItems::CENTER);
-    contentBox->setPadding(8);
-    contentBox->setGrow(1.0f);
-    contentBox->setCornerRadius(6);
 
     // Background color based on state
     NVGcolor originalBgColor;
@@ -1066,7 +1043,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     } else {
         originalBgColor = nvgRGBA(40, 40, 40, 200);
     }
-    contentBox->setBackgroundColor(originalBgColor);
+    row->setBackgroundColor(originalBgColor);
 
     // Info box
     auto infoBox = new brls::Box();
@@ -1098,7 +1075,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
     infoBox->addView(chapterLabel);
 
-    contentBox->addView(infoBox);
+    row->addView(infoBox);
 
     // Status box (progress + X button icon)
     auto statusBox = new brls::Box();
@@ -1144,10 +1121,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     outXButtonIcon = xButtonIcon;
     statusBox->addView(xButtonIcon);
 
-    contentBox->addView(statusBox);
-
-    row->addView(contentBox);
-    outContentBox = contentBox;
+    row->addView(statusBox);
 
     // Show X button icon when this row gets focus
     row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
@@ -1201,11 +1175,11 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
             return true;
         });
 
-    // Add swipe gesture for removal - slides content to reveal red "Remove" background
+    // Add swipe gesture for removal
     auto localSwipeState = std::make_shared<SwipeState>();
     row->addGestureRecognizer(new brls::PanGestureRecognizer(
-        [this, mangaId, chapterIndex, contentBox, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-            const float SWIPE_THRESHOLD = 100.0f;
+        [this, row, mangaId, chapterIndex, originalBgColor, localSwipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            const float SWIPE_THRESHOLD = 60.0f;
             const float TAP_THRESHOLD = 15.0f;
 
             if (status.state == brls::GestureState::START) {
@@ -1217,19 +1191,20 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
 
                 if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
                     localSwipeState->isValidSwipe = true;
-                    // Slide content with finger (only leftward, clamped to 0)
-                    float offset = std::min(0.0f, dx);
-                    contentBox->setTranslationX(offset);
+                    if (dx < -SWIPE_THRESHOLD * 0.5f) {
+                        row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
+                    } else {
+                        row->setBackgroundColor(originalBgColor);
+                    }
                 }
             } else if (status.state == brls::GestureState::END) {
+                row->setBackgroundColor(originalBgColor);
+
                 float dx = status.position.x - localSwipeState->touchStart.x;
                 if (localSwipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
                     DownloadsManager& mgr = DownloadsManager::getInstance();
                     mgr.cancelChapterDownload(mangaId, chapterIndex);
                     removeLocalItem(mangaId, chapterIndex);
-                } else {
-                    // Snap back
-                    contentBox->setTranslationX(0);
                 }
             }
         }, brls::PanAxis::HORIZONTAL));
@@ -1263,16 +1238,16 @@ void DownloadsTab::updateLocalProgress(int mangaId, int chapterIndex, int downlo
                 }
                 elem.progressLabel->setText(progressText);
 
-                // Update content box background color based on state
-                if (elem.contentBox) {
+                // Update background color based on state
+                if (elem.row) {
                     if (state == static_cast<int>(LocalDownloadState::DOWNLOADING)) {
-                        elem.contentBox->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
+                        elem.row->setBackgroundColor(nvgRGBA(30, 60, 30, 200));
                     } else if (state == static_cast<int>(LocalDownloadState::FAILED)) {
-                        elem.contentBox->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
+                        elem.row->setBackgroundColor(nvgRGBA(60, 30, 30, 200));
                     } else if (state == static_cast<int>(LocalDownloadState::PAUSED)) {
-                        elem.contentBox->setBackgroundColor(nvgRGBA(50, 50, 30, 200));
+                        elem.row->setBackgroundColor(nvgRGBA(50, 50, 30, 200));
                     } else {
-                        elem.contentBox->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
+                        elem.row->setBackgroundColor(nvgRGBA(40, 40, 40, 200));
                     }
                 }
             }
@@ -1356,10 +1331,9 @@ void DownloadsTab::addLocalItem(int mangaId, int chapterIndex, const std::string
                                 int downloadedPages, int pageCount, int state) {
     brls::Label* progressLabel = nullptr;
     brls::Image* xButtonIcon = nullptr;
-    brls::Box* contentBox = nullptr;
 
     auto* row = createLocalRow(mangaId, chapterIndex, mangaTitle, chapterName, chapterNumber,
-                               downloadedPages, pageCount, state, progressLabel, xButtonIcon, contentBox);
+                               downloadedPages, pageCount, state, progressLabel, xButtonIcon);
 
     // Add to container
     m_localContainer->addView(row);
@@ -1367,7 +1341,6 @@ void DownloadsTab::addLocalItem(int mangaId, int chapterIndex, const std::string
     // Track the elements
     LocalRowElements elem;
     elem.row = row;
-    elem.contentBox = contentBox;
     elem.progressLabel = progressLabel;
     elem.xButtonIcon = xButtonIcon;
     elem.mangaId = mangaId;
@@ -1458,37 +1431,15 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
                                          const std::string& chapterName, float chapterNumber,
                                          int downloadedPages, int pageCount, int state,
                                          int currentIndex, int queueSize,
-                                         brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon,
-                                         brls::Box*& outContentBox) {
-    // Outer container: clips children so sliding content stays within bounds
+                                         brls::Label*& outProgressLabel, brls::Image*& outXButtonIcon) {
     auto row = new brls::Box();
     row->setAxis(brls::Axis::ROW);
+    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+    row->setAlignItems(brls::AlignItems::CENTER);
+    row->setPadding(8);
     row->setMargins(0, 0, 8, 0);
     row->setCornerRadius(6);
     row->setFocusable(true);
-    row->setClipsToBounds(true);
-    row->setBackgroundColor(nvgRGBA(200, 60, 50, 255));  // Red delete background
-
-    // "Remove" label visible when content slides away
-    auto* deleteLabel = new brls::Label();
-    deleteLabel->setText("Remove");
-    deleteLabel->setFontSize(16);
-    deleteLabel->setTextColor(nvgRGB(255, 255, 255));
-    deleteLabel->setPositionType(brls::PositionType::ABSOLUTE);
-    deleteLabel->setPositionRight(20);
-    deleteLabel->setPositionTop(0);
-    deleteLabel->setPositionBottom(0);
-    deleteLabel->setVerticalAlign(brls::VerticalAlign::CENTER);
-    row->addView(deleteLabel);
-
-    // Content layer: slides on swipe to reveal the red background
-    auto contentBox = new brls::Box();
-    contentBox->setAxis(brls::Axis::ROW);
-    contentBox->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-    contentBox->setAlignItems(brls::AlignItems::CENTER);
-    contentBox->setPadding(8);
-    contentBox->setGrow(1.0f);
-    contentBox->setCornerRadius(6);
 
     NVGcolor originalBgColor;
     if (state == static_cast<int>(DownloadState::DOWNLOADING)) {
@@ -1500,7 +1451,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     } else {
         originalBgColor = nvgRGBA(40, 40, 40, 200);
     }
-    contentBox->setBackgroundColor(originalBgColor);
+    row->setBackgroundColor(originalBgColor);
 
     auto infoBox = new brls::Box();
     infoBox->setAxis(brls::Axis::COLUMN);
@@ -1524,7 +1475,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     chapterLabel->setTextColor(nvgRGBA(180, 180, 180, 255));
     infoBox->addView(chapterLabel);
 
-    contentBox->addView(infoBox);
+    row->addView(infoBox);
 
     auto statusBox = new brls::Box();
     statusBox->setAxis(brls::Axis::ROW);
@@ -1567,10 +1518,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     outXButtonIcon = xButtonIcon;
     statusBox->addView(xButtonIcon);
 
-    contentBox->addView(statusBox);
-
-    row->addView(contentBox);
-    outContentBox = contentBox;
+    row->addView(statusBox);
 
     // FIX 2: Focus handler with null-check validation to guard against dangling pointer
     row->getFocusEvent()->subscribe([this, xButtonIcon](brls::View* view) {
@@ -1644,11 +1592,10 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
             return true;
         });
 
-    // Swipe gesture - slides content to reveal red "Remove" background
     auto swipeState = std::make_shared<SwipeState>();
     row->addGestureRecognizer(new brls::PanGestureRecognizer(
-        [this, mangaId, chapterId, contentBox, swipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-            const float SWIPE_THRESHOLD = 100.0f;
+        [this, row, mangaId, chapterId, originalBgColor, swipeState](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            const float SWIPE_THRESHOLD = 60.0f;
             const float TAP_THRESHOLD = 15.0f;
 
             if (status.state == brls::GestureState::START) {
@@ -1660,11 +1607,15 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
 
                 if (std::abs(dx) > std::abs(dy) * 1.5f && std::abs(dx) > TAP_THRESHOLD) {
                     swipeState->isValidSwipe = true;
-                    // Slide content with finger (only leftward, clamped to 0)
-                    float offset = std::min(0.0f, dx);
-                    contentBox->setTranslationX(offset);
+                    if (dx < -SWIPE_THRESHOLD * 0.5f) {
+                        row->setBackgroundColor(nvgRGBA(231, 76, 60, 100));
+                    } else {
+                        row->setBackgroundColor(originalBgColor);
+                    }
                 }
             } else if (status.state == brls::GestureState::END) {
+                row->setBackgroundColor(originalBgColor);
+
                 float dx = status.position.x - swipeState->touchStart.x;
                 if (swipeState->isValidSwipe && dx < -SWIPE_THRESHOLD) {
                     asyncRun([this, mangaId, chapterId, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
@@ -1677,9 +1628,6 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
                             refreshQueue();
                         });
                     });
-                } else {
-                    // Snap back
-                    contentBox->setTranslationX(0);
                 }
             }
         }, brls::PanAxis::HORIZONTAL));
@@ -1694,17 +1642,15 @@ void DownloadsTab::addServerItem(int chapterId, int mangaId, const std::string& 
                                   int currentIndex, int queueSize) {
     brls::Label* progressLabel = nullptr;
     brls::Image* xButtonIcon = nullptr;
-    brls::Box* contentBox = nullptr;
 
     auto* row = createServerRow(chapterId, mangaId, mangaTitle, chapterName, chapterNumber,
                                 downloadedPages, pageCount, state, currentIndex, queueSize,
-                                progressLabel, xButtonIcon, contentBox);
+                                progressLabel, xButtonIcon);
 
     m_queueContainer->addView(row);
 
     ServerRowElements elem;
     elem.row = row;
-    elem.contentBox = contentBox;
     elem.progressLabel = progressLabel;
     elem.xButtonIcon = xButtonIcon;
     elem.chapterId = chapterId;

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -844,6 +844,9 @@ void ExtensionsTab::willDisappear(bool resetState) {
 
     // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
     if (m_alive) *m_alive = false;
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
 }
 
 void ExtensionsTab::onFocusGained() {

--- a/src/view/history_tab.cpp
+++ b/src/view/history_tab.cpp
@@ -141,6 +141,10 @@ void HistoryTab::willDisappear(bool resetState) {
 
     // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
     if (m_alive) *m_alive = false;
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
+    m_isLoadingMore = false;
 }
 
 void HistoryTab::onFocusGained() {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2186,9 +2186,13 @@ void LibrarySectionTab::markMangaRead(const std::vector<Manga>& mangaList) {
 
     asyncRun([this, asyncList, aliveWeak, categoryId]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
+        DownloadsManager& dm = DownloadsManager::getInstance();
         int count = 0;
         for (const auto& manga : asyncList) {
-            if (client.markAllChaptersRead(manga.id)) count++;
+            if (client.markAllChaptersRead(manga.id)) {
+                dm.clearReadingProgress(manga.id);
+                count++;
+            }
         }
 
         brls::sync([this, count, aliveWeak, categoryId]() {
@@ -2210,9 +2214,13 @@ void LibrarySectionTab::markMangaUnread(const std::vector<Manga>& mangaList) {
 
     asyncRun([this, asyncList, aliveWeak, categoryId]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
+        DownloadsManager& dm = DownloadsManager::getInstance();
         int count = 0;
         for (const auto& manga : asyncList) {
-            if (client.markAllChaptersUnread(manga.id)) count++;
+            if (client.markAllChaptersUnread(manga.id)) {
+                dm.clearReadingProgress(manga.id);
+                count++;
+            }
         }
 
         brls::sync([this, count, aliveWeak, categoryId]() {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -394,6 +394,9 @@ void LibrarySectionTab::willDisappear(bool resetState) {
 
     // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
     if (m_alive) *m_alive = false;
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
 }
 
 void LibrarySectionTab::onFocusGained() {

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -325,6 +325,10 @@ void SearchTab::willDisappear(bool resetState) {
 
     // Invalidate load generation so any in-flight async results are ignored
     m_loadGeneration++;
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
+    m_isLoadingPage = false;
 }
 
 void SearchTab::onFocusGained() {

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -67,6 +67,13 @@ SettingsTab::~SettingsTab() {
     if (m_alive) *m_alive = false;
 }
 
+void SettingsTab::willDisappear(bool resetState) {
+    brls::Box::willDisappear(resetState);
+
+    // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
+    if (m_alive) *m_alive = false;
+}
+
 void SettingsTab::createAccountSection() {
     Application& app = Application::getInstance();
     AppSettings& settings = app.getSettings();

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -150,6 +150,9 @@ void SourceBrowseTab::willDisappear(bool resetState) {
 
     // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
     if (m_alive) *m_alive = false;
+
+    // Cancel pending image loads to free up worker threads and network bandwidth
+    ImageLoader::cancelAll();
 }
 
 void SourceBrowseTab::onFocusGained() {


### PR DESCRIPTION
Makes mark read/unread clear local reading progress, cancels image loads when leaving a tab, fixes a downloads-tab freeze and revisit behaviour, and adds a smooth slide animation for reader page transitions.

---
_Generated by [Claude Code](https://claude.ai/code)_