### PR TITLE
Add transition pages and failed page retry to webtoon mode

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -273,6 +273,7 @@ private:
     bool isTransitionPage(int index) const;
     void insertTransitionPages();
     void renderTransitionPage(int index);
+    void setupWebtoonTransitionText();  // Set transition text on webtoon scroll view
     int m_realPageCount = 0;  // Actual page count excluding transition pages
 
     // Guard flag: prevents slider callback from firing during programmatic setProgress

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -274,6 +274,7 @@ private:
     void insertTransitionPages();
     void renderTransitionPage(int index);
     void setupWebtoonTransitionText();  // Set transition text on webtoon scroll view
+    void webtoonExtendChapter(bool next);  // Smoothly append/prepend chapter in webtoon mode
     int m_realPageCount = 0;  // Actual page count excluding transition pages
 
     // Guard flag: prevents slider callback from firing during programmatic setProgress

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -191,6 +191,10 @@ private:
     float m_scrollAtTouchStart = 0.0f;
     std::chrono::steady_clock::time_point m_lastTouchTime;
 
+    // Overscroll tracking for auto chapter navigation
+    float m_overscrollAmount = 0.0f;      // Accumulated overscroll past boundary
+    bool m_overscrollTriggered = false;    // Prevents repeated triggers
+
     // Page tracking
     int m_currentPage = 0;
     std::set<int> m_loadedPages;      // Pages that have been loaded
@@ -236,6 +240,9 @@ private:
 
     // Failed page height (shows error message + retry)
     static constexpr float FAILED_PAGE_HEIGHT = 150.0f;
+
+    // Overscroll threshold to trigger chapter navigation (in view coords)
+    static constexpr float OVERSCROLL_THRESHOLD = 80.0f;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -8,8 +8,10 @@
 #include <borealis.hpp>
 #include <vector>
 #include <set>
+#include <map>
 #include <functional>
 #include <memory>
+#include <string>
 #include "view/rotatable_image.hpp"
 #include "app/suwayomi_client.hpp"
 
@@ -20,6 +22,13 @@ using ScrollProgressCallback = std::function<void(int currentPage, int totalPage
 
 // Callback when user taps (for toggling controls)
 using TapCallback = std::function<void()>;
+
+// Callback when user taps a transition page to navigate chapters
+// Parameter: true = next chapter, false = previous chapter
+using ChapterNavigateCallback = std::function<void(bool next)>;
+
+// Callback to retry loading a specific page
+using RetryPageCallback = std::function<void(int pageIndex)>;
 
 class WebtoonScrollView : public brls::Box {
 public:
@@ -67,6 +76,24 @@ public:
      * Set callback for tap gesture (to toggle controls)
      */
     void setTapCallback(TapCallback callback) { m_tapCallback = callback; }
+
+    /**
+     * Set callback for chapter navigation (transition page tap)
+     */
+    void setChapterNavigateCallback(ChapterNavigateCallback callback) { m_chapterNavigateCallback = callback; }
+
+    /**
+     * Set callback for page retry
+     */
+    void setRetryPageCallback(RetryPageCallback callback) { m_retryPageCallback = callback; }
+
+    /**
+     * Set transition page text (called by reader activity when setting up pages)
+     * @param pageIndex Index of the transition page
+     * @param line1 First line of text (e.g. "End of: Chapter 5")
+     * @param line2 Second line of text (e.g. "Next: Chapter 6")
+     */
+    void setTransitionText(int pageIndex, const std::string& line1, const std::string& line2);
 
     /**
      * Set side padding percentage (0-20)
@@ -126,6 +153,21 @@ private:
     // Apply momentum scrolling
     void applyMomentum();
 
+    // Check if a page is a transition page (chapter separator)
+    bool isTransitionPage(int pageIndex) const;
+
+    // Check if a page failed to load
+    bool isFailedPage(int pageIndex) const;
+
+    // Draw a transition page (chapter separator)
+    void drawTransitionPage(NVGcontext* vg, int pageIndex, float x, float y, float width, float height);
+
+    // Draw a failed page with retry prompt
+    void drawFailedPage(NVGcontext* vg, int pageIndex, float x, float y, float width, float height);
+
+    // Find which page a tap landed on (returns -1 if none)
+    int getPageAtPosition(float tapX, float tapY) const;
+
     // Pages data
     std::vector<Page> m_pages;
 
@@ -153,6 +195,15 @@ private:
     int m_currentPage = 0;
     std::set<int> m_loadedPages;      // Pages that have been loaded
     std::set<int> m_loadingPages;     // Pages currently being loaded
+    std::set<int> m_failedPages;      // Pages that failed to load
+
+    // Transition page data
+    struct TransitionInfo {
+        std::string line1;
+        std::string line2;
+        bool isNext = true;  // true = next chapter, false = previous chapter
+    };
+    std::map<int, TransitionInfo> m_transitionInfo;
 
     // Layout
     NVGcolor m_bgColor = nvgRGBA(26, 26, 46, 255);  // Background color (default dark)
@@ -164,6 +215,8 @@ private:
     // Callbacks
     ScrollProgressCallback m_progressCallback;
     TapCallback m_tapCallback;
+    ChapterNavigateCallback m_chapterNavigateCallback;
+    RetryPageCallback m_retryPageCallback;
 
     // Alive flag for async callback safety (cleared in clearPages/destructor)
     std::shared_ptr<bool> m_alive = std::make_shared<bool>(true);
@@ -177,6 +230,12 @@ private:
 
     // Touch thresholds
     static constexpr float TAP_THRESHOLD = 15.0f;
+
+    // Transition page height (fixed size for chapter separators)
+    static constexpr float TRANSITION_PAGE_HEIGHT = 200.0f;
+
+    // Failed page height (shows error message + retry)
+    static constexpr float FAILED_PAGE_HEIGHT = 150.0f;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -48,6 +48,20 @@ public:
     void clearPages();
 
     /**
+     * Append pages at the end (for seamless next chapter loading)
+     * Removes the trailing transition page, appends new pages.
+     * Scroll position stays the same so the user keeps scrolling naturally.
+     */
+    void appendPages(const std::vector<Page>& pages);
+
+    /**
+     * Prepend pages at the beginning (for seamless prev chapter loading)
+     * Removes the leading transition page, prepends new pages.
+     * Adjusts scroll position so the view doesn't jump.
+     */
+    void prependPages(const std::vector<Page>& pages);
+
+    /**
      * Scroll to a specific page index
      */
     void scrollToPage(int pageIndex);
@@ -129,7 +143,7 @@ private:
     // Setup touch gestures for scrolling
     void setupGestures();
 
-    // Load images that are visible or near visible
+    // Load images that are visible or near visible, unload distant ones
     void updateVisibleImages();
 
     // Check if a page is in the visible range
@@ -227,6 +241,9 @@ private:
 
     // Preload buffer - how many pages ahead/behind to load
     static constexpr int PRELOAD_PAGES = 3;
+
+    // Unload buffer - pages beyond this distance from visible area get their images freed
+    static constexpr int UNLOAD_PAGES = 8;
 
     // Momentum friction
     static constexpr float MOMENTUM_FRICTION = 0.95f;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1295,14 +1295,11 @@ void ReaderActivity::loadPages() {
                 });
 
                 // Set up chapter navigation callback for transition pages
+                // Use smooth extend (append/prepend) instead of full chapter replacement
                 webtoonScroll->setChapterNavigateCallback([this, cbAlive](bool next) {
                     auto a = cbAlive.lock();
                     if (!a || !*a) return;
-                    if (next) {
-                        nextChapter();
-                    } else {
-                        previousChapter();
-                    }
+                    webtoonExtendChapter(next);
                 });
 
                 // Load all pages into the scroll view
@@ -2447,6 +2444,205 @@ void ReaderActivity::setupWebtoonTransitionText() {
     }
 }
 
