### PR TITLE
Fix swipe preview overlap at 90/180 rotation

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -109,7 +109,8 @@ private:
     // UI components - NOBORU style
     BRLS_BIND(brls::Box, container, "reader/container");
     BRLS_BIND(RotatableImage, pageImage, "reader/page_image");
-    BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");  // Preview page for swipe
+    BRLS_BIND(RotatableImage, previewImage, "reader/preview_image");    // Positive-side preview
+    BRLS_BIND(RotatableImage, previewImageB, "reader/preview_image_b"); // Negative-side preview
     BRLS_BIND(brls::Box, topBar, "reader/top_bar");
     BRLS_BIND(brls::Box, bottomBar, "reader/bottom_bar");
     BRLS_BIND(RotatableLabel, pageCounter, "reader/page_counter");
@@ -203,13 +204,21 @@ private:
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
 
-    // NOBORU-style swipe animation (shows next/prev page sliding in)
+    // 3-page carousel swipe: positive side + current + negative side
+    // "Positive" = revealed when swiping positive (right/down on screen)
+    // "Negative" = revealed when swiping negative (left/up on screen)
     bool m_isSwipeAnimating = false;
     float m_swipeOffset = 0.0f;           // Current swipe offset in pixels
-    int m_previewPageIndex = -1;          // Index of page being previewed (-1 = none)
+    int m_previewPageIndex = -1;          // Active side's page index for page turn
     bool m_swipingToNext = true;          // true = swiping to next page, false = previous
+    int m_posPreviewIdx = -1;             // Page index loaded in positive-side preview
+    int m_negPreviewIdx = -1;             // Page index loaded in negative-side preview
+    bool m_posIsTransition = false;       // Positive side is a transition page (uses transitionBox)
+    bool m_negIsTransition = false;       // Negative side is a transition page
     void updateSwipePreview(float offset);
     void loadPreviewPage(int index);
+    void loadPreviewInto(RotatableImage* target, int index);
+    void preloadAdjacentPreviews();       // Pre-load both sides after page loads
     void completeSwipeAnimation(bool turnPage);
     void resetSwipeState();
 

--- a/include/view/rotatable_box.hpp
+++ b/include/view/rotatable_box.hpp
@@ -27,17 +27,10 @@ public:
      */
     float getRotation() const { return m_rotationDegrees; }
 
-    /**
-     * Set slide offset for swipe push effect (content slides within clipped view bounds)
-     */
-    void setSlideOffset(float x, float y) { m_slideOffsetX = x; m_slideOffsetY = y; }
-
     static brls::View* create();
 
 private:
     float m_rotationDegrees = 0.0f;
-    float m_slideOffsetX = 0.0f;
-    float m_slideOffsetY = 0.0f;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/rotatable_box.hpp
+++ b/include/view/rotatable_box.hpp
@@ -27,10 +27,18 @@ public:
      */
     float getRotation() const { return m_rotationDegrees; }
 
+    /**
+     * Set slide offset for swipe carousel (NanoVG-based positioning)
+     */
+    void setSlideOffset(float x, float y);
+    void resetSlideOffset();
+
     static brls::View* create();
 
 private:
     float m_rotationDegrees = 0.0f;
+    float m_slideX = 0.0f;
+    float m_slideY = 0.0f;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/rotatable_box.hpp
+++ b/include/view/rotatable_box.hpp
@@ -27,10 +27,17 @@ public:
      */
     float getRotation() const { return m_rotationDegrees; }
 
+    /**
+     * Set slide offset for swipe push effect (content slides within clipped view bounds)
+     */
+    void setSlideOffset(float x, float y) { m_slideOffsetX = x; m_slideOffsetY = y; }
+
     static brls::View* create();
 
 private:
     float m_rotationDegrees = 0.0f;
+    float m_slideOffsetX = 0.0f;
+    float m_slideOffsetY = 0.0f;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -113,6 +113,23 @@ public:
      */
     void resetZoom();
 
+    /**
+     * Take ownership of the NVG image from another RotatableImage.
+     * The source image is cleared after the transfer.
+     * This enables seamless page transitions without reloading.
+     */
+    void takeImageFrom(RotatableImage* source);
+
+    /**
+     * Set a slide offset for swipe carousel transitions.
+     * Uses NanoVG transforms directly (bypasses borealis setTranslationX
+     * which may not work reliably on all platforms).
+     * The content slides by (x, y) pixels while the scissor clips to the
+     * view's original bounds, creating a proper page-slide effect.
+     */
+    void setSlideOffset(float x, float y);
+    void resetSlideOffset();
+
     static brls::View* create();
 
 private:
@@ -127,6 +144,10 @@ private:
     // Zoom state
     float m_zoomLevel = 1.0f;      // Current zoom level (1.0 = normal)
     brls::Point m_zoomOffset = {0, 0};  // Pan offset when zoomed
