### PR TITLE
Fix zoomed pan speed to track finger 1:1

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -250,6 +250,7 @@ private:
     float m_initialZoomLevel = 1.0f;
     brls::Point m_pinchStartCenter = {0, 0};   // Pinch center at gesture start
     brls::Point m_pinchStartOffset = {0, 0};   // Zoom offset at gesture start
+    std::chrono::steady_clock::time_point m_pinchEndTime;  // When pinch ended (cooldown guard)
 
     // Touch control methods
     void handleDoubleTap(brls::Point position);

--- a/include/view/webtoon_scroll_view.hpp
+++ b/include/view/webtoon_scroll_view.hpp
@@ -260,11 +260,17 @@ private:
 
     // Touch thresholds
     static constexpr float TAP_THRESHOLD = 15.0f;
+    static constexpr int DOUBLE_TAP_THRESHOLD_MS = 300;
+    static constexpr float DOUBLE_TAP_DISTANCE = 50.0f;
 
     // Zoom state
     bool m_isZoomed = false;
     float m_zoomLevel = 1.0f;
     brls::Point m_zoomOffset = {0, 0};
+
+    // Double-tap tracking
+    std::chrono::steady_clock::time_point m_lastTapTime;
+    brls::Point m_lastTapPosition = {0, 0};
 
     // Pinch-to-zoom tracking
     bool m_isPinching = false;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -635,9 +635,7 @@ void ReaderActivity::onContentAvailable() {
 
                     if (std::abs(newZoom - m_zoomLevel) > 0.01f) {
                         m_zoomLevel = newZoom;
-                        // Mark as zoomed whenever zoom differs from 1.0
-                        // (only double-tap should clear this flag via resetZoom)
-                        m_isZoomed = true;
+                        m_isZoomed = (newZoom > 1.01f);
 
                         if (pageImage) {
                             pageImage->setZoomLevel(newZoom);
@@ -662,7 +660,12 @@ void ReaderActivity::onContentAvailable() {
                 } else if (status.state == brls::GestureState::END) {
                     m_isPinching = false;
                     m_pinchEndTime = std::chrono::steady_clock::now();
-                    // Don't snap back - only double-tap resets zoom
+
+                    // If user pinched back down to 1.0x, clear zoomed state
+                    // so swipe page navigation works again without needing double-tap
+                    if (m_zoomLevel <= 1.0f) {
+                        resetZoom();
+                    }
                 }
             }));
     }

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -612,7 +612,7 @@ void ReaderActivity::onContentAvailable() {
                     m_pinchStartOffset = m_zoomOffset;
                 } else if (status.state == brls::GestureState::STAY) {
                     float newZoom = m_initialZoomLevel * status.scaleFactor;
-                    newZoom = std::max(0.5f, std::min(1.0f, newZoom));
+                    newZoom = std::max(1.0f, std::min(4.0f, newZoom));
 
                     if (std::abs(newZoom - m_zoomLevel) > 0.01f) {
                         m_zoomLevel = newZoom;
@@ -2212,8 +2212,8 @@ void ReaderActivity::handlePinchZoom(float scaleFactor) {
     // Pinch-to-zoom - scale by the pinch factor
     float newZoom = m_zoomLevel * scaleFactor;
 
-    // Clamp zoom between 0.5x and 1.0x (no zoom-in past fit)
-    newZoom = std::max(0.5f, std::min(1.0f, newZoom));
+    // Clamp zoom between 1.0x and 4.0x (no zoom-out past fit)
+    newZoom = std::max(1.0f, std::min(4.0f, newZoom));
 
     if (newZoom != m_zoomLevel) {
         if (newZoom <= 1.05f && newZoom >= 0.95f) {

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -616,7 +616,9 @@ void ReaderActivity::onContentAvailable() {
 
                     if (std::abs(newZoom - m_zoomLevel) > 0.01f) {
                         m_zoomLevel = newZoom;
-                        m_isZoomed = (newZoom > 1.05f);
+                        // Mark as zoomed whenever zoom differs from 1.0
+                        // (only double-tap should clear this flag via resetZoom)
+                        m_isZoomed = true;
 
                         if (pageImage) {
                             pageImage->setZoomLevel(newZoom);

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -612,7 +612,7 @@ void ReaderActivity::onContentAvailable() {
                     m_pinchStartOffset = m_zoomOffset;
                 } else if (status.state == brls::GestureState::STAY) {
                     float newZoom = m_initialZoomLevel * status.scaleFactor;
-                    newZoom = std::max(0.5f, std::min(4.0f, newZoom));
+                    newZoom = std::max(0.5f, std::min(1.0f, newZoom));
 
                     if (std::abs(newZoom - m_zoomLevel) > 0.01f) {
                         m_zoomLevel = newZoom;
@@ -2212,8 +2212,8 @@ void ReaderActivity::handlePinchZoom(float scaleFactor) {
     // Pinch-to-zoom - scale by the pinch factor
     float newZoom = m_zoomLevel * scaleFactor;
 
-    // Clamp zoom between 0.5x and 4x
-    newZoom = std::max(0.5f, std::min(4.0f, newZoom));
+    // Clamp zoom between 0.5x and 1.0x (no zoom-in past fit)
+    newZoom = std::max(0.5f, std::min(1.0f, newZoom));
 
     if (newZoom != m_zoomLevel) {
         if (newZoom <= 1.05f && newZoom >= 0.95f) {

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -476,10 +476,14 @@ void ReaderActivity::onContentAvailable() {
 
                     // If zoomed, use pan to scroll the zoomed image instead of page navigation
                     if (m_isZoomed) {
-                        // Update zoom offset based on pan delta
+                        // Convert physical touch delta to view coords, then divide by zoom
+                        // since the offset is in pre-scale space (applied before nvgScale).
+                        // Without /zoom, panning feels too fast at higher zoom levels.
+                        float scaleX = (pageImage ? pageImage->getWidth() : 960.0f) / 960.0f;
+                        float scaleY = (pageImage ? pageImage->getHeight() : 544.0f) / 544.0f;
                         brls::Point newOffset = {
-                            m_zoomOffset.x + dx,
-                            m_zoomOffset.y + dy
+                            m_zoomOffset.x + dx * scaleX / m_zoomLevel,
+                            m_zoomOffset.y + dy * scaleY / m_zoomLevel
                         };
 
                         // Apply offset to image

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -375,11 +375,19 @@ void ReaderActivity::onContentAvailable() {
         // Initialize double-tap tracking
         m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
         m_lastTapPosition = {0, 0};
+        m_pinchEndTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
 
         // Tap gesture for controls toggle and optional tap-to-navigate zones
         pageImage->addGestureRecognizer(new brls::TapGestureRecognizer(
             [this](brls::TapGestureStatus status, brls::Sound* soundToPlay) {
                 if (m_errorOverlay) return;  // Don't handle taps while error overlay is shown
+                if (m_isPinching) return;    // Ignore taps during active pinch
+
+                // Ignore taps that fire shortly after a pinch ends (finger-lift artifacts)
+                auto timeSincePinch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - m_pinchEndTime).count();
+                if (timeSincePinch < 300) return;
+
                 if (status.state == brls::GestureState::END) {
                     // Check for double-tap
                     auto now = std::chrono::steady_clock::now();
@@ -542,7 +550,14 @@ void ReaderActivity::onContentAvailable() {
                     }
                 } else if (status.state == brls::GestureState::END) {
                     // Don't turn the page if we were just pinch-zooming
+                    // (also check cooldown — pinch END may fire before pan END)
                     if (m_isPinching) {
+                        resetSwipeState();
+                        return;
+                    }
+                    auto msSincePinch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - m_pinchEndTime).count();
+                    if (msSincePinch < 300) {
                         resetSwipeState();
                         return;
                     }
@@ -607,6 +622,10 @@ void ReaderActivity::onContentAvailable() {
                     m_initialPinchDistance = 0;
                     m_initialZoomLevel = m_zoomLevel;
 
+                    // Invalidate any pending double-tap so lifting fingers after
+                    // pinch can't accidentally trigger handleDoubleTap/resetZoom.
+                    m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
+
                     // Record initial pinch center and current zoom offset for focal-point tracking
                     m_pinchStartCenter = status.center;
                     m_pinchStartOffset = m_zoomOffset;
@@ -642,6 +661,7 @@ void ReaderActivity::onContentAvailable() {
                     }
                 } else if (status.state == brls::GestureState::END) {
                     m_isPinching = false;
+                    m_pinchEndTime = std::chrono::steady_clock::now();
                     // Don't snap back - only double-tap resets zoom
                 }
             }));
@@ -838,6 +858,13 @@ void ReaderActivity::onContentAvailable() {
         container->addGestureRecognizer(new brls::TapGestureRecognizer(
             [this](brls::TapGestureStatus status, brls::Sound* soundToPlay) {
                 if (m_errorOverlay) return;  // Don't handle taps while error overlay is shown
+                if (m_isPinching) return;    // Ignore taps during active pinch
+
+                // Ignore taps that fire shortly after a pinch ends (finger-lift artifacts)
+                auto timeSincePinch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - m_pinchEndTime).count();
+                if (timeSincePinch < 300) return;
+
                 if (status.state == brls::GestureState::END) {
                     // Check for double-tap
                     auto now = std::chrono::steady_clock::now();

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -640,10 +640,7 @@ void ReaderActivity::onContentAvailable() {
                     }
                 } else if (status.state == brls::GestureState::END) {
                     m_isPinching = false;
-                    // Snap to 1x if near normal
-                    if (m_zoomLevel <= 1.05f && m_zoomLevel >= 0.95f) {
-                        resetZoom();
-                    }
+                    // Don't snap back - only double-tap resets zoom
                 }
             }));
     }

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -399,7 +399,7 @@ void RotatableImage::cycleRotation() {
 }
 
 void RotatableImage::setZoomLevel(float level) {
-    m_zoomLevel = std::max(0.5f, std::min(1.0f, level));  // Clamp between 0.5x and 1.0x
+    m_zoomLevel = std::max(1.0f, std::min(4.0f, level));  // Clamp between 1.0x and 4.0x
     this->invalidate();
 }
 

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -399,7 +399,7 @@ void RotatableImage::cycleRotation() {
 }
 
 void RotatableImage::setZoomLevel(float level) {
-    m_zoomLevel = std::max(0.5f, std::min(4.0f, level));  // Clamp between 0.5x and 4x
+    m_zoomLevel = std::max(0.5f, std::min(1.0f, level));  // Clamp between 0.5x and 1.0x
     this->invalidate();
 }
 

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -20,6 +20,9 @@ WebtoonScrollView::WebtoonScrollView() {
     this->setAlignItems(brls::AlignItems::CENTER);
     this->setGrow(1.0f);
 
+    // Initialize double-tap tracking
+    m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
+
     // Setup touch gestures
     setupGestures();
 }
@@ -145,27 +148,46 @@ void WebtoonScrollView::setupGestures() {
                 if (distance < TAP_THRESHOLD) {
                     m_scrollVelocity = 0.0f;
 
-                    // If zoomed, double-tap resets zoom
-                    // (single tap while zoomed just toggles controls)
+                    // Check for double-tap
+                    auto now = std::chrono::steady_clock::now();
+                    auto timeSinceLastTap = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - m_lastTapTime).count();
+                    float tapDistance = std::sqrt(
+                        std::pow(status.position.x - m_lastTapPosition.x, 2) +
+                        std::pow(status.position.y - m_lastTapPosition.y, 2));
 
-                    // Scale tap position from physical to view coords
-                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
-                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
-                    float tapX = status.position.x * scaleX;
-                    float tapY = status.position.y * scaleY;
-
-                    int tappedPage = getPageAtPosition(tapX, tapY);
-
-                    if (tappedPage >= 0 && isFailedPage(tappedPage)) {
-                        // Tapped on a failed page - retry loading
-                        m_failedPages.erase(tappedPage);
-                        m_loadedPages.erase(tappedPage);
-                        m_loadingPages.erase(tappedPage);
-                        updateVisibleImages();
+                    if (timeSinceLastTap < DOUBLE_TAP_THRESHOLD_MS &&
+                        tapDistance < DOUBLE_TAP_DISTANCE) {
+                        // Double-tap detected - reset zoom if zoomed
+                        if (m_isZoomed) {
+                            resetZoom();
+                        }
+                        // Prevent triple-tap from triggering another double-tap
+                        m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
                     } else {
-                        // Regular tap (including on transition pages) - toggle controls
-                        if (m_tapCallback) {
-                            m_tapCallback();
+                        // Single tap
+                        m_lastTapTime = now;
+                        m_lastTapPosition = status.position;
+
+                        // Scale tap position from physical to view coords
+                        float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
+                        float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                        float tapX = status.position.x * scaleX;
+                        float tapY = status.position.y * scaleY;
+
+                        int tappedPage = getPageAtPosition(tapX, tapY);
+
+                        if (tappedPage >= 0 && isFailedPage(tappedPage)) {
+                            // Tapped on a failed page - retry loading
+                            m_failedPages.erase(tappedPage);
+                            m_loadedPages.erase(tappedPage);
+                            m_loadingPages.erase(tappedPage);
+                            updateVisibleImages();
+                        } else {
+                            // Regular tap - toggle controls
+                            if (m_tapCallback) {
+                                m_tapCallback();
+                            }
                         }
                     }
                 }
@@ -211,10 +233,7 @@ void WebtoonScrollView::setupGestures() {
                 }
             } else if (status.state == brls::GestureState::END) {
                 m_isPinching = false;
-                // Snap to 1x if near normal
-                if (m_zoomLevel <= 1.05f) {
-                    resetZoom();
-                }
+                // Don't snap back - only double-tap resets zoom
             }
         }));
 }

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -229,7 +229,9 @@ void WebtoonScrollView::setupGestures() {
                     m_zoomOffset.y = (currentCenter.y - cy) / newZoom - (m_initialPinchCenter.y - cy) / m_initialZoomLevel + m_initialZoomOffset.y;
 
                     m_zoomLevel = newZoom;
-                    m_isZoomed = (newZoom > 1.05f);
+                    // Mark as zoomed whenever actively pinching
+                    // (only double-tap should clear this via resetZoom)
+                    m_isZoomed = true;
                 }
             } else if (status.state == brls::GestureState::END) {
                 m_isPinching = false;

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -298,16 +298,43 @@ int WebtoonScrollView::getPageAtPosition(float tapX, float tapY) const {
 
 void WebtoonScrollView::drawTransitionPage(NVGcontext* vg, int pageIndex,
                                              float x, float y, float width, float height) {
-    // Dark background for transition
+    // Dark background for transition (drawn in screen space)
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
     nvgFillColor(vg, nvgRGBA(20, 20, 30, 255));
     nvgFill(vg);
 
+    // Apply rotation so text matches page content orientation
+    int rotation = static_cast<int>(m_rotationDegrees);
+    float drawX = x, drawY = y, drawW = width, drawH = height;
+
+    nvgSave(vg);
+
+    if (rotation != 0) {
+        float cx = x + width * 0.5f;
+        float cy = y + height * 0.5f;
+        nvgTranslate(vg, cx, cy);
+        nvgRotate(vg, nvgDegToRad(static_cast<float>(rotation)));
+
+        if (rotation == 90 || rotation == 270) {
+            // In the rotated coordinate space, width and height are swapped
+            drawX = -height * 0.5f;
+            drawY = -width * 0.5f;
+            drawW = height;
+            drawH = width;
+        } else {
+            // 180°
+            drawX = -width * 0.5f;
+            drawY = -height * 0.5f;
+            drawW = width;
+            drawH = height;
+        }
+    }
+
     // Horizontal divider line
-    float lineY = y + height * 0.35f;
+    float lineY = drawY + drawH * 0.35f;
     nvgBeginPath(vg);
-    nvgRect(vg, x + width * 0.2f, lineY, width * 0.6f, 1.0f);
+    nvgRect(vg, drawX + drawW * 0.2f, lineY, drawW * 0.6f, 1.0f);
     nvgFillColor(vg, nvgRGBA(150, 150, 150, 100));
     nvgFill(vg);
 
@@ -321,7 +348,7 @@ void WebtoonScrollView::drawTransitionPage(NVGcontext* vg, int pageIndex,
             nvgFontSize(vg, fontSize1);
             nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
             nvgFillColor(vg, nvgRGBA(220, 220, 220, 255));
-            nvgText(vg, x + width * 0.5f, lineY - 8.0f, it->second.line1.c_str(), nullptr);
+            nvgText(vg, drawX + drawW * 0.5f, lineY - 8.0f, it->second.line1.c_str(), nullptr);
         }
 
         // Line 2 (below divider)
@@ -329,33 +356,60 @@ void WebtoonScrollView::drawTransitionPage(NVGcontext* vg, int pageIndex,
             nvgFontSize(vg, fontSize2);
             nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
             nvgFillColor(vg, nvgRGBA(180, 180, 180, 255));
-            nvgText(vg, x + width * 0.5f, lineY + 12.0f, it->second.line2.c_str(), nullptr);
+            nvgText(vg, drawX + drawW * 0.5f, lineY + 12.0f, it->second.line2.c_str(), nullptr);
         }
 
         // Scroll hint
         nvgFontSize(vg, 14.0f);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
         nvgFillColor(vg, nvgRGBA(120, 120, 120, 200));
-        nvgText(vg, x + width * 0.5f, y + height - 12.0f, "Keep scrolling to continue", nullptr);
+        nvgText(vg, drawX + drawW * 0.5f, drawY + drawH - 12.0f, "Keep scrolling to continue", nullptr);
     } else {
         // Fallback text if no transition info set
         nvgFontSize(vg, 18.0f);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
         nvgFillColor(vg, nvgRGBA(180, 180, 180, 255));
-        nvgText(vg, x + width * 0.5f, y + height * 0.5f, "Chapter transition", nullptr);
+        nvgText(vg, drawX + drawW * 0.5f, drawY + drawH * 0.5f, "Chapter transition", nullptr);
     }
+
+    nvgRestore(vg);
 }
 
 void WebtoonScrollView::drawFailedPage(NVGcontext* vg, int pageIndex,
                                         float x, float y, float width, float height) {
-    // Dark red-tinted background
+    // Dark red-tinted background (drawn in screen space)
     nvgBeginPath(vg);
     nvgRect(vg, x, y, width, height);
     nvgFillColor(vg, nvgRGBA(40, 20, 20, 255));
     nvgFill(vg);
 
-    float centerX = x + width * 0.5f;
-    float centerY = y + height * 0.5f;
+    // Apply rotation so text matches page content orientation
+    int rotation = static_cast<int>(m_rotationDegrees);
+    float drawX = x, drawY = y, drawW = width, drawH = height;
+
+    nvgSave(vg);
+
+    if (rotation != 0) {
+        float cx = x + width * 0.5f;
+        float cy = y + height * 0.5f;
+        nvgTranslate(vg, cx, cy);
+        nvgRotate(vg, nvgDegToRad(static_cast<float>(rotation)));
+
+        if (rotation == 90 || rotation == 270) {
+            drawX = -height * 0.5f;
+            drawY = -width * 0.5f;
+            drawW = height;
+            drawH = width;
+        } else {
+            drawX = -width * 0.5f;
+            drawY = -height * 0.5f;
+            drawW = width;
+            drawH = height;
+        }
+    }
+
+    float centerX = drawX + drawW * 0.5f;
+    float centerY = drawY + drawH * 0.5f;
 
     // Error message
     nvgFontSize(vg, 16.0f);
@@ -368,6 +422,8 @@ void WebtoonScrollView::drawFailedPage(NVGcontext* vg, int pageIndex,
     nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
     nvgFillColor(vg, nvgRGBA(100, 200, 180, 255));
     nvgText(vg, centerX, centerY + 4.0f, "Tap to retry", nullptr);
+
+    nvgRestore(vg);
 }
 
 void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWidth) {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -57,11 +57,13 @@ void WebtoonScrollView::setupGestures() {
                 float rawDy = status.position.y - m_touchLast.y;
 
                 // If zoomed, pan the zoomed view instead of normal scrolling
+                // Divide by zoom level since offset is in pre-scale space;
+                // without this, panning moves too fast at higher zoom levels.
                 if (m_isZoomed) {
                     float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
                     float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
-                    m_zoomOffset.x += rawDx * scaleX;
-                    m_zoomOffset.y += rawDy * scaleY;
+                    m_zoomOffset.x += rawDx * scaleX / m_zoomLevel;
+                    m_zoomOffset.y += rawDy * scaleY / m_zoomLevel;
                     m_touchLast = status.position;
                     m_lastTouchTime = std::chrono::steady_clock::now();
                     return;


### PR DESCRIPTION
Fixes reader zoom behaviour: 1:1 finger-tracked panning, removal of zoom snap-back, double-tap reset in webtoon mode, transition-page rotation, and clamping zoom to a 1.0×–4.0× range so swipe navigation still works.

---
_Generated by [Claude Code](https://claude.ai/code)_