+void ReaderActivity::webtoonExtendChapter(bool next) {
+    if (!webtoonScroll) {
+        // Fallback if webtoon scroll not available
+        if (next) nextChapter(); else previousChapter();
+        return;
+    }
+
+    if (next) {
+        brls::Logger::info("WEBTOON_EXTEND: next chapter, chapterPos={}/{} preloaded={}",
+                           m_chapterPosition, m_totalChapters, m_nextChapterLoaded);
+
+        if (m_chapterPosition < 0 || m_chapterPosition >= m_totalChapters - 1 ||
+            m_chapterPosition + 1 >= static_cast<int>(m_chapters.size())) {
+            return;  // No next chapter
+        }
+
+        // Get next chapter pages (preloaded or fetch)
+        std::vector<Page> newPages;
+        if (m_nextChapterLoaded && !m_nextChapterPages.empty()) {
+            newPages = std::move(m_nextChapterPages);
+            m_nextChapterLoaded = false;
+            m_nextChapterPages.clear();
+        } else {
+            // Not preloaded - fall back to full chapter load
+            nextChapter();
+            return;
+        }
+
+        // Mark current chapter as read and advance
+        markChapterAsRead();
+        m_chapterPosition++;
+        m_chapterIndex = m_chapters[m_chapterPosition].id;
+        m_chapterName = m_chapters[m_chapterPosition].name;
+        m_prevChapterLoaded = false;
+        m_prevChapterPages.clear();
+
+        // Build the pages to append:
+        // - The new chapter's real pages
+        // - A transition page at the end (next or end)
+        std::vector<Page> appendList = std::move(newPages);
+
+        // Add end transition
+        Page endPage;
+        if (m_chapterPosition < m_totalChapters - 1) {
+            endPage.imageUrl = TRANSITION_NEXT;
+        } else {
+            endPage.imageUrl = TRANSITION_END;
+        }
+        endPage.index = -1;
+        appendList.push_back(endPage);
+
+        // Remember where new pages start in the webtoon view
+        int newStartIdx = webtoonScroll->getPageCount();
+        // The appendPages call will remove the old trailing transition,
+        // so the new pages start at (old count - 1)
+        newStartIdx = std::max(0, newStartIdx - 1);
+
+        // Append to webtoon scroll view (removes old trailing transition, adds new pages)
+        webtoonScroll->appendPages(appendList);
+
+        // Update m_pages to match webtoon view's state is not needed for webtoon mode
+        // (webtoon view manages its own page list), but update chapter metadata
+
+        // Set transition text for the newly appended pages
+        std::string currentChapterDisplay = m_chapterName.empty() ?
+            "Chapter " + getChapterDisplayNumber() : m_chapterName;
+
+        for (int i = newStartIdx; i < webtoonScroll->getPageCount(); i++) {
+            // Only set text for transition pages in the new section
+            // Check by attempting to set - the view will ignore non-transition pages
+            if (i == webtoonScroll->getPageCount() - 1) {
+                // Last page is the end/next transition
+                std::string line1 = "End of: " + currentChapterDisplay;
+                std::string line2;
+                if (m_chapterPosition < m_totalChapters - 1) {
+                    const Chapter& nextCh = m_chapters[m_chapterPosition + 1];
+                    std::string nextName = nextCh.name;
+                    if (nextName.empty()) {
+                        float num = nextCh.chapterNumber;
+                        if (num == static_cast<int>(num))
+                            nextName = "Chapter " + std::to_string(static_cast<int>(num));
+                        else {
+                            char buf[32];
+                            snprintf(buf, sizeof(buf), "Chapter %.1f", num);
+                            nextName = buf;
+                        }
+                    }
+                    line2 = "Next: " + nextName;
+                } else {
+                    line2 = "You've reached the end!";
+                }
+                webtoonScroll->setTransitionText(i, line1, line2);
+            }
+        }
+
+        // Update UI labels
+        if (chapterLabel) {
+            std::string label = m_chapterName.empty() ?
+                "Chapter " + getChapterDisplayNumber() : m_chapterName;
+            chapterLabel->setText(label);
+        }
+        if (chapterProgress) {
+            chapterProgress->setText("Ch. " + getChapterDisplayNumber() +
+                                     " of " + std::to_string(m_totalChapters));
+        }
+
+        // Start preloading next adjacent chapters
+        preloadNextChapter();
+        preloadPrevChapter();
+
+    } else {
+        brls::Logger::info("WEBTOON_EXTEND: prev chapter, chapterPos={}/{} preloaded={}",
+                           m_chapterPosition, m_totalChapters, m_prevChapterLoaded);
+
+        if (m_chapterPosition <= 0 ||
+            m_chapterPosition - 1 >= static_cast<int>(m_chapters.size())) {
+            return;  // No previous chapter
+        }
+
+        // Get prev chapter pages (preloaded or fetch)
+        std::vector<Page> newPages;
+        if (m_prevChapterLoaded && !m_prevChapterPages.empty()) {
+            newPages = std::move(m_prevChapterPages);
+            m_prevChapterLoaded = false;
+            m_prevChapterPages.clear();
+        } else {
+            // Not preloaded - fall back to full chapter load
+            previousChapter();
+            return;
+        }
+
+        // Go to previous chapter
+        m_chapterPosition--;
+        m_chapterIndex = m_chapters[m_chapterPosition].id;
+        m_chapterName = m_chapters[m_chapterPosition].name;
+        m_nextChapterLoaded = false;
+        m_nextChapterPages.clear();
+
+        // Build the pages to prepend:
+        // - A transition page at the start (prev) if there's a further previous chapter
+        // - The new chapter's real pages
+        std::vector<Page> prependList;
+
+        if (m_chapterPosition > 0) {
+            Page prevPage;
+            prevPage.imageUrl = TRANSITION_PREV;
+            prevPage.index = -1;
+            prependList.push_back(prevPage);
+        }
+
+        // Append the chapter's real pages
+        for (auto& p : newPages) {
+            prependList.push_back(p);
+        }
+
+        // Prepend to webtoon scroll view (removes old leading transition, adds new pages)
+        webtoonScroll->prependPages(prependList);
+
+        // Set transition text for the newly prepended pages
+        std::string currentChapterDisplay = m_chapterName.empty() ?
+            "Chapter " + getChapterDisplayNumber() : m_chapterName;
+
+        if (m_chapterPosition > 0) {
+            // First page is the prev transition
+            std::string line1 = "Beginning of: " + currentChapterDisplay;
+            std::string line2;
+            const Chapter& prevCh = m_chapters[m_chapterPosition - 1];
+            std::string prevName = prevCh.name;
+            if (prevName.empty()) {
+                float num = prevCh.chapterNumber;
+                if (num == static_cast<int>(num))
+                    prevName = "Chapter " + std::to_string(static_cast<int>(num));
+                else {
+                    char buf[32];
+                    snprintf(buf, sizeof(buf), "Chapter %.1f", num);
+                    prevName = buf;
+                }
+            }
+            line2 = "Previous: " + prevName;
+            webtoonScroll->setTransitionText(0, line1, line2);
+        }
+
+        // Update UI labels
+        if (chapterLabel) {
+            std::string label = m_chapterName.empty() ?
+                "Chapter " + getChapterDisplayNumber() : m_chapterName;
+            chapterLabel->setText(label);
+        }
+        if (chapterProgress) {
+            chapterProgress->setText("Ch. " + getChapterDisplayNumber() +
+                                     " of " + std::to_string(m_totalChapters));
+        }
+
+        // Start preloading adjacent chapters
+        preloadNextChapter();
+        preloadPrevChapter();
+    }
+}
+
 // NOBORU-style swipe methods
 
 void ReaderActivity::updateSwipePreview(float offset) {
@@ -3065,14 +3261,11 @@ void ReaderActivity::updateReaderMode() {
             });
 
             // Set up chapter navigation callback for transition pages
