### PR TITLE
Fix focal-point zoom formula to include image center offset

### DIFF
--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -604,8 +604,6 @@ void ReaderActivity::onContentAvailable() {
                     m_initialZoomLevel = m_zoomLevel;
 
                     // Record initial pinch center and current zoom offset for focal-point tracking
-                    // PinchGestureRecognizer provides center in physical screen coords (0-959, 0-543)
-                    // which matches getFrame() coordinates on Vita (960x544 window)
                     m_pinchStartCenter = status.center;
                     m_pinchStartOffset = m_zoomOffset;
                 } else if (status.state == brls::GestureState::STAY) {
@@ -619,12 +617,18 @@ void ReaderActivity::onContentAvailable() {
                         if (pageImage) {
                             pageImage->setZoomLevel(newZoom);
 
-                            // Focal-point zoom: keep the image point that was under the initial
-                            // pinch center stable, adjusting for both zoom change and finger movement
-                            // Formula: offset = currentCenter/newZoom - startCenter/startZoom + startOffset
+                            // Focal-point zoom formula:
+                            // The NVG transform is: P' = C + z*(P - C + off)
+                            // where C = image center in view coords.
+                            // To keep image point P at screen pos S:
+                            //   off = (S-C)/z - (S0-C)/z0 + off0
+                            brls::Rect frame = pageImage->getFrame();
+                            float cx = frame.getMinX() + frame.getWidth() / 2.0f;
+                            float cy = frame.getMinY() + frame.getHeight() / 2.0f;
+
                             brls::Point offset = {
-                                status.center.x / newZoom - m_pinchStartCenter.x / m_initialZoomLevel + m_pinchStartOffset.x,
-                                status.center.y / newZoom - m_pinchStartCenter.y / m_initialZoomLevel + m_pinchStartOffset.y
+                                (status.center.x - cx) / newZoom - (m_pinchStartCenter.x - cx) / m_initialZoomLevel + m_pinchStartOffset.x,
+                                (status.center.y - cy) / newZoom - (m_pinchStartCenter.y - cy) / m_initialZoomLevel + m_pinchStartOffset.y
                             };
                             m_zoomOffset = offset;
                             pageImage->setZoomOffset(offset);

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -194,10 +194,15 @@ void WebtoonScrollView::setupGestures() {
                     float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
                     brls::Point currentCenter = {status.center.x * scaleX, status.center.y * scaleY};
 
-                    // Focal point zoom: keep the initial pinch point stable
-                    // offset_new = currentCenter/newZoom - initialCenter/initialZoom + initialOffset
-                    m_zoomOffset.x = currentCenter.x / newZoom - m_initialPinchCenter.x / m_initialZoomLevel + m_initialZoomOffset.x;
-                    m_zoomOffset.y = currentCenter.y / newZoom - m_initialPinchCenter.y / m_initialZoomLevel + m_initialZoomOffset.y;
+                    // Focal-point zoom formula:
+                    // NVG transform: P' = C + z*(P - C + off), C = view center
+                    // To keep image point P at screen pos S:
+                    //   off = (S-C)/z - (S0-C)/z0 + off0
+                    float cx = m_viewWidth / 2.0f;
+                    float cy = m_viewHeight / 2.0f;
+
+                    m_zoomOffset.x = (currentCenter.x - cx) / newZoom - (m_initialPinchCenter.x - cx) / m_initialZoomLevel + m_initialZoomOffset.x;
+                    m_zoomOffset.y = (currentCenter.y - cy) / newZoom - (m_initialPinchCenter.y - cy) / m_initialZoomLevel + m_initialZoomOffset.y;
 
                     m_zoomLevel = newZoom;
                     m_isZoomed = (newZoom > 1.05f);


### PR DESCRIPTION
Fix focal-point zoom formula to include image center offset

The zoom offset formula was missing the image center (C) term.
The NVG transform is P' = C + z*(P - C + off), so the correct
focal-point offset is: off = (S-C)/z - (S0-C)/z0 + off0

Without subtracting C before dividing by zoom, the image drifts
away from the pinch point as you zoom in/out.

---
_Generated by [Claude Code](https://claude.ai/code)_