### PR TITLE
Fix compressed/blurry webtoon images by auto-splitting tall images

### DIFF
--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -7,6 +7,7 @@
 
 #include <borealis.hpp>
 #include <string>
+#include <vector>
 
 namespace vitasuwayomi {
 
@@ -78,15 +79,24 @@ public:
     void setBackgroundFillColor(NVGcolor color) { m_bgColor = color; }
 
     /**
-     * Get image dimensions
+     * Set image from multiple segments (for tall images auto-split to fit GPU texture limit).
+     * Each segment is a TGA representing a horizontal slice of the original image.
+     * The RotatableImage draws them stacked vertically, transparent to the caller.
      */
-    int getImageWidth() const { return m_imageWidth; }
-    int getImageHeight() const { return m_imageHeight; }
+    void setImageSegments(const std::vector<std::vector<uint8_t>>& segments,
+                          int origWidth, int origHeight,
+                          const std::vector<int>& segmentSrcHeights);
 
     /**
-     * Check if image is loaded
+     * Get image dimensions (returns original dimensions for segmented images)
      */
-    bool hasImage() const { return m_nvgImage != 0; }
+    int getImageWidth() const { return (m_origWidth > 0) ? m_origWidth : m_imageWidth; }
+    int getImageHeight() const { return (m_origHeight > 0) ? m_origHeight : m_imageHeight; }
+
+    /**
+     * Check if image is loaded (single or segmented)
+     */
+    bool hasImage() const { return m_nvgImage != 0 || !m_segmentNvgImages.empty(); }
 
     /**
      * Set zoom level (1.0 = normal, >1.0 = zoomed in)
@@ -133,9 +143,17 @@ public:
     static brls::View* create();
 
 private:
-    int m_nvgImage = 0;           // NanoVG image handle
+    int m_nvgImage = 0;           // NanoVG image handle (single texture)
     int m_imageWidth = 0;
     int m_imageHeight = 0;
+
+    // Multi-segment support: tall images are auto-split into multiple GPU textures
+    // to preserve width quality within the 2048x2048 texture size limit.
+    std::vector<int> m_segmentNvgImages;      // NVG handles for each segment
+    std::vector<int> m_segmentSrcHeights;     // Source pixel height of each segment
+    int m_origWidth = 0;                       // Original full image width
+    int m_origHeight = 0;                      // Original full image height
+
     float m_rotationDegrees = 0.0f;
     float m_rotationRadians = 0.0f;
     ImageScaleMode m_scaleMode = ImageScaleMode::FIT_SCREEN;

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -240,10 +240,12 @@ private:
     std::shared_ptr<bool> m_alive = std::make_shared<bool>(true);
 
     // Preload buffer - how many pages ahead/behind to load
-    static constexpr int PRELOAD_PAGES = 3;
+    // Kept moderate to balance responsiveness vs VRAM (tall images use multiple GPU textures)
+    static constexpr int PRELOAD_PAGES = 2;
 
     // Unload buffer - pages beyond this distance from visible area get their images freed
-    static constexpr int UNLOAD_PAGES = 8;
+    // Reduced from 8 to limit VRAM usage when tall images have multiple segment textures
+    static constexpr int UNLOAD_PAGES = 5;
 
     // Momentum friction
     static constexpr float MOMENTUM_FRICTION = 0.95f;

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -13,6 +13,7 @@
 // WebP decoding support
 #include <webp/decode.h>
 #include <cstring>
+#include <cmath>
 #include <thread>
 #include <chrono>
 #include <fstream>
@@ -990,8 +991,99 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
         }
 
         // Convert images to TGA with size limit for Vita GPU (max texture 2048x2048)
-        // Webtoon images are often very tall and need to be split into segments
         const int MAX_TEXTURE_SIZE = 2048;
+
+        // Auto-split tall images to preserve width quality.
+        // Without splitting, an 800x15000 image gets scaled to 109x2048 (proportional),
+        // which looks extremely blurry when displayed at screen width.
+        // By splitting into vertical segments, each segment keeps full image width.
+        if (totalSegments == 1 && (isWebP || isJpegOrPng)) {
+            int origW = 0, origH = 0;
+
+            if (isWebP) {
+                WebPBitstreamFeatures feat;
+                if (WebPGetFeatures(reinterpret_cast<const uint8_t*>(imageBody.data()),
+                                    imageBody.size(), &feat) == VP8_STATUS_OK) {
+                    origW = feat.width;
+                    origH = feat.height;
+                }
+            } else {
+                int c;
+                stbi_info_from_memory(reinterpret_cast<const unsigned char*>(imageBody.data()),
+                                      static_cast<int>(imageBody.size()), &origW, &origH, &c);
+            }
+
+            if (origW > 0 && origH > MAX_TEXTURE_SIZE) {
+                int autoSegments = (origH + MAX_TEXTURE_SIZE - 1) / MAX_TEXTURE_SIZE;
+
+                // VRAM budget: cap total texture memory per image to prevent GPU exhaustion.
+                // The segment function scales both dims proportionally when width > maxSize,
+                // so total VRAM = maxSize² * origH / origW * 4.
+                // Solve for maxSize: maxSize = sqrt(budget * origW / (origH * 4))
+                const int MAX_VRAM_PER_IMAGE = 16 * 1024 * 1024;  // 16MB
+                int segMaxSize = MAX_TEXTURE_SIZE;
+                long long totalUnscaledBytes = (long long)origW * origH * 4;
+                if (totalUnscaledBytes > MAX_VRAM_PER_IMAGE) {
+                    float maxSizeF = std::sqrt((float)MAX_VRAM_PER_IMAGE * origW / ((float)origH * 4.0f));
+                    segMaxSize = std::max(256, std::min((int)maxSizeF, MAX_TEXTURE_SIZE));
+                    brls::Logger::info("ImageLoader: VRAM budget {}x{} -> maxWidth={}", origW, origH, segMaxSize);
+                }
+
+                brls::Logger::info("ImageLoader: Auto-splitting {}x{} into {} segments (maxSize={})",
+                                   origW, origH, autoSegments, segMaxSize);
+
+                std::vector<std::vector<uint8_t>> segmentDatas;
+                std::vector<int> segSrcHeights;
+                bool allOK = true;
+
+                for (int seg = 0; seg < autoSegments && allOK; seg++) {
+                    if (alive && !*alive) return;  // Owner destroyed during processing
+
+                    std::vector<uint8_t> segData;
+                    if (isWebP) {
+                        segData = convertWebPtoTGASegment(
+                            reinterpret_cast<const uint8_t*>(imageBody.data()),
+                            imageBody.size(), seg, autoSegments, segMaxSize);
+                    } else {
+                        segData = convertImageToTGASegment(
+                            reinterpret_cast<const uint8_t*>(imageBody.data()),
+                            imageBody.size(), seg, autoSegments, segMaxSize);
+                    }
+                    if (segData.empty()) {
+                        allOK = false;
+                        break;
+                    }
+
+                    // Cache each segment
+                    std::string segCK = url + "_full_autoseg" + std::to_string(seg);
+                    cachePut(segCK, segData);
+                    segmentDatas.push_back(std::move(segData));
+
+                    // Track source height for proportional display
+                    int segH = (origH + autoSegments - 1) / autoSegments;
+                    int startY = seg * segH;
+                    int endY = std::min(startY + segH, origH);
+                    segSrcHeights.push_back(endY - startY);
+                }
+
+                if (allOK && !segmentDatas.empty() && (target || callback)) {
+                    brls::sync([segDatas = std::move(segmentDatas), origW, origH,
+                                segHeights = std::move(segSrcHeights), callback, target, alive]() {
+                        if (alive && !*alive) return;
+                        if (target) {
+                            target->setImageSegments(segDatas, origW, origH, segHeights);
+                            if (callback) callback(target);
+                        }
+                    });
+                    return;  // Done - skip normal single-texture path
+                }
+
+                // Auto-split failed, fall through to normal proportional scaling
+                brls::Logger::warning("ImageLoader: Auto-split failed for {}x{}, using proportional scaling", origW, origH);
+            }
+        }
+
+        // Normal single-texture path (images that fit in one texture, or auto-split fallback)
         std::vector<uint8_t> imageData;
 
         if (isWebP) {

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -249,15 +249,47 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
         float imgX, imgY, imgW, imgH;
         calculateImageBounds(x, y, width, height, imgX, imgY, imgW, imgH);
 
-        float yPos = imgY;
+        bool isRotated90or270 = (m_rotationDegrees == 90.0f || m_rotationDegrees == 270.0f);
+        bool hasRotation = (m_rotationDegrees != 0.0f);
+
+        // Determine drawing space: for rotated images, apply rotation transform
+        // and draw segments in pre-rotation coordinates
+        float drawX, drawY, drawW, drawH;
+        if (hasRotation) {
+            float centerX = imgX + imgW / 2.0f;
+            float centerY = imgY + imgH / 2.0f;
+            nvgTranslate(vg, centerX, centerY);
+            nvgRotate(vg, m_rotationRadians);
+            nvgTranslate(vg, -centerX, -centerY);
+
+            if (isRotated90or270) {
+                // Swap back to pre-rotation dimensions
+                drawW = imgH;
+                drawH = imgW;
+            } else {
+                // 180° - same dimensions
+                drawW = imgW;
+                drawH = imgH;
+            }
+            drawX = (imgX + imgW / 2.0f) - drawW / 2.0f;
+            drawY = (imgY + imgH / 2.0f) - drawH / 2.0f;
+        } else {
+            drawX = imgX;
+            drawY = imgY;
+            drawW = imgW;
+            drawH = imgH;
+        }
+
+        // Draw segments stacked vertically in (possibly pre-rotation) space
+        float yPos = drawY;
         for (size_t i = 0; i < m_segmentNvgImages.size(); i++) {
             float segFraction = (float)m_segmentSrcHeights[i] / (float)m_origHeight;
-            float segDisplayH = imgH * segFraction;
+            float segDisplayH = drawH * segFraction;
 
-            NVGpaint paint = nvgImagePattern(vg, imgX, yPos, imgW, segDisplayH,
+            NVGpaint paint = nvgImagePattern(vg, drawX, yPos, drawW, segDisplayH,
                                               0, m_segmentNvgImages[i], 1.0f);
             nvgBeginPath(vg);
-            nvgRect(vg, imgX, yPos, imgW, segDisplayH);
+            nvgRect(vg, drawX, yPos, drawW, segDisplayH);
             nvgFillPaint(vg, paint);
             nvgFill(vg);
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -22,15 +22,27 @@ RotatableImage::~RotatableImage() {
 }
 
 void RotatableImage::clearImage() {
-    if (m_nvgImage != 0) {
-        NVGcontext* vg = brls::Application::getNVGContext();
-        if (vg) {
-            nvgDeleteImage(vg, m_nvgImage);
-        }
-        m_nvgImage = 0;
-        m_imageWidth = 0;
-        m_imageHeight = 0;
+    NVGcontext* vg = brls::Application::getNVGContext();
+
+    // Clear single image
+    if (m_nvgImage != 0 && vg) {
+        nvgDeleteImage(vg, m_nvgImage);
     }
+    m_nvgImage = 0;
+
+    // Clear segments
+    if (vg) {
+        for (int handle : m_segmentNvgImages) {
+            if (handle != 0) nvgDeleteImage(vg, handle);
+        }
+    }
+    m_segmentNvgImages.clear();
+    m_segmentSrcHeights.clear();
+    m_origWidth = 0;
+    m_origHeight = 0;
+
+    m_imageWidth = 0;
+    m_imageHeight = 0;
 }
 
 void RotatableImage::setImageFromMem(const unsigned char* data, size_t size) {
@@ -75,6 +87,42 @@ void RotatableImage::setImageFromFile(const std::string& path) {
         brls::Logger::error("RotatableImage: Failed to load image from {}", path);
     }
 
+    this->invalidate();
+}
+
+void RotatableImage::setImageSegments(const std::vector<std::vector<uint8_t>>& segments,
+                                       int origWidth, int origHeight,
+                                       const std::vector<int>& segmentSrcHeights) {
+    NVGcontext* vg = brls::Application::getNVGContext();
+    if (!vg || segments.empty() || origWidth <= 0 || origHeight <= 0) return;
+
+    // Clear any existing image/segments
+    clearImage();
+
+    for (const auto& segData : segments) {
+        int nvgImg = nvgCreateImageMem(vg, 0, const_cast<unsigned char*>(segData.data()), segData.size());
+        if (nvgImg == 0) {
+            brls::Logger::error("RotatableImage: Failed to create segment NVG image");
+            // Clean up on failure
+            for (int handle : m_segmentNvgImages) {
+                nvgDeleteImage(vg, handle);
+            }
+            m_segmentNvgImages.clear();
+            m_segmentSrcHeights.clear();
+            return;
+        }
+        m_segmentNvgImages.push_back(nvgImg);
+    }
+
+    m_segmentSrcHeights = segmentSrcHeights;
+    m_origWidth = origWidth;
+    m_origHeight = origHeight;
+    // Set m_imageWidth/Height to original dims for calculateImageBounds compatibility
+    m_imageWidth = origWidth;
+    m_imageHeight = origHeight;
+
+    brls::Logger::info("RotatableImage: Loaded {} segments for {}x{} image",
+                       m_segmentNvgImages.size(), origWidth, origHeight);
     this->invalidate();
 }
 
@@ -186,13 +234,40 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     nvgFillColor(vg, m_bgColor);
     nvgFill(vg);
 
-    // If no image, just show background
-    if (m_nvgImage == 0 || m_imageWidth <= 0 || m_imageHeight <= 0) {
+    // If no image at all, just show background
+    if (m_nvgImage == 0 && m_segmentNvgImages.empty()) {
+        nvgRestore(vg);
+        return;
+    }
+    if (m_imageWidth <= 0 || m_imageHeight <= 0) {
         nvgRestore(vg);
         return;
     }
 
-    // Calculate where the image should be drawn (accounts for rotation)
+    // Segmented image drawing (tall images auto-split for GPU texture limit)
+    if (!m_segmentNvgImages.empty() && m_origHeight > 0) {
+        float imgX, imgY, imgW, imgH;
+        calculateImageBounds(x, y, width, height, imgX, imgY, imgW, imgH);
+
+        float yPos = imgY;
+        for (size_t i = 0; i < m_segmentNvgImages.size(); i++) {
+            float segFraction = (float)m_segmentSrcHeights[i] / (float)m_origHeight;
+            float segDisplayH = imgH * segFraction;
+
+            NVGpaint paint = nvgImagePattern(vg, imgX, yPos, imgW, segDisplayH,
+                                              0, m_segmentNvgImages[i], 1.0f);
+            nvgBeginPath(vg);
+            nvgRect(vg, imgX, yPos, imgW, segDisplayH);
+            nvgFillPaint(vg, paint);
+            nvgFill(vg);
+
+            yPos += segDisplayH;
+        }
+        nvgRestore(vg);
+        return;
+    }
+
+    // Single-texture image drawing (normal path)
     float imgX, imgY, imgW, imgH;
     calculateImageBounds(x, y, width, height, imgX, imgY, imgW, imgH);
 
@@ -323,15 +398,23 @@ void RotatableImage::takeImageFrom(RotatableImage* source) {
     // Clear our current image
     clearImage();
 
-    // Transfer the NVG image handle and dimensions
+    // Transfer single NVG image handle and dimensions
     m_nvgImage = source->m_nvgImage;
     m_imageWidth = source->m_imageWidth;
     m_imageHeight = source->m_imageHeight;
 
-    // Clear the source without deleting the NVG image (we own it now)
+    // Transfer segments
+    m_segmentNvgImages = std::move(source->m_segmentNvgImages);
+    m_segmentSrcHeights = std::move(source->m_segmentSrcHeights);
+    m_origWidth = source->m_origWidth;
+    m_origHeight = source->m_origHeight;
+
+    // Clear the source without deleting handles (we own them now)
     source->m_nvgImage = 0;
     source->m_imageWidth = 0;
     source->m_imageHeight = 0;
+    source->m_origWidth = 0;
+    source->m_origHeight = 0;
 
     this->invalidate();
     source->invalidate();


### PR DESCRIPTION
Fixes compressed/blurry webtoon images by auto-splitting tall images, and fixes segmented-image rendering at 90/270° rotation.

---
_Generated by [Claude Code](https://claude.ai/code)_