+            // Use smooth extend (append/prepend) instead of full chapter replacement
             webtoonScroll->setChapterNavigateCallback([this, cbAlive](bool next) {
                 auto a = cbAlive.lock();
                 if (!a || !*a) return;
-                if (next) {
-                    nextChapter();
-                } else {
-                    previousChapter();
-                }
+                webtoonExtendChapter(next);
             });
 
             // Load pages into the scroll view

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1294,12 +1294,27 @@ void ReaderActivity::loadPages() {
                     toggleControls();
                 });
 
+                // Set up chapter navigation callback for transition pages
+                webtoonScroll->setChapterNavigateCallback([this, cbAlive](bool next) {
+                    auto a = cbAlive.lock();
+                    if (!a || !*a) return;
+                    if (next) {
+                        nextChapter();
+                    } else {
+                        previousChapter();
+                    }
+                });
+
                 // Load all pages into the scroll view
                 // Use actual view width (internal rendering coords, ~1280) rather than
                 // physical screen width (960) to avoid coordinate system mismatch.
                 float viewW = webtoonScroll->getWidth();
                 if (viewW <= 0) viewW = container ? container->getWidth() : 960.0f;
                 webtoonScroll->setPages(m_pages, viewW);
+
+                // Set transition text for chapter separator pages
+                setupWebtoonTransitionText();
+
                 webtoonScroll->scrollToPage(m_currentPage);
             }
         } else {
@@ -1622,6 +1637,7 @@ void ReaderActivity::nextChapter() {
                 float viewW = webtoonScroll->getWidth();
                 if (viewW <= 0) viewW = container ? container->getWidth() : 960.0f;
                 webtoonScroll->setPages(m_pages, viewW);
+                setupWebtoonTransitionText();
                 webtoonScroll->scrollToPage(m_currentPage);
             } else {
                 loadPage(m_currentPage);
@@ -1694,6 +1710,7 @@ void ReaderActivity::previousChapter() {
                 float viewW = webtoonScroll->getWidth();
                 if (viewW <= 0) viewW = container ? container->getWidth() : 960.0f;
                 webtoonScroll->setPages(m_pages, viewW);
+                setupWebtoonTransitionText();
                 webtoonScroll->scrollToPage(m_currentPage);
             } else {
                 loadPage(m_currentPage);
@@ -2375,6 +2392,61 @@ void ReaderActivity::renderTransitionPage(int index) {
     brls::Application::giveFocus(transitionBox);
 }
 
+void ReaderActivity::setupWebtoonTransitionText() {
+    if (!webtoonScroll) return;
+
+    std::string currentChapterDisplay = m_chapterName.empty() ?
+        "Chapter " + getChapterDisplayNumber() : m_chapterName;
+
+    for (int i = 0; i < static_cast<int>(m_pages.size()); i++) {
+        if (!isTransitionPage(i)) continue;
+
+        const std::string& url = m_pages[i].imageUrl;
+        std::string line1, line2;
+
+        if (url == TRANSITION_NEXT) {
+            line1 = "End of: " + currentChapterDisplay;
+            if (m_chapterPosition >= 0 && m_chapterPosition < m_totalChapters - 1) {
+                const Chapter& nextCh = m_chapters[m_chapterPosition + 1];
+                std::string nextName = nextCh.name;
+                if (nextName.empty()) {
+                    float num = nextCh.chapterNumber;
+                    if (num == static_cast<int>(num))
+                        nextName = "Chapter " + std::to_string(static_cast<int>(num));
+                    else {
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), "Chapter %.1f", num);
+                        nextName = buf;
+                    }
+                }
+                line2 = "Next: " + nextName;
+            }
+        } else if (url == TRANSITION_PREV) {
+            line1 = "Beginning of: " + currentChapterDisplay;
+            if (m_chapterPosition > 0) {
+                const Chapter& prevCh = m_chapters[m_chapterPosition - 1];
+                std::string prevName = prevCh.name;
+                if (prevName.empty()) {
+                    float num = prevCh.chapterNumber;
+                    if (num == static_cast<int>(num))
+                        prevName = "Chapter " + std::to_string(static_cast<int>(num));
+                    else {
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), "Chapter %.1f", num);
+                        prevName = buf;
+                    }
+                }
+                line2 = "Previous: " + prevName;
+            }
+        } else if (url == TRANSITION_END) {
+            line1 = "End of: " + currentChapterDisplay;
+            line2 = "You've reached the end!";
+        }
+
+        webtoonScroll->setTransitionText(i, line1, line2);
+    }
+}
+
 // NOBORU-style swipe methods
 
 void ReaderActivity::updateSwipePreview(float offset) {
@@ -2992,11 +3064,23 @@ void ReaderActivity::updateReaderMode() {
                 toggleControls();
             });
 
