### PR TITLE
Fix manga reader tap zones and container swipe for rotated views

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -253,6 +253,10 @@ private:
     void handleDoubleTap(brls::Point position);
     void handlePinchZoom(float scaleFactor);
     void resetZoom();
+
+    // Returns -1 for user's left zone, 0 for center, +1 for user's right zone
+    // accounting for rotation (user's left/right depends on how device is held)
+    int getTapZone(brls::Point position) const;
     void zoomTo(float level, brls::Point center);
 
     // Error overlay for failed page loads

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -267,9 +267,19 @@ public:
         bool markedRead = false;  // Whether chapter was marked as read
         int64_t timestamp = 0;   // When this was updated (milliseconds)
     };
-    void setLastReaderResult(const ReaderResult& result) { m_lastReaderResult = result; }
+    void setLastReaderResult(const ReaderResult& result) {
+        m_lastReaderResult = result;
+        // Notify registered listener (MangaDetailView) to update UI
+        if (m_readerResultCallback) {
+            m_readerResultCallback(result);
+        }
+    }
     const ReaderResult& getLastReaderResult() const { return m_lastReaderResult; }
     void clearLastReaderResult() { m_lastReaderResult = {}; }
+
+    // Callback for when reader result is set (detail view registers to update UI)
+    using ReaderResultCallback = std::function<void(const ReaderResult&)>;
+    void setReaderResultCallback(ReaderResultCallback cb) { m_readerResultCallback = std::move(cb); }
 
     // Get string for display
     static std::string getThemeString(AppTheme theme);
@@ -292,6 +302,7 @@ private:
     std::set<int> m_recentLibraryAdditions;  // Manga IDs added to library this session
     AppSettings m_settings;
     ReaderResult m_lastReaderResult;
+    ReaderResultCallback m_readerResultCallback;
 };
 
 } // namespace vitasuwayomi

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -204,6 +204,9 @@ private:
     // Update the read button text based on reading progress
     void updateReadButtonText();
 
+    // Apply pending reader result to m_chapters (progress from last reader session)
+    void applyReaderResult();
+
     // Cancel all downloading chapters (keep completed)
     void cancelAllDownloading();
 

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -400,34 +400,26 @@ void ReaderActivity::onContentAvailable() {
                         m_lastTapPosition = status.position;
 
                         // Tap-to-navigate: left 1/3 = prev, right 1/3 = next, center = toggle
-                        // Respects reading direction (RTL: right=prev, left=next)
+                        // Respects reading direction and rotation
                         AppSettings& appSettings = Application::getInstance().getSettings();
                         if (appSettings.tapToNavigate && !m_isZoomed && !m_continuousScrollMode) {
-                            const float SCREEN_WIDTH = 960.0f;
-                            float tapX = status.position.x;
-                            float leftZone = SCREEN_WIDTH / 3.0f;
-                            float rightZone = SCREEN_WIDTH * 2.0f / 3.0f;
-
-                            if (tapX < leftZone) {
-                                // Left zone
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                            int zone = getTapZone(status.position);
+                            if (zone == -1) {
+                                // User's left zone
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                     nextPage();
-                                } else {
+                                else
                                     previousPage();
-                                }
-                            } else if (tapX > rightZone) {
-                                // Right zone
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                            } else if (zone == +1) {
+                                // User's right zone
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                     previousPage();
-                                } else {
+                                else
                                     nextPage();
-                                }
                             } else {
-                                // Center zone - toggle controls
                                 toggleControls();
                             }
                         } else {
-                            // Tap-to-navigate disabled - toggle controls
                             toggleControls();
                         }
                     }
