### PR TITLE
Fix chapter completion marking to work both offline and online

### DIFF
--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -45,6 +45,7 @@ struct DownloadedChapter {
     LocalDownloadState state = LocalDownloadState::QUEUED;
     int lastPageRead = 0;       // Reading progress
     time_t lastReadTime = 0;    // Last read timestamp
+    bool read = false;          // Chapter has been fully read
 };
 
 // Download item information (manga)
@@ -148,6 +149,9 @@ public:
 
     // Update reading progress
     void updateReadingProgress(int mangaId, int chapterIndex, int lastPageRead);
+
+    // Mark a chapter as fully read in the local cache
+    void markChapterReadLocally(int mangaId, int chapterIndex);
 
     // Clear all reading progress for a manga (used by mark as read/unread)
     void clearReadingProgress(int mangaId);

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1727,16 +1727,21 @@ void ReaderActivity::previousChapter() {
 }
 
 void ReaderActivity::markChapterAsRead() {
-    // Skip server call when offline
-    if (!Application::getInstance().isConnected()) {
-        brls::Logger::info("ReaderActivity: offline, skipping mark as read");
-        return;
-    }
-
     int mangaId = m_mangaId;
     int chapterId = m_chapterIndex;  // This is the chapter ID
     int chapterPos = m_chapterPosition;
     int totalChapters = m_totalChapters;
+
+    // Always mark locally in downloads manager (works offline)
+    DownloadsManager::getInstance().markChapterReadLocally(mangaId, chapterId);
+
+    if (!Application::getInstance().isConnected()) {
+        brls::Logger::info("ReaderActivity: offline, marked chapter read locally (will sync later)");
+        // Still update reading statistics locally
+        bool mangaCompleted = (chapterPos >= 0 && chapterPos == totalChapters - 1);
+        Application::getInstance().updateReadingStatistics(true, mangaCompleted);
+        return;
+    }
 
     vitasuwayomi::asyncRun([mangaId, chapterId, chapterPos, totalChapters]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
@@ -3325,6 +3330,17 @@ void ReaderActivity::willDisappear(bool resetState) {
     result.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
     Application::getInstance().setLastReaderResult(result);
+
+    // If user finished the chapter (on last page), mark it as read
+    if (result.markedRead) {
+        markChapterAsRead();
+    }
+
+    // Save final reading progress (both online and offline)
+    if (!m_pages.empty() && !isTransitionPage(m_currentPage)) {
+        DownloadsManager::getInstance().updateReadingProgress(
+            m_mangaId, m_chapterIndex, result.lastPageRead);
+    }
 
     // Invalidate alive flag so pending async callbacks bail out safely.
     // This must happen BEFORE any cleanup so that in-flight callbacks

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -704,6 +704,32 @@ void DownloadsManager::updateReadingProgress(int mangaId, int chapterIndex, int 
     }
 }
 
+void DownloadsManager::markChapterReadLocally(int mangaId, int chapterIndex) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    for (auto& manga : m_downloads) {
+        if (manga.mangaId == mangaId) {
+            for (auto& chapter : manga.chapters) {
+                if (chapter.chapterIndex == chapterIndex || chapter.chapterId == chapterIndex) {
+                    if (!chapter.read) {
+                        chapter.read = true;
+                        // Set progress to last page
+                        if (chapter.pageCount > 0) {
+                            chapter.lastPageRead = chapter.pageCount - 1;
+                        }
+                        chapter.lastReadTime = std::time(nullptr);
+                        brls::Logger::info("DownloadsManager: Marked chapter {} as read locally (manga={})",
+                                          chapterIndex, mangaId);
+                        saveStateUnlocked();
+                    }
+                    break;
+                }
+            }
+            break;
+        }
+    }
+}
+
 void DownloadsManager::clearReadingProgress(int mangaId) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -733,6 +759,7 @@ void DownloadsManager::syncProgressToServer() {
         int chapterId;
         int lastPageRead;
         int pageCount;
+        bool read;
     };
     std::vector<SyncItem> items;
 
@@ -740,12 +767,13 @@ void DownloadsManager::syncProgressToServer() {
         std::lock_guard<std::mutex> lock(m_mutex);
         for (const auto& manga : m_downloads) {
             for (const auto& chapter : manga.chapters) {
-                if (chapter.lastPageRead > 0) {
+                if (chapter.lastPageRead > 0 || chapter.read) {
                     SyncItem item;
                     item.mangaId = manga.mangaId;
                     item.chapterId = chapter.chapterId > 0 ? chapter.chapterId : chapter.chapterIndex;
                     item.lastPageRead = chapter.lastPageRead;
                     item.pageCount = chapter.pageCount;
+                    item.read = chapter.read;
                     items.push_back(item);
                 }
             }
@@ -758,10 +786,13 @@ void DownloadsManager::syncProgressToServer() {
     int markedReadCount = 0;
 
     for (const auto& item : items) {
-        if (client.updateChapterProgress(item.mangaId, item.chapterId, item.lastPageRead)) {
-            syncedCount++;
+        if (item.lastPageRead > 0) {
+            if (client.updateChapterProgress(item.mangaId, item.chapterId, item.lastPageRead)) {
+                syncedCount++;
+            }
         }
-        if (item.pageCount > 0 && item.lastPageRead >= item.pageCount - 1) {
+        // Mark as read if locally flagged or if on/past last page
+        if (item.read || (item.pageCount > 0 && item.lastPageRead >= item.pageCount - 1)) {
             if (client.markChapterRead(item.mangaId, item.chapterId)) {
                 markedReadCount++;
             }
@@ -1071,6 +1102,7 @@ void DownloadsManager::saveStateUnlocked() {
                << "\"downloadedPages\":" << ch.downloadedPages << ",\n"
                << "\"state\":" << static_cast<int>(ch.state) << ",\n"
                << "\"lastPageRead\":" << ch.lastPageRead << ",\n"
+               << "\"read\":" << (ch.read ? "true" : "false") << ",\n"
                << "\"pages\":[\n";
 
             for (size_t k = 0; k < ch.pages.size(); ++k) {
@@ -1275,6 +1307,7 @@ void DownloadsManager::loadState() {
                         chapter.downloadedPages = extractJsonInt(chJson, "downloadedPages");
                         chapter.state = static_cast<LocalDownloadState>(extractJsonInt(chJson, "state"));
                         chapter.lastPageRead = extractJsonInt(chJson, "lastPageRead");
+                        chapter.read = extractJsonBool(chJson, "read");
 
                         // Parse pages array
                         size_t pagesPos = chJson.find("\"pages\":");


### PR DESCRIPTION
Fix chapter completion marking to work both offline and online

- Add `read` flag to DownloadedChapter struct for local read tracking
- Add markChapterReadLocally() to DownloadsManager for offline marking
- Update markChapterAsRead() to always mark locally first, then sync
  to server when online (previously did nothing when offline)
- Mark chapter as read in willDisappear() when user exits on last page
- Save final reading progress on reader exit (both online and offline)
- Persist `read` flag in save/load state (JSON serialization)
- Update syncProgressToServer() to sync locally-marked read chapters

---
_Generated by [Claude Code](https://claude.ai/code)_