+            // Set up chapter navigation callback for transition pages
+            webtoonScroll->setChapterNavigateCallback([this, cbAlive](bool next) {
+                auto a = cbAlive.lock();
+                if (!a || !*a) return;
+                if (next) {
+                    nextChapter();
+                } else {
+                    previousChapter();
+                }
+            });
+
             // Load pages into the scroll view
             if (!m_pages.empty()) {
                 float viewW = webtoonScroll->getWidth();
                 if (viewW <= 0) viewW = container ? container->getWidth() : 960.0f;
                 webtoonScroll->setPages(m_pages, viewW);
+                setupWebtoonTransitionText();
                 webtoonScroll->scrollToPage(m_currentPage);
             }
         }

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -317,16 +317,62 @@ static std::vector<uint8_t> convertImageToTGA(const uint8_t* data, size_t dataSi
 
 // Helper function to convert WebP to TGA format with downscaling
 static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t webpSize, int maxSize) {
-    std::vector<uint8_t> tgaData;
-
-    int width, height;
-    if (!WebPGetInfo(webpData, webpSize, &width, &height)) {
-        return tgaData;
+    // Use WebPGetFeatures for detailed error info instead of just WebPGetInfo
+    WebPBitstreamFeatures features;
+    VP8StatusCode status = WebPGetFeatures(webpData, webpSize, &features);
+    if (status != VP8_STATUS_OK) {
+        brls::Logger::error("ImageLoader: WebPGetFeatures failed (status={}, dataSize={})",
+                            static_cast<int>(status), webpSize);
+        return {};
     }
 
+    int width = features.width;
+    int height = features.height;
+    brls::Logger::debug("ImageLoader: WebP {}x{} hasAlpha={} format={}",
+                        width, height, features.has_alpha, features.format);
+
+    if (width <= 0 || height <= 0) {
+        brls::Logger::error("ImageLoader: WebP has invalid dimensions {}x{}", width, height);
+        return {};
+    }
+
+    // Try RGBA decode first
     uint8_t* rgba = WebPDecodeRGBA(webpData, webpSize, &width, &height);
     if (!rgba) {
-        return tgaData;
+        // RGBA decode failed - try RGB (uses less memory) and add alpha manually
+        brls::Logger::warning("ImageLoader: WebPDecodeRGBA failed for {}x{}, trying RGB fallback", width, height);
+        uint8_t* rgb = WebPDecodeRGB(webpData, webpSize, &width, &height);
+        if (!rgb) {
+            brls::Logger::error("ImageLoader: WebP decode completely failed for {}x{} ({}KB data)",
+                                width, height, webpSize / 1024);
+            return {};
+        }
+
+        // Convert RGB to RGBA
+        size_t pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+        std::vector<uint8_t> rgbaVec(pixelCount * 4);
+        for (size_t i = 0; i < pixelCount; i++) {
+            rgbaVec[i * 4 + 0] = rgb[i * 3 + 0];
+            rgbaVec[i * 4 + 1] = rgb[i * 3 + 1];
+            rgbaVec[i * 4 + 2] = rgb[i * 3 + 2];
+            rgbaVec[i * 4 + 3] = 255;
+        }
+        WebPFree(rgb);
+
+        int targetW = width;
+        int targetH = height;
+        if (maxSize > 0 && (width > maxSize || height > maxSize)) {
+            float scale = (float)maxSize / std::max(width, height);
+            targetW = std::max(1, (int)(width * scale));
+            targetH = std::max(1, (int)(height * scale));
+        }
+
+        if (targetW != width || targetH != height) {
+            std::vector<uint8_t> scaledRgba(targetW * targetH * 4);
+            downscaleRGBA(rgbaVec.data(), width, height, scaledRgba.data(), targetW, targetH);
+            return createTGAFromRGBA(scaledRgba.data(), targetW, targetH);
+        }
+        return createTGAFromRGBA(rgbaVec.data(), targetW, targetH);
     }
 
     int targetW = width;
@@ -347,27 +393,7 @@ static std::vector<uint8_t> convertWebPtoTGA(const uint8_t* webpData, size_t web
         finalRgba = scaledRgba.data();
     }
 
-    size_t imageSize = targetW * targetH * 4;
-    tgaData.resize(18 + imageSize);
-
-    uint8_t* header = tgaData.data();
-    memset(header, 0, 18);
-    header[2] = 2;
-    header[12] = targetW & 0xFF;
-    header[13] = (targetW >> 8) & 0xFF;
-    header[14] = targetH & 0xFF;
-    header[15] = (targetH >> 8) & 0xFF;
-    header[16] = 32;
-    header[17] = 0x28;
-
-    uint8_t* pixels = tgaData.data() + 18;
-    for (int i = 0; i < targetW * targetH; i++) {
-        pixels[i * 4 + 0] = finalRgba[i * 4 + 2];  // B
-        pixels[i * 4 + 1] = finalRgba[i * 4 + 1];  // G
-        pixels[i * 4 + 2] = finalRgba[i * 4 + 0];  // R
-        pixels[i * 4 + 3] = finalRgba[i * 4 + 3];  // A
-    }
-
+    auto tgaData = createTGAFromRGBA(finalRgba, targetW, targetH);
     WebPFree(rgba);
     return tgaData;
 }
@@ -952,8 +978,19 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
                 );
             }
             if (imageData.empty()) {
-                brls::Logger::error("ImageLoader: WebP conversion failed for {}", url);
-                return;
+                // WebP decode failed - fall back to stb_image in case format was
+                // misidentified or stb can handle this particular encoding
+                brls::Logger::warning("ImageLoader: WebP conversion failed for {}, trying stb_image fallback", url);
+                imageData = convertImageToTGA(
+                    reinterpret_cast<const uint8_t*>(imageBody.data()),
+                    imageBody.size(),
+                    MAX_TEXTURE_SIZE
+                );
+                if (imageData.empty()) {
+                    brls::Logger::error("ImageLoader: All decode attempts failed for {}", url);
+                    return;
+                }
+                brls::Logger::info("ImageLoader: stb_image fallback succeeded for {}", url);
             }
         } else if (isJpegOrPng) {
             if (totalSegments > 1) {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -390,6 +390,191 @@ void WebtoonScrollView::clearPages() {
     m_currentPage = 0;
 }
 
+void WebtoonScrollView::appendPages(const std::vector<Page>& pages) {
+    if (pages.empty()) return;
+
+    float availableWidth = m_viewWidth - (m_sidePadding * 2);
+    float defaultHeight = availableWidth * 1.5f;
+
+    // Remove trailing transition page if present
+    if (!m_pages.empty() && isTransitionPage(static_cast<int>(m_pages.size()) - 1)) {
+        int lastIdx = static_cast<int>(m_pages.size()) - 1;
+        float removedSize = getEffectivePageSize(lastIdx);
+        m_totalHeight -= removedSize;
+        if (lastIdx > 0) m_totalHeight -= m_pageGap;  // Remove gap before removed page
+
+        m_pages.pop_back();
+        m_pageImages.pop_back();
+        m_pageHeights.pop_back();
+        m_loadedPages.erase(lastIdx);
+        m_loadingPages.erase(lastIdx);
+        m_transitionInfo.erase(lastIdx);
+    }
+
+    int startIdx = static_cast<int>(m_pages.size());
+
+    // Append new pages
+    for (size_t i = 0; i < pages.size(); i++) {
+        float pageHeight;
+
+        m_pages.push_back(pages[i]);
+
+        // Check if new page is a transition page
+        const std::string& url = pages[i].imageUrl;
+        bool isTransition = url.compare(0, TRANSITION_PREFIX.size(), TRANSITION_PREFIX) == 0;
+
+        if (isTransition) {
+            pageHeight = TRANSITION_PAGE_HEIGHT;
+        } else {
+            pageHeight = defaultHeight;
+        }
+
+        auto pageImg = std::make_shared<RotatableImage>();
+        pageImg->setWidth(availableWidth);
+        pageImg->setHeight(pageHeight);
+        pageImg->setScalingType(brls::ImageScalingType::FIT);
+        pageImg->setBackgroundFillColor(m_bgColor);
+        pageImg->setRotation(m_rotationDegrees);
+
+        m_pageImages.push_back(pageImg);
+        m_pageHeights.push_back(pageHeight);
+
+        // Add gap + page height to total
+        if (startIdx + static_cast<int>(i) > 0) {
+            m_totalHeight += m_pageGap;
+        }
+        m_totalHeight += pageHeight;
+    }
+
+    // Reset overscroll since we just added content
+    m_overscrollAmount = 0.0f;
+    m_overscrollTriggered = false;
+
+    // Load newly visible images
+    updateVisibleImages();
+    updateCurrentPage();
+
+    brls::Logger::info("WebtoonScrollView: Appended {} pages (total now {})", pages.size(), m_pages.size());
+}
+
+void WebtoonScrollView::prependPages(const std::vector<Page>& pages) {
+    if (pages.empty()) return;
+
+    float availableWidth = m_viewWidth - (m_sidePadding * 2);
+    float defaultHeight = availableWidth * 1.5f;
+
+    // Calculate the size of the leading transition page we're about to remove
+    float removedSize = 0.0f;
+    bool hadLeadingTransition = false;
+    if (!m_pages.empty() && isTransitionPage(0)) {
+        removedSize = getEffectivePageSize(0);
+        if (m_pages.size() > 1) removedSize += m_pageGap;
+        hadLeadingTransition = true;
+    }
+
+    // Build new page data
+    std::vector<Page> newPages;
+    std::vector<std::shared_ptr<RotatableImage>> newImages;
+    std::vector<float> newHeights;
+    float addedHeight = 0.0f;
+
+    for (size_t i = 0; i < pages.size(); i++) {
+        const std::string& url = pages[i].imageUrl;
+        bool isTransition = url.compare(0, TRANSITION_PREFIX.size(), TRANSITION_PREFIX) == 0;
+
+        float pageHeight = isTransition ? TRANSITION_PAGE_HEIGHT : defaultHeight;
+
+        auto pageImg = std::make_shared<RotatableImage>();
+        pageImg->setWidth(availableWidth);
+        pageImg->setHeight(pageHeight);
+        pageImg->setScalingType(brls::ImageScalingType::FIT);
+        pageImg->setBackgroundFillColor(m_bgColor);
+        pageImg->setRotation(m_rotationDegrees);
+
+        newPages.push_back(pages[i]);
+        newImages.push_back(pageImg);
+        newHeights.push_back(pageHeight);
+        addedHeight += pageHeight;
+        if (i > 0) addedHeight += m_pageGap;
+    }
+
+    // Skip old leading transition page
+    int skipOld = hadLeadingTransition ? 1 : 0;
+
+    // Append existing pages (minus the removed transition) to new lists
+    for (size_t i = skipOld; i < m_pages.size(); i++) {
+        newPages.push_back(m_pages[i]);
+        newImages.push_back(m_pageImages[i]);
+        newHeights.push_back(m_pageHeights[i]);
+    }
+
+    // Rebuild tracking sets with shifted indices
+    int shift = static_cast<int>(pages.size()) - skipOld;
+    std::set<int> newLoaded, newLoading, newFailed;
+    for (int idx : m_loadedPages) {
+        int newIdx = idx + shift;
+        if (newIdx >= 0 && newIdx < static_cast<int>(newPages.size())) {
+            newLoaded.insert(newIdx);
+        }
+    }
+    for (int idx : m_loadingPages) {
+        int newIdx = idx + shift;
+        if (newIdx >= 0 && newIdx < static_cast<int>(newPages.size())) {
+            newLoading.insert(newIdx);
+        }
+    }
+    for (int idx : m_failedPages) {
+        int newIdx = idx + shift;
+        if (newIdx >= 0 && newIdx < static_cast<int>(newPages.size())) {
+            newFailed.insert(newIdx);
+        }
+    }
+
+    // Shift transition info
+    std::map<int, TransitionInfo> newTransitionInfo;
+    for (auto& pair : m_transitionInfo) {
+        int newIdx = pair.first + shift;
+        if (newIdx >= 0 && newIdx < static_cast<int>(newPages.size())) {
+            newTransitionInfo[newIdx] = pair.second;
+        }
+    }
+
+    // Replace all data
+    m_pages = std::move(newPages);
+    m_pageImages = std::move(newImages);
+    m_pageHeights = std::move(newHeights);
+    m_loadedPages = std::move(newLoaded);
+    m_loadingPages = std::move(newLoading);
+    m_failedPages = std::move(newFailed);
+    m_transitionInfo = std::move(newTransitionInfo);
+
+    // Recalculate total height
+    m_totalHeight = 0.0f;
+    for (size_t i = 0; i < m_pageHeights.size(); i++) {
+        m_totalHeight += m_pageHeights[i];
+        if (i > 0) m_totalHeight += m_pageGap;
+    }
+
+    // Adjust scroll position: user's view stays in the same visual spot
+    // We added content before the current view and possibly removed a transition page
+    float scrollAdjust = addedHeight + (pages.empty() ? 0 : m_pageGap) - removedSize;
+    m_scrollY -= scrollAdjust;
+
+    // Adjust current page index
+    m_currentPage += shift;
+
+    // Reset overscroll
+    m_overscrollAmount = 0.0f;
+    m_overscrollTriggered = false;
+
+    // Load newly visible images
+    updateVisibleImages();
+    updateCurrentPage();
+
+    brls::Logger::info("WebtoonScrollView: Prepended {} pages (total now {}, scrollAdjust={:.0f})",
+                        pages.size(), m_pages.size(), scrollAdjust);
+}
+
 void WebtoonScrollView::scrollToPage(int pageIndex) {
     if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pages.size())) {
         return;
@@ -660,6 +845,23 @@ void WebtoonScrollView::updateVisibleImages() {
 
                 brls::Logger::debug("WebtoonScrollView: Loaded page {}", pageIndex);
             }, img, m_alive);
+    }
+
+    // Unload images that are far from the visible area to free GPU memory
+    // This is important when multiple chapters accumulate via append/prepend
+    int unloadStart = std::max(0, firstVisible - UNLOAD_PAGES);
+    int unloadEnd = std::min(static_cast<int>(m_pages.size()) - 1, lastVisible + UNLOAD_PAGES);
+
+    for (int i = 0; i < static_cast<int>(m_pages.size()); i++) {
+        if (i >= unloadStart && i <= unloadEnd) continue;  // Within keep range
+        if (isTransitionPage(i)) continue;  // Transition pages have no images
+
+        if (m_loadedPages.count(i) > 0 && m_pageImages[i] && m_pageImages[i]->hasImage()) {
+            m_pageImages[i]->clearImage();
+            m_loadedPages.erase(i);
+            // Don't erase from m_loadingPages or add to m_failedPages -
+            // the page will be re-loaded when it comes back into range
+        }
     }
 }
 

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -6,8 +6,12 @@
 #include "view/webtoon_scroll_view.hpp"
 #include "utils/image_loader.hpp"
 #include <cmath>