@@ -653,17 +645,13 @@ void ReaderActivity::onContentAvailable() {
                 if (status.state == brls::GestureState::END) {
                     AppSettings& appSettings = Application::getInstance().getSettings();
                     if (appSettings.tapToNavigate) {
-                        const float SCREEN_WIDTH = 960.0f;
-                        float tapX = status.position.x;
-                        float leftZone = SCREEN_WIDTH / 3.0f;
-                        float rightZone = SCREEN_WIDTH * 2.0f / 3.0f;
-
-                        if (tapX < leftZone) {
+                        int zone = getTapZone(status.position);
+                        if (zone == -1) {
                             if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                 nextPage();
                             else
                                 previousPage();
-                        } else if (tapX > rightZone) {
+                        } else if (zone == +1) {
                             if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                 previousPage();
                             else
@@ -859,23 +847,17 @@ void ReaderActivity::onContentAvailable() {
                         // Same tap-to-navigate logic as pageImage
                         AppSettings& appSettings = Application::getInstance().getSettings();
                         if (appSettings.tapToNavigate && !m_isZoomed && !m_continuousScrollMode) {
-                            const float SCREEN_WIDTH = 960.0f;
-                            float tapX = status.position.x;
-                            float leftZone = SCREEN_WIDTH / 3.0f;
-                            float rightZone = SCREEN_WIDTH * 2.0f / 3.0f;
-
-                            if (tapX < leftZone) {
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                            int zone = getTapZone(status.position);
+                            if (zone == -1) {
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                     nextPage();
-                                } else {
+                                else
                                     previousPage();
-                                }
-                            } else if (tapX > rightZone) {
-                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT) {
+                            } else if (zone == +1) {
+                                if (m_settings.direction == ReaderDirection::RIGHT_TO_LEFT)
                                     previousPage();
-                                } else {
+                                else
                                     nextPage();
-                                }
                             } else {
                                 toggleControls();
                             }
@@ -898,15 +880,25 @@ void ReaderActivity::onContentAvailable() {
                     float dx = status.position.x - m_touchStart.x;
                     float dy = status.position.y - m_touchStart.y;
 
-                    // Only process swipes, not taps (handled by TapGestureRecognizer)
-                    if (std::abs(dx) > std::abs(dy) && std::abs(dx) >= PAGE_TURN_THRESHOLD) {
-                        if (dx > 0) {
+                    // Account for rotation when determining swipe direction
+                    bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
+                                             m_settings.rotation == ImageRotation::ROTATE_270);
+                    bool invertDirection = (m_settings.rotation == ImageRotation::ROTATE_180 ||
+                                            m_settings.rotation == ImageRotation::ROTATE_270);
+
+                    float primaryDelta = useVerticalSwipe ? dy : dx;
+                    float crossDelta = useVerticalSwipe ? dx : dy;
+                    float logicalPrimary = invertDirection ? -primaryDelta : primaryDelta;
+
+                    if (std::abs(primaryDelta) > std::abs(crossDelta) && std::abs(primaryDelta) >= PAGE_TURN_THRESHOLD) {
+                        if (logicalPrimary > 0) {
                             m_settings.direction == ReaderDirection::RIGHT_TO_LEFT ? nextPage() : previousPage();
                         } else {
                             m_settings.direction == ReaderDirection::RIGHT_TO_LEFT ? previousPage() : nextPage();
                         }
-                    } else if (std::abs(dy) >= PAGE_TURN_THRESHOLD) {
-                        dy > 0 ? previousPage() : nextPage();
+                    } else if (std::abs(crossDelta) >= PAGE_TURN_THRESHOLD) {
+                        float logicalCross = invertDirection ? -crossDelta : crossDelta;
+                        logicalCross > 0 ? previousPage() : nextPage();
                     }
                 }
             }, brls::PanAxis::ANY));
@@ -2126,6 +2118,30 @@ void ReaderActivity::saveSettingsToApp() {
 }
 
 // Touch handling is now implemented inline in gesture recognizers (onContentAvailable)
+
+int ReaderActivity::getTapZone(brls::Point position) const {
+    // Map physical tap position to user's perceived left/center/right zone,
+    // accounting for how the device is held at each rotation.
+    //   0°:   user's left = low X,  right = high X  (screen width 960)
+    //   90°:  user's left = low Y,  right = high Y  (screen height 544)
+    //   180°: user's left = high X, right = low X   (screen width 960, inverted)
+    //   270°: user's left = high Y, right = low Y   (screen height 544, inverted)
+    float normalized;
+    int rotation = static_cast<int>(m_settings.rotation);
+    if (rotation == 90) {
+        normalized = position.y / 544.0f;
+    } else if (rotation == 270) {
+        normalized = 1.0f - (position.y / 544.0f);
+    } else if (rotation == 180) {
+        normalized = 1.0f - (position.x / 960.0f);
+    } else {
+        normalized = position.x / 960.0f;
+    }
+
+    if (normalized < 1.0f / 3.0f) return -1;  // left zone
+    if (normalized > 2.0f / 3.0f) return +1;   // right zone
+    return 0;                                    // center zone
+}
 
 void ReaderActivity::handleDoubleTap(brls::Point position) {
     if (m_isZoomed) {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -471,6 +471,26 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     brls::Logger::info("MangaDetailView: Creating for '{}' id={}", manga.title, manga.id);
     m_lastProgressRefresh = std::chrono::steady_clock::now();
 
+    // Register callback so when the reader closes, we immediately update the
+    // Continue Reading button without waiting for willAppear (which may not fire
+    // since this view is a Box inside an Activity, not an Activity itself).
+    int mangaId = m_manga.id;
+    Application::getInstance().setReaderResultCallback(
+        [this, mangaId, aliveWeak = std::weak_ptr<bool>(m_alive)](const Application::ReaderResult& result) {
+            if (result.mangaId != mangaId) return;
+            // Defer to next frame so the reader activity finishes popping first
+            brls::sync([this, aliveWeak]() {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+                applyReaderResult();
+                Application::getInstance().clearLastReaderResult();
+                updateChapterDownloadStates();
+                updateReadButtonText();
+                // Also refresh chapter list cells to show updated read state
+                populateChaptersList();
+            });
+        });
+
     // Try to load cached details if description is missing
     if (m_manga.description.empty()) {
         LibraryCache& cache = LibraryCache::getInstance();
@@ -3790,6 +3810,7 @@ MangaDetailView::~MangaDetailView() {
     DownloadsManager& dm = DownloadsManager::getInstance();
     dm.setProgressCallback(nullptr);
     dm.setChapterCompletionCallback(nullptr);
+    Application::getInstance().setReaderResultCallback(nullptr);
 
     // Note: m_chaptersDataSource is owned and deleted by m_chaptersRecycler
 }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1022,23 +1022,8 @@ void MangaDetailView::willAppear(bool resetState) {
     if (!m_firstAppearance) {
         if (!m_chapters.empty()) {
             // Apply last reader result to update chapter state immediately
-            const auto& readerResult = Application::getInstance().getLastReaderResult();
-            if (readerResult.mangaId == m_manga.id && readerResult.timestamp > 0) {
-                for (auto& ch : m_chapters) {
-                    if (ch.id == readerResult.chapterId) {
-                        ch.lastPageRead = readerResult.lastPageRead;
-                        ch.lastReadAt = readerResult.timestamp;
-                        if (readerResult.markedRead) {
-                            ch.read = true;
-                        }
-                        brls::Logger::info("MangaDetailView: Applied reader result - ch={} page={} read={}",
-                                          ch.id, ch.lastPageRead, ch.read);
-                        break;
-                    }
-                }
-                Application::getInstance().clearLastReaderResult();
-            }
-
+            // (don't clear yet - loadChapters will re-apply after server data arrives)
+            applyReaderResult();
             updateChapterDownloadStates();
             updateReadButtonText();
         }
@@ -1449,8 +1434,14 @@ void MangaDetailView::loadChapters() {
                 }
 
                 m_chapters = chapters;
+
+                // Re-apply reader result over server data in case the server
+                // hasn't processed the progress update yet (race condition)
+                applyReaderResult();
+                Application::getInstance().clearLastReaderResult();
+
                 if (Application::getInstance().getSettings().cacheLibraryData) {
-                    LibraryCache::getInstance().saveChapters(m_manga.id, chapters);
+                    LibraryCache::getInstance().saveChapters(m_manga.id, m_chapters);
                 }
                 populateChaptersList();
 
@@ -3320,6 +3311,27 @@ void MangaDetailView::updateSortIcon() {
         : "app0:resources/icons/sort-1-9.png";
 
     m_sortIcon->setImageFromFile(iconPath);
+}
+
+void MangaDetailView::applyReaderResult() {
+    const auto& result = Application::getInstance().getLastReaderResult();
+    if (result.mangaId != m_manga.id || result.timestamp <= 0) return;
+
+    for (auto& ch : m_chapters) {
+        if (ch.id == result.chapterId) {
+            // Only apply if our reader result is more recent than what we have
+            if (result.timestamp >= ch.lastReadAt) {
+                ch.lastPageRead = result.lastPageRead;
+                ch.lastReadAt = result.timestamp;
+                if (result.markedRead) {
+                    ch.read = true;
+                }
+                brls::Logger::info("MangaDetailView: Applied reader result - ch={} page={} read={}",
+                                  ch.id, ch.lastPageRead, ch.read);
+            }
+            break;
+        }
+    }
 }
 
 void MangaDetailView::updateReadButtonText() {


### PR DESCRIPTION
Fixes the reader's tap zones and container swipe for rotated views and keeps the Continue Reading button from reverting to stale data after the reader closes (updated immediately via callback).

---
_Generated by [Claude Code](https://claude.ai/code)_