+
+    // Slide offset for swipe carousel (NanoVG-based, not borealis translation)
+    float m_slideX = 0.0f;
+    float m_slideY = 0.0f;
 
     // Calculate image bounds for current scaling type
     void calculateImageBounds(float viewX, float viewY, float viewW, float viewH,

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -113,11 +113,6 @@ public:
      */
     void resetZoom();
 
-    /**
-     * Set slide offset for swipe push effect (content slides within clipped view bounds)
-     */
-    void setSlideOffset(float x, float y) { m_slideOffsetX = x; m_slideOffsetY = y; }
-
     static brls::View* create();
 
 private:
@@ -132,10 +127,6 @@ private:
     // Zoom state
     float m_zoomLevel = 1.0f;      // Current zoom level (1.0 = normal)
     brls::Point m_zoomOffset = {0, 0};  // Pan offset when zoomed
-
-    // Slide offset for swipe push effect (pixels)
-    float m_slideOffsetX = 0.0f;
-    float m_slideOffsetY = 0.0f;
 
     // Calculate image bounds for current scaling type
     void calculateImageBounds(float viewX, float viewY, float viewW, float viewH,

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -113,6 +113,11 @@ public:
      */
     void resetZoom();
 
+    /**
+     * Set slide offset for swipe push effect (content slides within clipped view bounds)
+     */
+    void setSlideOffset(float x, float y) { m_slideOffsetX = x; m_slideOffsetY = y; }
+
     static brls::View* create();
 
 private:
@@ -127,6 +132,10 @@ private:
     // Zoom state
     float m_zoomLevel = 1.0f;      // Current zoom level (1.0 = normal)
     brls::Point m_zoomOffset = {0, 0};  // Pan offset when zoomed
+
+    // Slide offset for swipe push effect (pixels)
+    float m_slideOffsetX = 0.0f;
+    float m_slideOffsetY = 0.0f;
 
     // Calculate image bounds for current scaling type
     void calculateImageBounds(float viewX, float viewY, float viewW, float viewH,

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -45,6 +45,9 @@
         justifyContent="center"
         alignItems="center"
         backgroundColor="#14141e"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
         visibility="gone">
 
         <brls:Label

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -16,9 +16,19 @@
         height="100%"
         grow="1"/>
 
-    <!-- Preview page (slides in during swipe) - hidden by default, AFTER main page for z-order -->
+    <!-- Preview page (positive swipe direction) - hidden by default -->
     <RotatableImage
         id="reader/preview_image"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="gone"/>
+
+    <!-- Preview page (negative swipe direction) - hidden by default -->
+    <RotatableImage
+        id="reader/preview_image_b"
         width="100%"
         height="100%"
         positionType="absolute"

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -2399,71 +2399,50 @@ void ReaderActivity::renderTransitionPage(int index) {
 
 void ReaderActivity::updateSwipePreview(float offset) {
     // Update visual positions during swipe - PUSH EFFECT
-    // Current page is pushed off screen, preview page follows behind pushing it
+    // Uses NanoVG slide offsets (rendered inside scissor) instead of borealis
+    // translations, which don't work reliably on PSV at 90/180 rotation.
     const float SCREEN_WIDTH = 960.0f;
     const float SCREEN_HEIGHT = 544.0f;
 
     if (!previewImage) return;
 
     // Determine which view is the "current page" being swiped away
-    // When m_previewIsTransition is set, transitionBox is the INCOMING view, not the current
     bool onTransition = !m_previewIsTransition && transitionBox &&
                         transitionBox->getVisibility() == brls::Visibility::VISIBLE;
 
     // Show the incoming view
     if (m_previewIsTransition) {
-        // transitionBox is the incoming preview — keep previewImage hidden
         previewImage->setVisibility(brls::Visibility::GONE);
     } else {
         previewImage->setVisibility(brls::Visibility::VISIBLE);
     }
 
-    // Determine if we should use vertical swipe based on rotation
+    // Determine swipe axis based on rotation
     bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
                              m_settings.rotation == ImageRotation::ROTATE_270);
 
-    if (useVerticalSwipe) {
-        offset = std::max(-SCREEN_HEIGHT, std::min(SCREEN_HEIGHT, offset));
+    float screenExtent = useVerticalSwipe ? SCREEN_HEIGHT : SCREEN_WIDTH;
+    offset = std::max(-screenExtent, std::min(screenExtent, offset));
 
-        // Move the active view (current page) with finger
-        if (onTransition) {
-            transitionBox->setTranslationY(offset);
-            transitionBox->setTranslationX(0.0f);
-        } else if (pageImage) {
-            pageImage->setTranslationY(offset);
-            pageImage->setTranslationX(0.0f);
-        }
+    // Calculate slide offsets
+    float slideX = useVerticalSwipe ? 0.0f : offset;
+    float slideY = useVerticalSwipe ? offset : 0.0f;
+    float incomingVal = offset > 0 ? offset - screenExtent : offset + screenExtent;
+    float inSlideX = useVerticalSwipe ? 0.0f : incomingVal;
+    float inSlideY = useVerticalSwipe ? incomingVal : 0.0f;
 
-        // Position the incoming view behind (off-screen initially)
-        float incomingY = offset > 0 ? offset - SCREEN_HEIGHT : offset + SCREEN_HEIGHT;
-        if (m_previewIsTransition && transitionBox) {
-            transitionBox->setTranslationY(incomingY);
-            transitionBox->setTranslationX(0.0f);
-        } else {
-            previewImage->setTranslationY(incomingY);
-            previewImage->setTranslationX(0.0f);
-        }
+    // Move the active view (current page) with finger
+    if (onTransition) {
+        transitionBox->setSlideOffset(slideX, slideY);
+    } else if (pageImage) {
+        pageImage->setSlideOffset(slideX, slideY);
+    }
+
+    // Position the incoming view behind (off-screen initially, slides in)
+    if (m_previewIsTransition && transitionBox) {
+        transitionBox->setSlideOffset(inSlideX, inSlideY);
     } else {
-        offset = std::max(-SCREEN_WIDTH, std::min(SCREEN_WIDTH, offset));
-
-        // Move the active view (current page) with finger
-        if (onTransition) {
-            transitionBox->setTranslationX(offset);
-            transitionBox->setTranslationY(0.0f);
-        } else if (pageImage) {
-            pageImage->setTranslationX(offset);
-            pageImage->setTranslationY(0.0f);
-        }
-
-        // Position the incoming view behind (off-screen initially)
-        float incomingX = offset > 0 ? offset - SCREEN_WIDTH : offset + SCREEN_WIDTH;
-        if (m_previewIsTransition && transitionBox) {
-            transitionBox->setTranslationX(incomingX);
-            transitionBox->setTranslationY(0.0f);
-        } else {
-            previewImage->setTranslationX(incomingX);
-            previewImage->setTranslationY(0.0f);
-        }
+        previewImage->setSlideOffset(inSlideX, inSlideY);
     }
 }
 
@@ -2735,16 +2714,14 @@ void ReaderActivity::resetSwipeState() {
     m_swipeOffset = 0.0f;
     m_previewPageIndex = -1;
 
-    // Reset page positions (both X and Y)
+    // Reset slide offsets
     if (pageImage) {
-        pageImage->setTranslationX(0.0f);
-        pageImage->setTranslationY(0.0f);
+        pageImage->setSlideOffset(0.0f, 0.0f);
     }
 
-    // Reset transition box position and hide if it was used as preview
+    // Reset transition box and hide if it was used as preview
     if (transitionBox) {
-        transitionBox->setTranslationX(0.0f);
-        transitionBox->setTranslationY(0.0f);
+        transitionBox->setSlideOffset(0.0f, 0.0f);
         if (wasTransitionPreview && !isTransitionPage(m_currentPage)) {
             transitionBox->setVisibility(brls::Visibility::GONE);
         }
@@ -2753,8 +2730,7 @@ void ReaderActivity::resetSwipeState() {
     // Hide preview image
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
-        previewImage->setTranslationX(0.0f);
-        previewImage->setTranslationY(0.0f);
+        previewImage->setSlideOffset(0.0f, 0.0f);
     }
 }
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -2413,9 +2413,8 @@ void ReaderActivity::renderTransitionPage(int index) {
 
 void ReaderActivity::updateSwipePreview(float offset) {
     // 3-page carousel: positive side + current + negative side
-    // All three views slide together as a strip using NanoVG slide offsets.
-    // "Positive side" = page revealed when swiping in the positive direction (right/down)
-    // "Negative side" = page revealed when swiping in the negative direction (left/up)
+    // Views are moved to their actual screen positions using setTranslationX/Y
+    // so they don't overlap. Each view draws at its own location.
     const float SCREEN_WIDTH = 960.0f;
     const float SCREEN_HEIGHT = 544.0f;
 
@@ -2424,7 +2423,14 @@ void ReaderActivity::updateSwipePreview(float offset) {
     float screenExtent = useVerticalSwipe ? SCREEN_HEIGHT : SCREEN_WIDTH;
     offset = std::max(-screenExtent, std::min(screenExtent, offset));
 
-    // Calculate slide offsets for the 3-page strip
+    // Helper: position a view at (tx, ty) using borealis translation
+    auto moveView = [&](brls::View* view, float tx, float ty) {
+        if (!view) return;
+        view->setTranslationX(tx);
+        view->setTranslationY(ty);
+    };
+
+    // Calculate positions for the 3-page strip
     auto makeSlide = [&](float val) -> std::pair<float,float> {
         return useVerticalSwipe ? std::make_pair(0.0f, val) : std::make_pair(val, 0.0f);
     };
@@ -2438,25 +2444,25 @@ void ReaderActivity::updateSwipePreview(float offset) {
                         transitionBox->getVisibility() == brls::Visibility::VISIBLE &&
                         isTransitionPage(m_currentPage);
     if (onTransition) {
-        transitionBox->setSlideOffset(curX, curY);
+        moveView(transitionBox, curX, curY);
     } else if (pageImage) {
-        pageImage->setSlideOffset(curX, curY);
+        moveView(pageImage, curX, curY);
     }
 
     // Positive side preview
     if (m_posIsTransition && transitionBox && !onTransition) {
-        transitionBox->setSlideOffset(posX, posY);
+        moveView(transitionBox, posX, posY);
     } else if (previewImage && m_posPreviewIdx >= 0) {
         previewImage->setVisibility(brls::Visibility::VISIBLE);
-        previewImage->setSlideOffset(posX, posY);
+        moveView(previewImage, posX, posY);
     }
 
     // Negative side preview
     if (m_negIsTransition && transitionBox && !onTransition && !m_posIsTransition) {
-        transitionBox->setSlideOffset(negX, negY);
+        moveView(transitionBox, negX, negY);
     } else if (previewImageB && m_negPreviewIdx >= 0) {
         previewImageB->setVisibility(brls::Visibility::VISIBLE);
-        previewImageB->setSlideOffset(negX, negY);
+        moveView(previewImageB, negX, negY);
     }
 }
 
@@ -2792,27 +2798,31 @@ void ReaderActivity::resetSwipeState() {
     m_swipeOffset = 0.0f;
     m_previewPageIndex = -1;
 
-    // Reset slide offsets on all views
+    // Reset translations on all views
     if (pageImage) {
-        pageImage->setSlideOffset(0.0f, 0.0f);
+        pageImage->setTranslationX(0.0f);
+        pageImage->setTranslationY(0.0f);
     }
 
     // Reset transition box
     if (transitionBox) {
-        transitionBox->setSlideOffset(0.0f, 0.0f);
+        transitionBox->setTranslationX(0.0f);
+        transitionBox->setTranslationY(0.0f);
         if (wasTransitionPreview && !isTransitionPage(m_currentPage)) {
             transitionBox->setVisibility(brls::Visibility::GONE);
         }
     }
 
-    // Hide both preview images and reset offsets
+    // Hide both preview images and reset translations
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
-        previewImage->setSlideOffset(0.0f, 0.0f);
+        previewImage->setTranslationX(0.0f);
+        previewImage->setTranslationY(0.0f);
     }
     if (previewImageB) {
         previewImageB->setVisibility(brls::Visibility::GONE);
-        previewImageB->setSlideOffset(0.0f, 0.0f);
+        previewImageB->setTranslationX(0.0f);
+        previewImageB->setTranslationY(0.0f);
     }
 }
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -511,7 +511,16 @@ void ReaderActivity::onContentAvailable() {
                     // Only track swipes in the primary direction
                     if (std::abs(rawDelta) > std::abs(crossDelta) && std::abs(rawDelta) > SWIPE_START_THRESHOLD) {
                         m_isSwipeAnimating = true;
-                        m_swipeOffset = rawDelta;  // Store raw for visual
+
+                        // Scale touch delta from physical screen coords to view coords
+                        // for 1:1 finger-to-page tracking. Touch is in physical pixels
+                        // (960x544) but NanoVG views use internal coords (~1280x726).
+                        float physScreen = useVerticalSwipe ? 544.0f : 960.0f;
+                        float viewSize = useVerticalSwipe ?
+                            (pageImage ? pageImage->getHeight() : physScreen) :
+                            (pageImage ? pageImage->getWidth() : physScreen);
+                        float scaledDelta = rawDelta * (viewSize / physScreen);
+                        m_swipeOffset = scaledDelta;
 
                         // Determine active swipe direction for page turn logic
                         bool swipingPositive = logicalDelta > 0;
@@ -533,7 +542,7 @@ void ReaderActivity::onContentAvailable() {
                         }
 
                         // Update visual positions - all 3 pages slide together
-                        updateSwipePreview(rawDelta);
+                        updateSwipePreview(scaledDelta);
                     }
                 } else if (status.state == brls::GestureState::END) {
                     // Don't turn the page if we were just pinch-zooming
@@ -711,7 +720,14 @@ void ReaderActivity::onContentAvailable() {
 
                     if (std::abs(rawDelta) > std::abs(crossDelta) && std::abs(rawDelta) > SWIPE_START_THRESHOLD) {
                         m_isSwipeAnimating = true;
-                        m_swipeOffset = rawDelta;
+
+                        // Scale touch delta from physical screen coords to view coords
+                        float physScreen = useVerticalSwipe ? 544.0f : 960.0f;
+                        float viewSize = useVerticalSwipe ?
+                            (pageImage ? pageImage->getHeight() : physScreen) :
+                            (pageImage ? pageImage->getWidth() : physScreen);
+                        float scaledDelta = rawDelta * (viewSize / physScreen);
+                        m_swipeOffset = scaledDelta;
 
                         bool swipingPositive = logicalDelta > 0;
                         bool wantNextPage = (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) ? swipingPositive : !swipingPositive;
@@ -766,7 +782,7 @@ void ReaderActivity::onContentAvailable() {
                             }
                         }
 
-                        updateSwipePreview(rawDelta);
+                        updateSwipePreview(scaledDelta);
                     }
                 } else if (status.state == brls::GestureState::END) {
                     if (m_pages.empty()) {
@@ -2424,12 +2440,18 @@ void ReaderActivity::updateSwipePreview(float offset) {
     // rendering on PS Vita's GXM backend. Each view's draw() method applies
     // the slide offset via nvgTranslate inside a scissor clip, so pages
     // slide off screen without overlapping.
-    const float SCREEN_WIDTH = 960.0f;
-    const float SCREEN_HEIGHT = 544.0f;
+    //
+    // Use actual view dimensions (internal rendering coords), NOT physical
+    // screen dimensions (960x544). The borealis framework renders at a higher
+    // internal resolution (~1280x726) that gets scaled to the physical display.
+    // Using physical screen dimensions causes pages to be spaced too close
+    // together, resulting in overlap during swipe transitions.
+    float viewWidth = pageImage ? pageImage->getWidth() : 960.0f;
+    float viewHeight = pageImage ? pageImage->getHeight() : 544.0f;
 
     bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
                              m_settings.rotation == ImageRotation::ROTATE_270);
-    float screenExtent = useVerticalSwipe ? SCREEN_HEIGHT : SCREEN_WIDTH;
+    float screenExtent = useVerticalSwipe ? viewHeight : viewWidth;
     offset = std::max(-screenExtent, std::min(screenExtent, offset));
 
     // Calculate positions for the 3-page strip
@@ -2664,9 +2686,12 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
         m_previewPageIndex, m_swipingToNext, m_currentPage);
 
     // Determine target offset for slide animation
+    // Use actual view dimensions, not physical screen dimensions
     bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
                              m_settings.rotation == ImageRotation::ROTATE_270);
-    float screenExtent = useVerticalSwipe ? 544.0f : 960.0f;
+    float viewWidth = pageImage ? pageImage->getWidth() : 960.0f;
+    float viewHeight = pageImage ? pageImage->getHeight() : 544.0f;
+    float screenExtent = useVerticalSwipe ? viewHeight : viewWidth;
 
     if (turnPage && m_swipeToChapter) {
         // Swiped on a transition page showing a chapter page preview —

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -354,9 +354,18 @@ void ReaderActivity::onContentAvailable() {
     // Set background color based on dark/light mode (shows when page doesn't fill screen)
     updateMarginColors();
 
-    // Hide preview image initially
+    // Clip children to container bounds so swipe carousel pages
+    // don't render outside the screen area or overlap each other
+    if (container) {
+        container->setClipsToBounds(true);
+    }
+
+    // Hide preview images initially
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
+    }
+    if (previewImageB) {
+        previewImageB->setVisibility(brls::Visibility::GONE);
     }
 
     // NOBORU-style touch handling with swipe controls
@@ -2413,8 +2422,11 @@ void ReaderActivity::renderTransitionPage(int index) {
 
 void ReaderActivity::updateSwipePreview(float offset) {
     // 3-page carousel: positive side + current + negative side
-    // Views are moved to their actual screen positions using setTranslationX/Y
-    // so they don't overlap. Each view draws at its own location.
+    // Uses NanoVG slide offsets (not borealis setTranslationX/Y) to position
+    // views, because borealis translations don't reliably move NanoVG
+    // rendering on PS Vita's GXM backend. Each view's draw() method applies
+    // the slide offset via nvgTranslate inside a scissor clip, so pages
+    // slide off screen without overlapping.
     const float SCREEN_WIDTH = 960.0f;
     const float SCREEN_HEIGHT = 544.0f;
 
@@ -2422,13 +2434,6 @@ void ReaderActivity::updateSwipePreview(float offset) {
                              m_settings.rotation == ImageRotation::ROTATE_270);
     float screenExtent = useVerticalSwipe ? SCREEN_HEIGHT : SCREEN_WIDTH;
     offset = std::max(-screenExtent, std::min(screenExtent, offset));
-
-    // Helper: position a view at (tx, ty) using borealis translation
-    auto moveView = [&](brls::View* view, float tx, float ty) {
-        if (!view) return;
-        view->setTranslationX(tx);
-        view->setTranslationY(ty);
-    };
 
     // Calculate positions for the 3-page strip
     auto makeSlide = [&](float val) -> std::pair<float,float> {
@@ -2444,25 +2449,25 @@ void ReaderActivity::updateSwipePreview(float offset) {
                         transitionBox->getVisibility() == brls::Visibility::VISIBLE &&
                         isTransitionPage(m_currentPage);
     if (onTransition) {
-        moveView(transitionBox, curX, curY);
+        transitionBox->setSlideOffset(curX, curY);
     } else if (pageImage) {
-        moveView(pageImage, curX, curY);
+        pageImage->setSlideOffset(curX, curY);
     }
 
     // Positive side preview
     if (m_posIsTransition && transitionBox && !onTransition) {
-        moveView(transitionBox, posX, posY);
+        transitionBox->setSlideOffset(posX, posY);
     } else if (previewImage && m_posPreviewIdx >= 0) {
         previewImage->setVisibility(brls::Visibility::VISIBLE);
-        moveView(previewImage, posX, posY);
+        previewImage->setSlideOffset(posX, posY);
     }
 
     // Negative side preview
     if (m_negIsTransition && transitionBox && !onTransition && !m_posIsTransition) {
-        moveView(transitionBox, negX, negY);
+        transitionBox->setSlideOffset(negX, negY);
     } else if (previewImageB && m_negPreviewIdx >= 0) {
         previewImageB->setVisibility(brls::Visibility::VISIBLE);
-        moveView(previewImageB, negX, negY);
+        previewImageB->setSlideOffset(negX, negY);
     }
 }
 
@@ -2770,6 +2775,16 @@ void ReaderActivity::finalizePageTurn() {
         loadPage(m_currentPage);
     } else if (m_previewPageIndex >= 0 &&
                m_previewPageIndex < static_cast<int>(m_pages.size())) {
+        // Transfer the already-loaded preview image to pageImage for a
+        // seamless transition. This avoids a brief flash of the old page
+        // that would occur if we hid the preview before the async load
+        // into pageImage completed.
+        bool swipedPositive = (m_swipeOffset > 0);
+        RotatableImage* sourcePreview = swipedPositive ? previewImage : previewImageB;
+        if (pageImage && sourcePreview && sourcePreview->hasImage()) {
+            pageImage->takeImageFrom(sourcePreview);
+        }
+
         m_currentPage = m_previewPageIndex;
         updatePageDisplay();
         loadPage(m_currentPage);
@@ -2798,31 +2813,27 @@ void ReaderActivity::resetSwipeState() {
     m_swipeOffset = 0.0f;
     m_previewPageIndex = -1;
 
-    // Reset translations on all views
+    // Reset slide offsets on all views (NanoVG-based positioning)
     if (pageImage) {
-        pageImage->setTranslationX(0.0f);
-        pageImage->setTranslationY(0.0f);
+        pageImage->resetSlideOffset();
     }
 
     // Reset transition box
     if (transitionBox) {
-        transitionBox->setTranslationX(0.0f);
-        transitionBox->setTranslationY(0.0f);
+        transitionBox->resetSlideOffset();
         if (wasTransitionPreview && !isTransitionPage(m_currentPage)) {
             transitionBox->setVisibility(brls::Visibility::GONE);
         }
     }
 
-    // Hide both preview images and reset translations
+    // Hide both preview images and reset slide offsets
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
-        previewImage->setTranslationX(0.0f);
-        previewImage->setTranslationY(0.0f);
+        previewImage->resetSlideOffset();
     }
     if (previewImageB) {
         previewImageB->setVisibility(brls::Visibility::GONE);
-        previewImageB->setTranslationX(0.0f);
-        previewImageB->setTranslationY(0.0f);
+        previewImageB->resetSlideOffset();
     }
 }
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -354,12 +354,6 @@ void ReaderActivity::onContentAvailable() {
     // Set background color based on dark/light mode (shows when page doesn't fill screen)
     updateMarginColors();
 
-    // Clip children to container bounds so swipe carousel pages
-    // don't render outside the screen area or overlap each other
-    if (container) {
-        container->setClipsToBounds(true);
-    }
-
     // Hide preview images initially
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
@@ -473,6 +467,9 @@ void ReaderActivity::onContentAvailable() {
                     m_swipeToChapter = false;
                     m_previewIsTransition = false;
                     m_swipingToNext = true;
+                    brls::Logger::info("PAN START rot={} vert={} invert={} page={}/{}",
+                        static_cast<int>(m_settings.rotation), useVerticalSwipe,
+                        invertDirection, m_currentPage, static_cast<int>(m_pages.size()));
                 } else if (status.state == brls::GestureState::STAY) {
                     // Suppress page navigation while pinch-to-zoom is active
                     if (m_isPinching) return;
@@ -2443,6 +2440,19 @@ void ReaderActivity::updateSwipePreview(float offset) {
     auto [curX, curY] = makeSlide(offset);
     auto [posX, posY] = makeSlide(offset - screenExtent);  // positive side (left/above)
     auto [negX, negY] = makeSlide(offset + screenExtent);  // negative side (right/below)
+
+    // Debug: log slide positions once when swipe first starts or direction changes
+    static int s_lastLoggedOffset = -99999;
+    int roundedOffset = static_cast<int>(offset / 50) * 50;  // log every ~50px
+    if (roundedOffset != s_lastLoggedOffset) {
+        s_lastLoggedOffset = roundedOffset;
+        brls::Logger::info("SWIPE offset={:.0f} rot={} vert={} extent={:.0f} | "
+            "cur=({:.0f},{:.0f}) pos=({:.0f},{:.0f}) neg=({:.0f},{:.0f}) | "
+            "posIdx={} negIdx={} posIsTrans={} negIsTrans={}",
+            offset, static_cast<int>(m_settings.rotation), useVerticalSwipe, screenExtent,
+            curX, curY, posX, posY, negX, negY,
+            m_posPreviewIdx, m_negPreviewIdx, m_posIsTransition, m_negIsTransition);
+    }
 
     // Current page
     bool onTransition = transitionBox &&

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -507,21 +507,26 @@ void ReaderActivity::onContentAvailable() {
                         m_isSwipeAnimating = true;
                         m_swipeOffset = rawDelta;  // Store raw for visual
 
-                        // Determine which page we're swiping to based on logical direction
+                        // Determine active swipe direction for page turn logic
                         bool swipingPositive = logicalDelta > 0;
                         bool wantNextPage = (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) ? swipingPositive : !swipingPositive;
 
-                        int previewIndex = wantNextPage ? m_currentPage + 1 : m_currentPage - 1;
-
-                        // Load preview page if not already loaded
-                        if (previewIndex != m_previewPageIndex && previewIndex >= 0 &&
-                            previewIndex < static_cast<int>(m_pages.size())) {
-                            m_previewPageIndex = previewIndex;
+                        // Set active preview index based on raw direction
+                        // Positive raw offset → positive side preview, negative → negative side
+                        int activeIdx = rawDelta > 0 ? m_posPreviewIdx : m_negPreviewIdx;
+                        if (activeIdx != m_previewPageIndex) {
+                            m_previewPageIndex = activeIdx;
                             m_swipingToNext = wantNextPage;
-                            loadPreviewPage(previewIndex);
+
+                            // Check if active side is a transition page for chapter navigation
+                            bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
+                            m_previewIsTransition = activeIsTransition;
+                            if (activeIsTransition && transitionBox) {
+                                loadPreviewPage(activeIdx);  // Populate transitionBox text
+                            }
                         }
 
-                        // Update visual positions - page follows finger (use raw delta)
+                        // Update visual positions - all 3 pages slide together
                         updateSwipePreview(rawDelta);
                     }
                 } else if (status.state == brls::GestureState::END) {
@@ -705,49 +710,54 @@ void ReaderActivity::onContentAvailable() {
                         bool swipingPositive = logicalDelta > 0;
                         bool wantNextPage = (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) ? swipingPositive : !swipingPositive;
 
-                        int previewIndex = wantNextPage ? m_currentPage + 1 : m_currentPage - 1;
+                        // Set active preview index based on raw direction
+                        int activeIdx = rawDelta > 0 ? m_posPreviewIdx : m_negPreviewIdx;
 
-                        if (previewIndex != m_previewPageIndex && previewIndex >= 0 &&
-                            previewIndex < static_cast<int>(m_pages.size())) {
-                            m_previewPageIndex = previewIndex;
-                            m_swipingToNext = wantNextPage;
-                            loadPreviewPage(previewIndex);
-                        } else if (previewIndex != m_previewPageIndex &&
-                                   (previewIndex < 0 || previewIndex >= static_cast<int>(m_pages.size()))) {
-                            // Out of bounds — we're on a transition page swiping toward next/prev chapter
-                            // Load the chapter's page into previewImage if preloaded
-                            m_swipingToNext = wantNextPage;
-                            m_swipeToChapter = false;
-                            m_previewIsTransition = false;
-                            const std::string& tUrl = m_pages[m_currentPage].imageUrl;
+                        // On a transition page, adjacent pages may be out of bounds (chapter boundary)
+                        // In that case, try loading the cross-chapter page
+                        if (activeIdx < 0 || activeIdx >= static_cast<int>(m_pages.size())) {
+                            if (activeIdx != m_previewPageIndex) {
+                                m_swipingToNext = wantNextPage;
+                                m_swipeToChapter = false;
+                                m_previewIsTransition = false;
+                                const std::string& tUrl = m_pages[m_currentPage].imageUrl;
 
-                            std::string chapterPageUrl;
-                            if (wantNextPage && tUrl == TRANSITION_NEXT &&
-                                m_nextChapterLoaded && !m_nextChapterPages.empty()) {
-                                chapterPageUrl = m_nextChapterPages[0].imageUrl;
-                            } else if (!wantNextPage && tUrl == TRANSITION_PREV &&
-                                       m_prevChapterLoaded && !m_prevChapterPages.empty()) {
-                                chapterPageUrl = m_prevChapterPages.back().imageUrl;
+                                std::string chapterPageUrl;
+                                RotatableImage* target = rawDelta > 0 ? previewImage : previewImageB;
+                                if (wantNextPage && tUrl == TRANSITION_NEXT &&
+                                    m_nextChapterLoaded && !m_nextChapterPages.empty()) {
+                                    chapterPageUrl = m_nextChapterPages[0].imageUrl;
+                                } else if (!wantNextPage && tUrl == TRANSITION_PREV &&
+                                           m_prevChapterLoaded && !m_prevChapterPages.empty()) {
+                                    chapterPageUrl = m_prevChapterPages.back().imageUrl;
+                                }
+
+                                if (!chapterPageUrl.empty() && target) {
+                                    m_previewPageIndex = activeIdx;
+                                    m_swipeToChapter = true;
+                                    // Update the correct side's index so the view shows
+                                    if (rawDelta > 0) m_posPreviewIdx = activeIdx;
+                                    else m_negPreviewIdx = activeIdx;
+                                    target->setRotation(static_cast<float>(m_settings.rotation));
+                                    std::weak_ptr<bool> aliveWeak = m_alive;
+                                    ImageLoader::loadAsyncFullSize(chapterPageUrl,
+                                        [aliveWeak](RotatableImage* img) {
+                                            auto alive = aliveWeak.lock();
+                                            if (!alive || !*alive) return;
+                                        }, target, m_alive);
+                                } else {
+                                    m_previewPageIndex = activeIdx;
+                                }
                             }
-
-                            if (!chapterPageUrl.empty() && previewImage) {
-                                m_previewPageIndex = previewIndex;  // mark as loaded (out of bounds value)
-                                m_swipeToChapter = true;
-                                previewImage->setRotation(static_cast<float>(m_settings.rotation));
-                                std::weak_ptr<bool> aliveWeak = m_alive;
-                                ImageLoader::loadAsyncFullSize(chapterPageUrl,
-                                    [aliveWeak](RotatableImage* img) {
-                                        auto alive = aliveWeak.lock();
-                                        if (!alive || !*alive) return;
-                                    }, previewImage, m_alive);
-                            } else {
-                                // Mark as checked to prevent re-entry on every STAY event.
-                                // Store the OOB index so previewIndex != m_previewPageIndex fails next time.
-                                m_previewPageIndex = previewIndex;
+                        } else if (activeIdx != m_previewPageIndex) {
+                            m_previewPageIndex = activeIdx;
+                            m_swipingToNext = wantNextPage;
+                            // Check if active side uses transitionBox
+                            bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
+                            m_previewIsTransition = activeIsTransition;
+                            if (activeIsTransition && transitionBox) {
+                                loadPreviewPage(activeIdx);
                             }
-
-                            brls::Logger::info("TSWIPE OOB: previewIdx={} wantNext={} swipeToChapter={}",
-                                previewIndex, wantNextPage, m_swipeToChapter);
                         }
 
                         updateSwipePreview(rawDelta);
@@ -1412,8 +1422,9 @@ void ReaderActivity::loadPage(int index) {
         }
     }
 
-    // Preload adjacent pages
+    // Preload adjacent pages (texture cache + preview views)
     preloadAdjacentPages();
+    preloadAdjacentPreviews();
 }
 
 void ReaderActivity::preloadAdjacentPages() {
@@ -2023,6 +2034,9 @@ void ReaderActivity::applySettings() {
     if (previewImage) {
         previewImage->setRotation(rotation);
     }
+    if (previewImageB) {
+        previewImageB->setRotation(rotation);
+    }
 
     // Apply rotation to webtoon scroll view if in continuous mode
     if (webtoonScroll) {
@@ -2398,51 +2412,51 @@ void ReaderActivity::renderTransitionPage(int index) {
 // NOBORU-style swipe methods
 
 void ReaderActivity::updateSwipePreview(float offset) {
-    // Update visual positions during swipe - PUSH EFFECT
-    // Uses NanoVG slide offsets (rendered inside scissor) instead of borealis
-    // translations, which don't work reliably on PSV at 90/180 rotation.
+    // 3-page carousel: positive side + current + negative side
+    // All three views slide together as a strip using NanoVG slide offsets.
+    // "Positive side" = page revealed when swiping in the positive direction (right/down)
+    // "Negative side" = page revealed when swiping in the negative direction (left/up)
     const float SCREEN_WIDTH = 960.0f;
     const float SCREEN_HEIGHT = 544.0f;
 
-    if (!previewImage) return;
-
-    // Determine which view is the "current page" being swiped away
-    bool onTransition = !m_previewIsTransition && transitionBox &&
-                        transitionBox->getVisibility() == brls::Visibility::VISIBLE;
-
-    // Show the incoming view
-    if (m_previewIsTransition) {
-        previewImage->setVisibility(brls::Visibility::GONE);
-    } else {
-        previewImage->setVisibility(brls::Visibility::VISIBLE);
-    }
-
-    // Determine swipe axis based on rotation
     bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
                              m_settings.rotation == ImageRotation::ROTATE_270);
-
     float screenExtent = useVerticalSwipe ? SCREEN_HEIGHT : SCREEN_WIDTH;
     offset = std::max(-screenExtent, std::min(screenExtent, offset));
 
-    // Calculate slide offsets
-    float slideX = useVerticalSwipe ? 0.0f : offset;
-    float slideY = useVerticalSwipe ? offset : 0.0f;
-    float incomingVal = offset > 0 ? offset - screenExtent : offset + screenExtent;
-    float inSlideX = useVerticalSwipe ? 0.0f : incomingVal;
-    float inSlideY = useVerticalSwipe ? incomingVal : 0.0f;
+    // Calculate slide offsets for the 3-page strip
+    auto makeSlide = [&](float val) -> std::pair<float,float> {
+        return useVerticalSwipe ? std::make_pair(0.0f, val) : std::make_pair(val, 0.0f);
+    };
 
-    // Move the active view (current page) with finger
+    auto [curX, curY] = makeSlide(offset);
+    auto [posX, posY] = makeSlide(offset - screenExtent);  // positive side (left/above)
+    auto [negX, negY] = makeSlide(offset + screenExtent);  // negative side (right/below)
+
+    // Current page
+    bool onTransition = transitionBox &&
+                        transitionBox->getVisibility() == brls::Visibility::VISIBLE &&
+                        isTransitionPage(m_currentPage);
     if (onTransition) {
-        transitionBox->setSlideOffset(slideX, slideY);
+        transitionBox->setSlideOffset(curX, curY);
     } else if (pageImage) {
-        pageImage->setSlideOffset(slideX, slideY);
+        pageImage->setSlideOffset(curX, curY);
     }
 
-    // Position the incoming view behind (off-screen initially, slides in)
-    if (m_previewIsTransition && transitionBox) {
-        transitionBox->setSlideOffset(inSlideX, inSlideY);
-    } else {
-        previewImage->setSlideOffset(inSlideX, inSlideY);
+    // Positive side preview
+    if (m_posIsTransition && transitionBox && !onTransition) {
+        transitionBox->setSlideOffset(posX, posY);
+    } else if (previewImage && m_posPreviewIdx >= 0) {
+        previewImage->setVisibility(brls::Visibility::VISIBLE);
+        previewImage->setSlideOffset(posX, posY);
+    }
+
+    // Negative side preview
+    if (m_negIsTransition && transitionBox && !onTransition && !m_posIsTransition) {
+        transitionBox->setSlideOffset(negX, negY);
+    } else if (previewImageB && m_negPreviewIdx >= 0) {
+        previewImageB->setVisibility(brls::Visibility::VISIBLE);
+        previewImageB->setSlideOffset(negX, negY);
     }
 }
 
@@ -2556,6 +2570,70 @@ void ReaderActivity::loadPreviewPage(int index) {
         if (!alive || !*alive) return;
         brls::Logger::debug("Preview page {} loaded", index);
     }, previewImage, m_alive);
+}
+
+void ReaderActivity::loadPreviewInto(RotatableImage* target, int index) {
+    if (!target || index < 0 || index >= static_cast<int>(m_pages.size())) return;
+    if (isTransitionPage(index)) return;  // Transition pages use transitionBox, not images
+
+    const Page& page = m_pages[index];
+    std::string imageUrl = page.imageUrl;
+
+    target->setRotation(static_cast<float>(m_settings.rotation));
+
+    std::weak_ptr<bool> aliveWeak = m_alive;
+    if (page.totalSegments > 1) {
+        ImageLoader::loadAsyncFullSizeSegment(
+            imageUrl, page.segment, page.totalSegments,
+            [aliveWeak, index](RotatableImage* img) {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+            }, target, m_alive);
+    } else {
+        ImageLoader::loadAsyncFullSize(imageUrl, [aliveWeak, index](RotatableImage* img) {
+            auto alive = aliveWeak.lock();
+            if (!alive || !*alive) return;
+        }, target, m_alive);
+    }
+}
+
+void ReaderActivity::preloadAdjacentPreviews() {
+    // Determine which page goes on the positive side (swiping right/down reveals it)
+    // and which goes on the negative side (swiping left/up reveals it).
+    bool invertDirection = (m_settings.rotation == ImageRotation::ROTATE_180 ||
+                            m_settings.rotation == ImageRotation::ROTATE_270);
+    bool isRTL = (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT);
+    // In RTL at 0° rotation, swiping positive (right) → next page
+    bool positiveIsNext = (isRTL != invertDirection);
+
+    int posIdx = positiveIsNext ? m_currentPage + 1 : m_currentPage - 1;
+    int negIdx = positiveIsNext ? m_currentPage - 1 : m_currentPage + 1;
+
+    // Load positive side
+    m_posIsTransition = false;
+    if (posIdx >= 0 && posIdx < static_cast<int>(m_pages.size())) {
+        m_posPreviewIdx = posIdx;
+        if (isTransitionPage(posIdx)) {
+            m_posIsTransition = true;
+        } else if (previewImage) {
+            loadPreviewInto(previewImage, posIdx);
+        }
+    } else {
+        m_posPreviewIdx = -1;
+    }
+
+    // Load negative side
+    m_negIsTransition = false;
+    if (negIdx >= 0 && negIdx < static_cast<int>(m_pages.size())) {
+        m_negPreviewIdx = negIdx;
+        if (isTransitionPage(negIdx)) {
+            m_negIsTransition = true;
+        } else if (previewImageB) {
+            loadPreviewInto(previewImageB, negIdx);
+        }
+    } else {
+        m_negPreviewIdx = -1;
+    }
 }
 
 void ReaderActivity::completeSwipeAnimation(bool turnPage) {
@@ -2714,12 +2792,12 @@ void ReaderActivity::resetSwipeState() {
     m_swipeOffset = 0.0f;
     m_previewPageIndex = -1;
 
-    // Reset slide offsets
+    // Reset slide offsets on all views
     if (pageImage) {
         pageImage->setSlideOffset(0.0f, 0.0f);
     }
 
-    // Reset transition box and hide if it was used as preview
+    // Reset transition box
     if (transitionBox) {
         transitionBox->setSlideOffset(0.0f, 0.0f);
         if (wasTransitionPreview && !isTransitionPage(m_currentPage)) {
@@ -2727,10 +2805,14 @@ void ReaderActivity::resetSwipeState() {
         }
     }
 
-    // Hide preview image
+    // Hide both preview images and reset offsets
     if (previewImage) {
         previewImage->setVisibility(brls::Visibility::GONE);
         previewImage->setSlideOffset(0.0f, 0.0f);
+    }
+    if (previewImageB) {
+        previewImageB->setVisibility(brls::Visibility::GONE);
+        previewImageB->setSlideOffset(0.0f, 0.0f);
     }
 }
 
@@ -2763,6 +2845,9 @@ void ReaderActivity::updateMarginColors() {
     }
     if (previewImage) {
         previewImage->setBackgroundFillColor(bgColor);
+    }
+    if (previewImageB) {
+        previewImageB->setBackgroundFillColor(bgColor);
     }
 
     // Update webtoon scroll view background

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -35,24 +35,45 @@ void RotatableBox::setRotation(float degrees) {
     this->invalidate();
 }
 
+void RotatableBox::setSlideOffset(float x, float y) {
+    m_slideX = x;
+    m_slideY = y;
+}
+
+void RotatableBox::resetSlideOffset() {
+    m_slideX = 0.0f;
+    m_slideY = 0.0f;
+}
+
 void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
-    if (m_rotationDegrees == 0.0f) {
-        Box::draw(vg, x, y, width, height, style, ctx);
-        return;
+    // Apply slide offset for swipe carousel if active
+    bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
+    if (hasSlide) {
+        nvgSave(vg);
+        nvgIntersectScissor(vg, x, y, width, height);
+        nvgTranslate(vg, m_slideX, m_slideY);
     }
 
-    nvgSave(vg);
+    if (m_rotationDegrees == 0.0f) {
+        Box::draw(vg, x, y, width, height, style, ctx);
+    } else {
+        nvgSave(vg);
 
-    float centerX = x + width / 2.0f;
-    float centerY = y + height / 2.0f;
-    nvgTranslate(vg, centerX, centerY);
-    nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
-    nvgTranslate(vg, -centerX, -centerY);
+        float centerX = x + width / 2.0f;
+        float centerY = y + height / 2.0f;
+        nvgTranslate(vg, centerX, centerY);
+        nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
+        nvgTranslate(vg, -centerX, -centerY);
 
-    Box::draw(vg, x, y, width, height, style, ctx);
+        Box::draw(vg, x, y, width, height, style, ctx);
 
-    nvgRestore(vg);
+        nvgRestore(vg);
+    }
+
+    if (hasSlide) {
+        nvgRestore(vg);
+    }
 }
 
 brls::View* RotatableBox::create() {

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -37,23 +37,31 @@ void RotatableBox::setRotation(float degrees) {
 
 void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
-    if (m_rotationDegrees == 0.0f) {
-        // No rotation - draw normally
+    bool hasSlide = (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f);
+
+    if (m_rotationDegrees == 0.0f && !hasSlide) {
+        // No rotation, no slide - draw normally
         Box::draw(vg, x, y, width, height, style, ctx);
         return;
     }
 
-    float centerX = x + width / 2.0f;
-    float centerY = y + height / 2.0f;
-
     nvgSave(vg);
 
-    // Clip to view bounds so rotated content doesn't overflow
+    // Clip to view bounds (prevents overflow from rotation AND slide)
     nvgScissor(vg, x, y, width, height);
 
-    nvgTranslate(vg, centerX, centerY);
-    nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
-    nvgTranslate(vg, -centerX, -centerY);
+    // Apply slide offset for swipe push effect
+    if (hasSlide) {
+        nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
+    }
+
+    if (m_rotationDegrees != 0.0f) {
+        float centerX = x + width / 2.0f;
+        float centerY = y + height / 2.0f;
+        nvgTranslate(vg, centerX, centerY);
+        nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
+        nvgTranslate(vg, -centerX, -centerY);
+    }
 
     Box::draw(vg, x, y, width, height, style, ctx);
 

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -48,11 +48,20 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
     nvgSave(vg);
 
     if (hasSlide) {
-        // During swipe: clip to view bounds, translate, then intersect-clip
-        // to the tile boundary so rotated content doesn't bleed across tiles
-        nvgScissor(vg, x, y, width, height);
+        // Tight clip in the swipe direction (prevents tile overlap), extended
+        // in the cross direction so content isn't cropped during swipe.
+        float clipX = x, clipY = y, clipW = width, clipH = height;
+        const float PAD = 2000.0f;
+        if (m_slideOffsetY != 0.0f && m_slideOffsetX == 0.0f) {
+            clipX -= PAD;
+            clipW += 2.0f * PAD;
+        } else if (m_slideOffsetX != 0.0f && m_slideOffsetY == 0.0f) {
+            clipY -= PAD;
+            clipH += 2.0f * PAD;
+        }
+        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-        nvgIntersectScissor(vg, x, y, width, height);
+        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
     }
 
     if (m_rotationDegrees != 0.0f) {

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -47,6 +47,10 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
     float centerY = y + height / 2.0f;
 
     nvgSave(vg);
+
+    // Clip to view bounds so rotated content doesn't overflow
+    nvgScissor(vg, x, y, width, height);
+
     nvgTranslate(vg, centerX, centerY);
     nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
     nvgTranslate(vg, -centerX, -centerY);

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -47,12 +47,12 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
 
     nvgSave(vg);
 
-    // Clip to view bounds (prevents overflow from rotation AND slide)
-    nvgScissor(vg, x, y, width, height);
-
-    // Apply slide offset for swipe push effect
     if (hasSlide) {
+        // During swipe: clip to view bounds, translate, then intersect-clip
+        // to the tile boundary so rotated content doesn't bleed across tiles
+        nvgScissor(vg, x, y, width, height);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
+        nvgIntersectScissor(vg, x, y, width, height);
     }
 
     if (m_rotationDegrees != 0.0f) {

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -51,7 +51,9 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
     bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
     if (hasSlide) {
         nvgSave(vg);
-        // Clip in swipe direction only — extend cross-axis so rotated content isn't cut
+        // Clip in swipe direction only — extend cross-axis so rotated content isn't cut.
+        // Use nvgScissor (not nvgIntersectScissor) to override the parent scissor
+        // that borealis sets at the view bounds, which would negate cross-axis extension.
         const float PAD = 4000.0f;
         float clipX = x, clipY = y, clipW = width, clipH = height;
         if (m_slideY != 0.0f && m_slideX == 0.0f) {
@@ -59,7 +61,7 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
         } else {
             clipY -= PAD; clipH += 2.0f * PAD;
         }
-        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
+        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideX, m_slideY);
     }
 

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -48,20 +48,7 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
     nvgSave(vg);
 
     if (hasSlide) {
-        // Tight clip in the swipe direction (prevents tile overlap), extended
-        // in the cross direction so content isn't cropped during swipe.
-        float clipX = x, clipY = y, clipW = width, clipH = height;
-        const float PAD = 2000.0f;
-        if (m_slideOffsetY != 0.0f && m_slideOffsetX == 0.0f) {
-            clipX -= PAD;
-            clipW += 2.0f * PAD;
-        } else if (m_slideOffsetX != 0.0f && m_slideOffsetY == 0.0f) {
-            clipY -= PAD;
-            clipH += 2.0f * PAD;
-        }
-        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
     }
 
     if (m_rotationDegrees != 0.0f) {

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -37,27 +37,18 @@ void RotatableBox::setRotation(float degrees) {
 
 void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
-    bool hasSlide = (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f);
-
-    if (m_rotationDegrees == 0.0f && !hasSlide) {
-        // No rotation, no slide - draw normally
+    if (m_rotationDegrees == 0.0f) {
         Box::draw(vg, x, y, width, height, style, ctx);
         return;
     }
 
     nvgSave(vg);
 
-    if (hasSlide) {
-        nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-    }
-
-    if (m_rotationDegrees != 0.0f) {
-        float centerX = x + width / 2.0f;
-        float centerY = y + height / 2.0f;
-        nvgTranslate(vg, centerX, centerY);
-        nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
-        nvgTranslate(vg, -centerX, -centerY);
-    }
+    float centerX = x + width / 2.0f;
+    float centerY = y + height / 2.0f;
+    nvgTranslate(vg, centerX, centerY);
+    nvgRotate(vg, m_rotationDegrees * NVG_PI / 180.0f);
+    nvgTranslate(vg, -centerX, -centerY);
 
     Box::draw(vg, x, y, width, height, style, ctx);
 

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -51,7 +51,15 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
     bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
     if (hasSlide) {
         nvgSave(vg);
-        nvgIntersectScissor(vg, x, y, width, height);
+        // Clip in swipe direction only — extend cross-axis so rotated content isn't cut
+        const float PAD = 4000.0f;
+        float clipX = x, clipY = y, clipW = width, clipH = height;
+        if (m_slideY != 0.0f && m_slideX == 0.0f) {
+            clipX -= PAD; clipW += 2.0f * PAD;
+        } else {
+            clipY -= PAD; clipH += 2.0f * PAD;
+        }
+        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideX, m_slideY);
     }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -143,18 +143,20 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // Save state and clip to view bounds FIRST (before any slide offset)
-    // This ensures the push effect is properly clipped
-    nvgSave(vg);
-    nvgScissor(vg, x, y, width, height);
+    bool hasSlide = (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f);
 
-    // Apply slide offset for swipe push effect
-    // Content slides within the clipped view bounds
-    if (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f) {
+    nvgSave(vg);
+
+    if (hasSlide) {
+        // During swipe: clip to view bounds, translate, then intersect-clip to
+        // the translated view bounds (= tile boundary).  This prevents rotated
+        // image content from bleeding into adjacent carousel tiles at 90/270°.
+        nvgScissor(vg, x, y, width, height);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
+        nvgIntersectScissor(vg, x, y, width, height);
     }
 
-    // Draw the background to fill margins (inside scissor + slide)
+    // Draw the background to fill margins
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
     nvgFillColor(vg, m_bgColor);
@@ -228,7 +230,7 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
         nvgFill(vg);
     }
 
-    // Restore state (removes scissor, slide offset, and rotation)
+    // Restore state (removes scissor, slide offset, rotation transforms)
     nvgRestore(vg);
 }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -143,7 +143,18 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // First draw the background to fill margins
+    // Save state and clip to view bounds FIRST (before any slide offset)
+    // This ensures the push effect is properly clipped
+    nvgSave(vg);
+    nvgScissor(vg, x, y, width, height);
+
+    // Apply slide offset for swipe push effect
+    // Content slides within the clipped view bounds
+    if (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f) {
+        nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
+    }
+
+    // Draw the background to fill margins (inside scissor + slide)
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
     nvgFillColor(vg, m_bgColor);
@@ -151,18 +162,13 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
 
     // If no image, just show background
     if (m_nvgImage == 0 || m_imageWidth <= 0 || m_imageHeight <= 0) {
+        nvgRestore(vg);
         return;
     }
 
     // Calculate where the image should be drawn (accounts for rotation)
     float imgX, imgY, imgW, imgH;
     calculateImageBounds(x, y, width, height, imgX, imgY, imgW, imgH);
-
-    // Save state
-    nvgSave(vg);
-
-    // Use scissor to clip rendering to the view bounds (not calculated bounds when zoomed)
-    nvgScissor(vg, x, y, width, height);
 
     // Calculate center of the destination area
     float centerX = imgX + imgW / 2.0f;
@@ -222,7 +228,7 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
         nvgFill(vg);
     }
 
-    // Restore state (removes scissor and rotation)
+    // Restore state (removes scissor, slide offset, and rotation)
     nvgRestore(vg);
 }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -145,6 +145,18 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
                           brls::Style style, brls::FrameContext* ctx) {
     nvgSave(vg);
 
+    // Clip to the view's original bounds BEFORE applying the slide offset.
+    // This ensures each page only renders in its designated screen area
+    // and pages can't overlap during swipe carousel transitions.
+    nvgIntersectScissor(vg, x, y, width, height);
+
+    // Apply slide offset via NanoVG translate for swipe carousel.
+    // This bypasses borealis setTranslationX/Y which doesn't reliably
+    // move NanoVG rendering on all platforms (e.g. PS Vita GXM backend).
+    if (m_slideX != 0.0f || m_slideY != 0.0f) {
+        nvgTranslate(vg, m_slideX, m_slideY);
+    }
+
     // Draw the background to fill margins
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
@@ -270,6 +282,36 @@ void RotatableImage::resetZoom() {
     m_zoomLevel = 1.0f;
     m_zoomOffset = {0, 0};
     this->invalidate();
+}
+
+void RotatableImage::setSlideOffset(float x, float y) {
+    m_slideX = x;
+    m_slideY = y;
+}
+
+void RotatableImage::resetSlideOffset() {
+    m_slideX = 0.0f;
+    m_slideY = 0.0f;
+}
+
+void RotatableImage::takeImageFrom(RotatableImage* source) {
+    if (!source) return;
+
+    // Clear our current image
+    clearImage();
+
+    // Transfer the NVG image handle and dimensions
+    m_nvgImage = source->m_nvgImage;
+    m_imageWidth = source->m_imageWidth;
+    m_imageHeight = source->m_imageHeight;
+
+    // Clear the source without deleting the NVG image (we own it now)
+    source->m_nvgImage = 0;
+    source->m_imageWidth = 0;
+    source->m_imageHeight = 0;
+
+    this->invalidate();
+    source->invalidate();
 }
 
 brls::View* RotatableImage::create() {

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -145,15 +145,33 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
                           brls::Style style, brls::FrameContext* ctx) {
     nvgSave(vg);
 
-    // Clip to the view's original bounds BEFORE applying the slide offset.
-    // This ensures each page only renders in its designated screen area
-    // and pages can't overlap during swipe carousel transitions.
-    nvgIntersectScissor(vg, x, y, width, height);
+    bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
 
-    // Apply slide offset via NanoVG translate for swipe carousel.
-    // This bypasses borealis setTranslationX/Y which doesn't reliably
-    // move NanoVG rendering on all platforms (e.g. PS Vita GXM backend).
-    if (m_slideX != 0.0f || m_slideY != 0.0f) {
+    if (hasSlide) {
+        // Debug: log draw coords and slide offsets (throttled to avoid spam)
+        static int s_drawLogCounter = 0;
+        if ((s_drawLogCounter++ % 180) == 0) {  // ~every 3 seconds at 60fps
+            brls::Logger::info("DRAW slideX={:.0f} slideY={:.0f} x={:.0f} y={:.0f} "
+                "w={:.0f} h={:.0f} rot={:.0f} img={}x{}",
+                m_slideX, m_slideY, x, y, width, height,
+                m_rotationDegrees, m_imageWidth, m_imageHeight);
+        }
+
+        // During swipe: clip in the SWIPE direction only to prevent pages
+        // from overlapping each other. The cross-axis is left unclipped
+        // so wide/tall images (FIT_WIDTH, FIT_HEIGHT, rotated) aren't cut off.
+        const float PAD = 4000.0f;
+        float clipX = x, clipY = y, clipW = width, clipH = height;
+        if (m_slideY != 0.0f && m_slideX == 0.0f) {
+            // Vertical swipe (90/270 rotation): keep Y tight, extend X
+            clipX -= PAD;
+            clipW += 2.0f * PAD;
+        } else {
+            // Horizontal swipe (0/180 rotation): keep X tight, extend Y
+            clipY -= PAD;
+            clipH += 2.0f * PAD;
+        }
+        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideX, m_slideY);
     }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -148,24 +148,7 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     nvgSave(vg);
 
     if (hasSlide) {
-        // Build a clip rect that is tight in the swipe direction (prevents
-        // tiles from overlapping) but extended in the cross direction so that
-        // images which naturally extend beyond the view (FIT_WIDTH, wide
-        // images, rotated images) aren't cropped differently during a swipe.
-        float clipX = x, clipY = y, clipW = width, clipH = height;
-        const float PAD = 2000.0f;
-        if (m_slideOffsetY != 0.0f && m_slideOffsetX == 0.0f) {
-            // Vertical swipe (90°/270°): keep Y tight, extend X
-            clipX -= PAD;
-            clipW += 2.0f * PAD;
-        } else if (m_slideOffsetX != 0.0f && m_slideOffsetY == 0.0f) {
-            // Horizontal swipe (0°/180°): keep X tight, extend Y
-            clipY -= PAD;
-            clipH += 2.0f * PAD;
-        }
-        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
     }
 
     // Draw the background to fill margins

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -148,12 +148,24 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     nvgSave(vg);
 
     if (hasSlide) {
-        // During swipe: clip to view bounds, translate, then intersect-clip to
-        // the translated view bounds (= tile boundary).  This prevents rotated
-        // image content from bleeding into adjacent carousel tiles at 90/270°.
-        nvgScissor(vg, x, y, width, height);
+        // Build a clip rect that is tight in the swipe direction (prevents
+        // tiles from overlapping) but extended in the cross direction so that
+        // images which naturally extend beyond the view (FIT_WIDTH, wide
+        // images, rotated images) aren't cropped differently during a swipe.
+        float clipX = x, clipY = y, clipW = width, clipH = height;
+        const float PAD = 2000.0f;
+        if (m_slideOffsetY != 0.0f && m_slideOffsetX == 0.0f) {
+            // Vertical swipe (90°/270°): keep Y tight, extend X
+            clipX -= PAD;
+            clipW += 2.0f * PAD;
+        } else if (m_slideOffsetX != 0.0f && m_slideOffsetY == 0.0f) {
+            // Horizontal swipe (0°/180°): keep X tight, extend Y
+            clipY -= PAD;
+            clipH += 2.0f * PAD;
+        }
+        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-        nvgIntersectScissor(vg, x, y, width, height);
+        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
     }
 
     // Draw the background to fill margins

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -143,13 +143,7 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    bool hasSlide = (m_slideOffsetX != 0.0f || m_slideOffsetY != 0.0f);
-
     nvgSave(vg);
-
-    if (hasSlide) {
-        nvgTranslate(vg, m_slideOffsetX, m_slideOffsetY);
-    }
 
     // Draw the background to fill margins
     nvgBeginPath(vg);

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -160,6 +160,11 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
         // During swipe: clip in the SWIPE direction only to prevent pages
         // from overlapping each other. The cross-axis is left unclipped
         // so wide/tall images (FIT_WIDTH, FIT_HEIGHT, rotated) aren't cut off.
+        //
+        // Use nvgScissor (not nvgIntersectScissor) because borealis sets a
+        // parent scissor at the view bounds. nvgIntersectScissor would intersect
+        // with that parent scissor, negating our cross-axis extension and
+        // cutting off images that extend beyond the view.
         const float PAD = 4000.0f;
         float clipX = x, clipY = y, clipW = width, clipH = height;
         if (m_slideY != 0.0f && m_slideX == 0.0f) {
@@ -171,7 +176,7 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
             clipY -= PAD;
             clipH += 2.0f * PAD;
         }
-        nvgIntersectScissor(vg, clipX, clipY, clipW, clipH);
+        nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideX, m_slideY);
     }
 


### PR DESCRIPTION
Fixes swipe-preview overlap and page cutoff at rotated orientations, ultimately using NanoVG slide offsets with directional scissor clipping and a 3-page carousel of pre-loaded adjacent pages.

---
_Generated by [Claude Code](https://claude.ai/code)_