+#include <map>
 
 namespace vitasuwayomi {
+
+// Transition page URL prefixes (must match reader_activity constants)
+static const std::string TRANSITION_PREFIX = "__transition:";
 
 WebtoonScrollView::WebtoonScrollView() {
     // Set up as a full-size container
@@ -104,15 +108,158 @@ void WebtoonScrollView::setupGestures() {
                 float distance = std::sqrt(dx * dx + dy * dy);
 
                 if (distance < TAP_THRESHOLD) {
-                    // It's a tap - toggle controls via callback
                     m_scrollVelocity = 0.0f;
-                    if (m_tapCallback) {
-                        m_tapCallback();
+
+                    // Scale tap position from physical to view coords
+                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
+                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                    float tapX = status.position.x * scaleX;
+                    float tapY = status.position.y * scaleY;
+
+                    int tappedPage = getPageAtPosition(tapX, tapY);
+
+                    if (tappedPage >= 0 && isTransitionPage(tappedPage)) {
+                        // Tapped on a transition page - navigate to chapter
+                        if (m_chapterNavigateCallback) {
+                            auto it = m_transitionInfo.find(tappedPage);
+                            bool isNext = (it != m_transitionInfo.end()) ? it->second.isNext : true;
+                            m_chapterNavigateCallback(isNext);
+                        }
+                    } else if (tappedPage >= 0 && isFailedPage(tappedPage)) {
+                        // Tapped on a failed page - retry loading
+                        m_failedPages.erase(tappedPage);
+                        m_loadedPages.erase(tappedPage);
+                        m_loadingPages.erase(tappedPage);
+                        updateVisibleImages();
+                    } else {
+                        // Regular tap - toggle controls
+                        if (m_tapCallback) {
+                            m_tapCallback();
+                        }
                     }
                 }
                 // Otherwise, momentum will be applied in onFrame()
             }
         }, brls::PanAxis::ANY));
+}
+
+bool WebtoonScrollView::isTransitionPage(int pageIndex) const {
+    if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pages.size())) return false;
+    const std::string& url = m_pages[pageIndex].imageUrl;
+    return url.compare(0, TRANSITION_PREFIX.size(), TRANSITION_PREFIX) == 0;
+}
+
+bool WebtoonScrollView::isFailedPage(int pageIndex) const {
+    return m_failedPages.count(pageIndex) > 0;
+}
+
+void WebtoonScrollView::setTransitionText(int pageIndex, const std::string& line1, const std::string& line2) {
+    if (pageIndex < 0 || pageIndex >= static_cast<int>(m_pages.size())) return;
+    TransitionInfo info;
+    info.line1 = line1;
+    info.line2 = line2;
+    // Determine direction from URL
+    const std::string& url = m_pages[pageIndex].imageUrl;
+    info.isNext = (url.find("next") != std::string::npos);
+    m_transitionInfo[pageIndex] = info;
+}
+
+int WebtoonScrollView::getPageAtPosition(float tapX, float tapY) const {
+    // Convert tap position to content-space coordinate
+    bool horizontal = isHorizontalLayout();
+    float contentPos;
+    if (horizontal) {
+        contentPos = tapX - m_scrollY;  // scrollY acts as scrollX
+    } else {
+        contentPos = tapY - m_scrollY;
+    }
+
+    // Subtract the view origin (since tap coords start from view origin)
+    // The draw function uses x + m_scrollY or y + m_scrollY as starting offset
+
+    float offset = 0.0f;
+    for (int i = 0; i < static_cast<int>(m_pageHeights.size()); i++) {
+        float pageSize = getEffectivePageSize(i);
+        if (contentPos >= offset && contentPos < offset + pageSize) {
+            return i;
+        }
+        offset += pageSize + m_pageGap;
+    }
+    return -1;
+}
+
+void WebtoonScrollView::drawTransitionPage(NVGcontext* vg, int pageIndex,
+                                             float x, float y, float width, float height) {
+    // Dark background for transition
+    nvgBeginPath(vg);
+    nvgRect(vg, x, y, width, height);
+    nvgFillColor(vg, nvgRGBA(20, 20, 30, 255));
+    nvgFill(vg);
+
+    // Horizontal divider line
+    float lineY = y + height * 0.35f;
+    nvgBeginPath(vg);
+    nvgRect(vg, x + width * 0.2f, lineY, width * 0.6f, 1.0f);
+    nvgFillColor(vg, nvgRGBA(150, 150, 150, 100));
+    nvgFill(vg);
+
+    auto it = m_transitionInfo.find(pageIndex);
+    if (it != m_transitionInfo.end()) {
+        float fontSize1 = 20.0f;
+        float fontSize2 = 16.0f;
+
+        // Line 1 (above divider)
+        if (!it->second.line1.empty()) {
+            nvgFontSize(vg, fontSize1);
+            nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+            nvgFillColor(vg, nvgRGBA(220, 220, 220, 255));
+            nvgText(vg, x + width * 0.5f, lineY - 8.0f, it->second.line1.c_str(), nullptr);
+        }
+
+        // Line 2 (below divider)
+        if (!it->second.line2.empty()) {
+            nvgFontSize(vg, fontSize2);
+            nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+            nvgFillColor(vg, nvgRGBA(180, 180, 180, 255));
+            nvgText(vg, x + width * 0.5f, lineY + 12.0f, it->second.line2.c_str(), nullptr);
+        }
+
+        // "Tap to continue" hint
+        nvgFontSize(vg, 14.0f);
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+        nvgFillColor(vg, nvgRGBA(120, 120, 120, 200));
+        nvgText(vg, x + width * 0.5f, y + height - 12.0f, "Tap to continue", nullptr);
+    } else {
+        // Fallback text if no transition info set
+        nvgFontSize(vg, 18.0f);
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+        nvgFillColor(vg, nvgRGBA(180, 180, 180, 255));
+        nvgText(vg, x + width * 0.5f, y + height * 0.5f, "Chapter transition", nullptr);
+    }
+}
+
+void WebtoonScrollView::drawFailedPage(NVGcontext* vg, int pageIndex,
+                                        float x, float y, float width, float height) {
+    // Dark red-tinted background
+    nvgBeginPath(vg);
+    nvgRect(vg, x, y, width, height);
+    nvgFillColor(vg, nvgRGBA(40, 20, 20, 255));
+    nvgFill(vg);
+
+    float centerX = x + width * 0.5f;
+    float centerY = y + height * 0.5f;
+
+    // Error message
+    nvgFontSize(vg, 16.0f);
+    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+    nvgFillColor(vg, nvgRGBA(200, 120, 120, 255));
+    nvgText(vg, centerX, centerY - 4.0f, "Failed to load page", nullptr);
+
+    // Retry prompt
+    nvgFontSize(vg, 14.0f);
+    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+    nvgFillColor(vg, nvgRGBA(100, 200, 180, 255));
+    nvgText(vg, centerX, centerY + 4.0f, "Tap to retry", nullptr);
 }
 
 void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWidth) {
@@ -149,16 +296,25 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
 
     // Create image containers for each page
     for (size_t i = 0; i < pages.size(); i++) {
+        float pageHeight;
+
+        if (isTransitionPage(static_cast<int>(i))) {
+            // Transition pages use a fixed smaller height
+            pageHeight = TRANSITION_PAGE_HEIGHT;
+        } else {
+            pageHeight = defaultHeight;
+        }
+
         auto pageImg = std::make_shared<RotatableImage>();
         pageImg->setWidth(availableWidth);
-        pageImg->setHeight(defaultHeight);  // Will be adjusted when image loads
+        pageImg->setHeight(pageHeight);
         pageImg->setScalingType(brls::ImageScalingType::FIT);
         pageImg->setBackgroundFillColor(m_bgColor);
-        pageImg->setRotation(imageRotation);  // Apply corrected rotation for webtoon mode
+        pageImg->setRotation(imageRotation);
 
         m_pageImages.push_back(pageImg);
-        m_pageHeights.push_back(defaultHeight);
-        m_totalHeight += defaultHeight + m_pageGap;
+        m_pageHeights.push_back(pageHeight);
+        m_totalHeight += pageHeight + m_pageGap;
     }
 
     // Remove trailing gap
@@ -172,6 +328,8 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
     m_currentPage = 0;
     m_loadedPages.clear();
     m_loadingPages.clear();
+    m_failedPages.clear();
+    m_transitionInfo.clear();
 
     // Load initial visible images
     updateVisibleImages();
@@ -190,6 +348,8 @@ void WebtoonScrollView::clearPages() {
     m_pages.clear();
     m_loadedPages.clear();
     m_loadingPages.clear();
+    m_failedPages.clear();
+    m_transitionInfo.clear();
     m_totalHeight = 0.0f;
     m_scrollY = 0.0f;
     m_scrollVelocity = 0.0f;
@@ -299,9 +459,6 @@ float WebtoonScrollView::getEffectivePageSize(int pageIndex) const {
     }
 
     // Horizontal layout: calculate page width from stored height
-    // m_pageHeights was calculated as availableWidth * aspectRatio
-    // For horizontal mode, we need availableHeight * aspectRatio
-    // So: pageWidth = m_pageHeights[i] * (availableHeight / availableWidth)
     float availableWidth = m_viewWidth - (m_sidePadding * 2);
     float availableHeight = m_viewHeight - (m_sidePadding * 2);
 
@@ -379,18 +536,12 @@ bool WebtoonScrollView::isPageVisible(int pageIndex) const {
     float pageEnd = pageStart + pageSize;
 
     if (isHorizontalLayout()) {
-        // Horizontal layout: check X position
-        float visibleLeft = -m_scrollY;  // scrollY acts as scrollX
+        float visibleLeft = -m_scrollY;
         float visibleRight = visibleLeft + m_viewWidth;
-
-        // Check if page overlaps with visible area
         return (pageEnd > visibleLeft && pageStart < visibleRight);
     } else {
-        // Vertical layout: check Y position
         float visibleTop = -m_scrollY;
         float visibleBottom = visibleTop + m_viewHeight;
-
-        // Check if page overlaps with visible area
         return (pageEnd > visibleTop && pageStart < visibleBottom);
     }
 }
@@ -424,12 +575,20 @@ void WebtoonScrollView::updateVisibleImages() {
             continue;  // Already loaded or loading
         }
 
+        // Skip transition pages - they don't have real images to load
+        if (isTransitionPage(i)) {
+            m_loadedPages.insert(i);  // Mark as "loaded" so we don't retry
+            continue;
+        }
+
+        // Skip failed pages (user must tap to retry)
+        if (m_failedPages.count(i) > 0) {
+            continue;
+        }
+
         m_loadingPages.insert(i);
 
         const Page& page = m_pages[i];
-        // Capture shared_ptr so the RotatableImage stays alive until the image
-        // loader's brls::sync callback completes (it calls target->setImageFromMem
-        // before our callback, so the object must outlive the entire brls::sync lambda).
         std::shared_ptr<RotatableImage> imgPtr = m_pageImages[i];
         RotatableImage* img = imgPtr.get();
         int pageIndex = i;
@@ -441,9 +600,10 @@ void WebtoonScrollView::updateVisibleImages() {
                 if (!alive || !*alive) return;
 
                 m_loadingPages.erase(pageIndex);
-                m_loadedPages.insert(pageIndex);
 
                 if (imgPtr->hasImage()) {
+                    m_loadedPages.insert(pageIndex);
+
                     float imageWidth = static_cast<float>(imgPtr->getImageWidth());
                     float imageHeight = static_cast<float>(imgPtr->getImageHeight());
 
@@ -457,6 +617,18 @@ void WebtoonScrollView::updateVisibleImages() {
                         m_pageHeights[pageIndex] = newHeight;
                         imgPtr->setHeight(newHeight);
                     }
+                } else {
+                    // Image load failed - mark as failed for retry
+                    m_failedPages.insert(pageIndex);
+
+                    // Set a reasonable height for the failed page placeholder
+                    float oldHeight = m_pageHeights[pageIndex];
+                    if (oldHeight > FAILED_PAGE_HEIGHT * 2) {
+                        m_totalHeight += (FAILED_PAGE_HEIGHT - oldHeight);
+                        m_pageHeights[pageIndex] = FAILED_PAGE_HEIGHT;
+                    }
+
+                    brls::Logger::warning("WebtoonScrollView: Failed to load page {}", pageIndex);
                 }
 
                 brls::Logger::debug("WebtoonScrollView: Loaded page {}", pageIndex);
@@ -466,7 +638,6 @@ void WebtoonScrollView::updateVisibleImages() {
 
 void WebtoonScrollView::updateCurrentPage() {
     // Find the page at the start of the visible area
-    // (top for vertical layout, left for horizontal layout)
     float visibleStart = -m_scrollY;
 
     int newCurrentPage = 0;
@@ -477,7 +648,12 @@ void WebtoonScrollView::updateCurrentPage() {
         float pageEnd = offset + pageSize;
 
         if (pageEnd > visibleStart) {
-            newCurrentPage = i;
+            // Skip transition pages for progress reporting
+            if (!isTransitionPage(i)) {
+                newCurrentPage = i;
+            } else if (i + 1 < static_cast<int>(m_pageHeights.size())) {
+                newCurrentPage = i + 1;  // Report next real page
+            }
             break;
         }
 
@@ -514,47 +690,41 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
 
     if (horizontal) {
         // Horizontal layout (for 90/270 rotation)
-        // Pages are laid out left to right, scrollY acts as scrollX
         float availableHeight = height - (m_sidePadding * 2);
         float pageY = y + m_sidePadding;
-
-        // Draw visible pages horizontally
-        float currentX = x + m_scrollY;  // scrollY is used as horizontal offset
+        float currentX = x + m_scrollY;
 
         for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
             RotatableImage* img = m_pageImages[i].get();
 
-            // Calculate the correct page width for the rotated image
-            // When rotated 90/270, the effective aspect ratio is imageHeight/imageWidth
-            // The page width should fill the available height: availableHeight * (imageH/imageW)
             float pageWidth;
-            if (img && img->hasImage() && img->getImageWidth() > 0 && img->getImageHeight() > 0) {
-                // For 90/270 rotation, the rotated aspect ratio is height/width
+            if (isTransitionPage(i)) {
+                pageWidth = TRANSITION_PAGE_HEIGHT;  // Fixed width for transitions in horizontal
+            } else if (isFailedPage(i)) {
+                pageWidth = FAILED_PAGE_HEIGHT;
+            } else if (img && img->hasImage() && img->getImageWidth() > 0 && img->getImageHeight() > 0) {
                 float rotatedAspect = static_cast<float>(img->getImageHeight()) / static_cast<float>(img->getImageWidth());
                 pageWidth = availableHeight * rotatedAspect;
             } else {
-                // Fallback: use stored height scaled by aspect ratio
-                // m_pageHeights was calculated as availableWidth * aspectRatio
-                // For horizontal, we need availableHeight * aspectRatio
                 float availableWidth = width - (m_sidePadding * 2);
                 if (availableWidth > 0) {
                     pageWidth = m_pageHeights[i] * (availableHeight / availableWidth);
                 } else {
-                    pageWidth = availableHeight * 1.5f;  // Default 2:3 aspect ratio
+                    pageWidth = availableHeight * 1.5f;
                 }
             }
 
             float pageRight = currentX + pageWidth;
 
-            // Check if page is in visible area (with some margin for smooth scrolling)
+            // Check if page is in visible area
             if (pageRight >= x - 100 && currentX <= x + width + 100) {
-                // Draw this page
-                if (img) {
-                    // Update image size for horizontal layout
+                if (isTransitionPage(i)) {
+                    drawTransitionPage(vg, i, currentX, pageY, pageWidth, availableHeight);
+                } else if (isFailedPage(i)) {
+                    drawFailedPage(vg, i, currentX, pageY, pageWidth, availableHeight);
+                } else if (img) {
                     img->setWidth(pageWidth);
                     img->setHeight(availableHeight);
-
-                    // Draw the image
                     img->draw(vg, currentX, pageY, pageWidth, availableHeight, style, ctx);
                 }
             }
@@ -563,27 +733,26 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
         }
     } else {
         // Vertical layout (for 0/180 rotation)
-        // Calculate the X position for centered pages
         float availableWidth = width - (m_sidePadding * 2);
         float pageX = x + m_sidePadding;
-
-        // Draw visible pages vertically
-        float currentY = y + m_scrollY;  // Start position adjusted by scroll
+        float currentY = y + m_scrollY;
 
         for (int i = 0; i < static_cast<int>(m_pageImages.size()); i++) {
             float pageHeight = m_pageHeights[i];
             float pageBottom = currentY + pageHeight;
 
-            // Check if page is in visible area (with some margin for smooth scrolling)
+            // Check if page is in visible area
             if (pageBottom >= y - 100 && currentY <= y + height + 100) {
-                // Draw this page
-                RotatableImage* img = m_pageImages[i].get();
-                if (img) {
-                    // Update image width in case view resized
-                    img->setWidth(availableWidth);
-
-                    // Draw the image
-                    img->draw(vg, pageX, currentY, availableWidth, pageHeight, style, ctx);
+                if (isTransitionPage(i)) {
+                    drawTransitionPage(vg, i, pageX, currentY, availableWidth, pageHeight);
+                } else if (isFailedPage(i)) {
+                    drawFailedPage(vg, i, pageX, currentY, availableWidth, pageHeight);
+                } else {
+                    RotatableImage* img = m_pageImages[i].get();
+                    if (img) {
+                        img->setWidth(availableWidth);
+                        img->draw(vg, pageX, currentY, availableWidth, pageHeight, style, ctx);
+                    }
                 }
             }
 

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -41,6 +41,8 @@ void WebtoonScrollView::setupGestures() {
                 m_touchLast = status.position;
                 m_scrollAtTouchStart = m_scrollY;
                 m_scrollVelocity = 0.0f;
+                m_overscrollAmount = 0.0f;
+                m_overscrollTriggered = false;
                 m_lastTouchTime = std::chrono::steady_clock::now();
             } else if (status.state == brls::GestureState::STAY) {
                 // Calculate raw deltas
@@ -74,6 +76,7 @@ void WebtoonScrollView::setupGestures() {
                 }
 
                 // Update scroll position
+                float prevScrollY = m_scrollY;
                 m_scrollY += scrollDelta;
 
                 // Clamp scroll position based on layout direction
@@ -85,6 +88,44 @@ void WebtoonScrollView::setupGestures() {
                 if (minScroll > maxScroll) minScroll = maxScroll;
 
                 m_scrollY = std::max(minScroll, std::min(maxScroll, m_scrollY));
+
+                // Track overscroll for chapter navigation
+                // If user is scrolling past the boundary, accumulate overscroll
+                float unclamped = prevScrollY + scrollDelta;
+                if (unclamped > maxScroll && scrollDelta > 0) {
+                    // Overscrolling at the beginning (scrolling up past start)
+                    m_overscrollAmount += scrollDelta;
+                    if (m_overscrollAmount > OVERSCROLL_THRESHOLD && !m_overscrollTriggered) {
+                        // Check if first page is a transition page
+                        if (!m_pages.empty() && isTransitionPage(0)) {
+                            m_overscrollTriggered = true;
+                            auto it = m_transitionInfo.find(0);
+                            bool isNext = (it != m_transitionInfo.end()) ? it->second.isNext : false;
+                            if (m_chapterNavigateCallback) {
+                                m_chapterNavigateCallback(isNext);
+                            }
+                        }
+                    }
+                } else if (unclamped < minScroll && scrollDelta < 0) {
+                    // Overscrolling at the end (scrolling down past end)
+                    m_overscrollAmount += -scrollDelta;
+                    int lastIdx = static_cast<int>(m_pages.size()) - 1;
+                    if (m_overscrollAmount > OVERSCROLL_THRESHOLD && !m_overscrollTriggered) {
+                        // Check if last page is a transition page
+                        if (lastIdx >= 0 && isTransitionPage(lastIdx)) {
+                            m_overscrollTriggered = true;
+                            auto it = m_transitionInfo.find(lastIdx);
+                            bool isNext = (it != m_transitionInfo.end()) ? it->second.isNext : true;
+                            if (m_chapterNavigateCallback) {
+                                m_chapterNavigateCallback(isNext);
+                            }
+                        }
+                    }
+                } else {
+                    // Not overscrolling - reset
+                    m_overscrollAmount = 0.0f;
+                    m_overscrollTriggered = false;
+                }
 
                 // Calculate velocity for momentum
                 auto now = std::chrono::steady_clock::now();
@@ -118,26 +159,23 @@ void WebtoonScrollView::setupGestures() {
 
                     int tappedPage = getPageAtPosition(tapX, tapY);
 
-                    if (tappedPage >= 0 && isTransitionPage(tappedPage)) {
-                        // Tapped on a transition page - navigate to chapter
-                        if (m_chapterNavigateCallback) {
-                            auto it = m_transitionInfo.find(tappedPage);
-                            bool isNext = (it != m_transitionInfo.end()) ? it->second.isNext : true;
-                            m_chapterNavigateCallback(isNext);
-                        }
-                    } else if (tappedPage >= 0 && isFailedPage(tappedPage)) {
+                    if (tappedPage >= 0 && isFailedPage(tappedPage)) {
                         // Tapped on a failed page - retry loading
                         m_failedPages.erase(tappedPage);
                         m_loadedPages.erase(tappedPage);
                         m_loadingPages.erase(tappedPage);
                         updateVisibleImages();
                     } else {
-                        // Regular tap - toggle controls
+                        // Regular tap (including on transition pages) - toggle controls
                         if (m_tapCallback) {
                             m_tapCallback();
                         }
                     }
                 }
+
+                // Reset overscroll state when finger lifts
+                m_overscrollAmount = 0.0f;
+                m_overscrollTriggered = false;
                 // Otherwise, momentum will be applied in onFrame()
             }
         }, brls::PanAxis::ANY));
@@ -224,11 +262,11 @@ void WebtoonScrollView::drawTransitionPage(NVGcontext* vg, int pageIndex,
             nvgText(vg, x + width * 0.5f, lineY + 12.0f, it->second.line2.c_str(), nullptr);
         }
 
-        // "Tap to continue" hint
+        // Scroll hint
         nvgFontSize(vg, 14.0f);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
         nvgFillColor(vg, nvgRGBA(120, 120, 120, 200));
-        nvgText(vg, x + width * 0.5f, y + height - 12.0f, "Tap to continue", nullptr);
+        nvgText(vg, x + width * 0.5f, y + height - 12.0f, "Keep scrolling to continue", nullptr);
     } else {
         // Fallback text if no transition info set
         nvgFontSize(vg, 18.0f);
@@ -286,14 +324,6 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
     m_pageHeights.clear();
     m_pageHeights.reserve(pages.size());
 
-    // Calculate image rotation (swap 90/270 for webtoon mode)
-    float imageRotation = m_rotationDegrees;
-    if (m_rotationDegrees == 90.0f) {
-        imageRotation = 270.0f;
-    } else if (m_rotationDegrees == 270.0f) {
-        imageRotation = 90.0f;
-    }
-
     // Create image containers for each page
     for (size_t i = 0; i < pages.size(); i++) {
         float pageHeight;
@@ -310,7 +340,7 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
         pageImg->setHeight(pageHeight);
         pageImg->setScalingType(brls::ImageScalingType::FIT);
         pageImg->setBackgroundFillColor(m_bgColor);
-        pageImg->setRotation(imageRotation);
+        pageImg->setRotation(m_rotationDegrees);
 
         m_pageImages.push_back(pageImg);
         m_pageHeights.push_back(pageHeight);
@@ -325,6 +355,8 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
     // Reset scroll
     m_scrollY = 0.0f;
     m_scrollVelocity = 0.0f;
+    m_overscrollAmount = 0.0f;
+    m_overscrollTriggered = false;
     m_currentPage = 0;
     m_loadedPages.clear();
     m_loadingPages.clear();
@@ -353,6 +385,8 @@ void WebtoonScrollView::clearPages() {
     m_totalHeight = 0.0f;
     m_scrollY = 0.0f;
     m_scrollVelocity = 0.0f;
+    m_overscrollAmount = 0.0f;
+    m_overscrollTriggered = false;
     m_currentPage = 0;
 }
 
@@ -425,22 +459,15 @@ void WebtoonScrollView::setRotation(float degrees) {
         m_rotationDegrees = 0.0f;
     }
 
-    // For webtoon mode with horizontal layout (90°/270°), swap rotation
-    float imageRotation = m_rotationDegrees;
-    if (m_rotationDegrees == 90.0f) {
-        imageRotation = 270.0f;
-    } else if (m_rotationDegrees == 270.0f) {
-        imageRotation = 90.0f;
-    }
-
-    // Apply rotation to all existing page images
+    // Apply rotation directly to all existing page images
+    // RotatableImage handles rotation rendering correctly on its own
     for (auto& img : m_pageImages) {
         if (img) {
-            img->setRotation(imageRotation);
+            img->setRotation(m_rotationDegrees);
         }
     }
 
-    brls::Logger::debug("WebtoonScrollView: setRotation({}) -> {} degrees (image: {} degrees)", degrees, m_rotationDegrees, imageRotation);
+    brls::Logger::debug("WebtoonScrollView: setRotation({}) -> {} degrees", degrees, m_rotationDegrees);
 }
 
 bool WebtoonScrollView::isHorizontalLayout() const {


### PR DESCRIPTION
Adds transition pages and failed-page retry to webtoon mode, fixes a webtoon rotation bug, adds overscroll chapter navigation, and fixes WebP decode failures with smooth chapter transitions.

---
_Generated by [Claude Code](https://claude.ai/code)_