### PR TITLE
Optimize reader page loading for downloaded and server content

### DIFF
--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -87,8 +87,19 @@ public:
 
     // Queue manga chapter(s) for download
     bool queueChapterDownload(int mangaId, int chapterId, int chapterIndex,
-                              const std::string& mangaTitle, const std::string& chapterName = "");
+                              const std::string& mangaTitle, const std::string& chapterName = "",
+                              float chapterNumber = 0.0f);
+
+    // ChapterInfo for batch queueing (carries chapter number and name)
+    struct ChapterQueueInfo {
+        int chapterId;
+        int chapterIndex;
+        float chapterNumber;
+        std::string chapterName;
+    };
     bool queueChaptersDownload(int mangaId, const std::vector<std::pair<int,int>>& chapters,
+                               const std::string& mangaTitle);
+    bool queueChaptersDownload(int mangaId, const std::vector<ChapterQueueInfo>& chapters,
                                const std::string& mangaTitle);
 
     // Start downloading queued items

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -12,6 +12,7 @@
 #include <list>
 #include <mutex>
 #include <queue>
+#include <set>
 #include <atomic>
 #include <condition_variable>
 #include <vector>
@@ -133,6 +134,7 @@ private:
     // Shared queue for worker threads
     static std::queue<LoadRequest> s_loadQueue;
     static std::queue<RotatableLoadRequest> s_rotatableLoadQueue;
+    static std::set<std::string> s_pendingFullSizeUrls;  // URLs queued or being processed (dedup)
     static std::mutex s_queueMutex;
     static std::condition_variable s_queueCV;  // Wake workers when items are queued
     static int s_maxConcurrentLoads;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1219,6 +1219,32 @@ void ReaderActivity::loadPages() {
                 }
                 loadedFromLocal = true;
                 *sharedLoadedFromLocal = true;
+
+                // Use DownloadsManager metadata for chapter navigation instead of
+                // blocking on network requests. This makes downloaded chapters load
+                // instantly without waiting for server round-trips.
+                {
+                    std::unique_lock<std::mutex> dlLock;
+                    auto* dlChapters = localMgr.getChapterDownloads(mangaId, dlLock);
+                    if (dlChapters && !dlChapters->empty()) {
+                        for (const auto& dlChapter : *dlChapters) {
+                            if (dlChapter.state != LocalDownloadState::COMPLETED) continue;
+                            Chapter ch;
+                            ch.id = dlChapter.chapterId;
+                            ch.name = dlChapter.name;
+                            ch.chapterNumber = dlChapter.chapterNumber;
+                            ch.index = dlChapter.chapterIndex;
+                            ch.downloaded = true;
+                            sharedChapters->push_back(ch);
+
+                            // Get current chapter name
+                            if (dlChapter.chapterId == chapterIndex || dlChapter.chapterIndex == chapterIndex) {
+                                *sharedChapterName = dlChapter.name;
+                            }
+                        }
+                        *sharedTotalChapters = static_cast<int>(sharedChapters->size());
+                    }
+                }  // dlLock released
             } else {
                 brls::Logger::warning("ReaderActivity: Local chapter marked as downloaded but no pages found");
             }
@@ -1236,8 +1262,9 @@ void ReaderActivity::loadPages() {
         // Use pages as-is (no splitting)
         *sharedPages = std::move(rawPages);
 
-        // Fetch chapter details and navigation from server (skip when offline)
-        if (Application::getInstance().isConnected()) {
+        // For server-loaded pages, fetch chapter metadata now (required for navigation).
+        // Downloaded chapters already got metadata from DownloadsManager above.
+        if (!loadedFromLocal && Application::getInstance().isConnected()) {
             Chapter chapter;
             if (client.fetchChapter(mangaId, chapterIndex, chapter)) {
                 *sharedChapterName = chapter.name;

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -142,7 +142,8 @@ bool DownloadsManager::init() {
 
 bool DownloadsManager::queueChapterDownload(int mangaId, int chapterId, int chapterIndex,
                                              const std::string& mangaTitle,
-                                             const std::string& chapterName) {
+                                             const std::string& chapterName,
+                                             float chapterNumber) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     brls::Logger::info("DownloadsManager: Queueing chapter {} (id={}) for manga {} ({})",
@@ -181,6 +182,7 @@ bool DownloadsManager::queueChapterDownload(int mangaId, int chapterId, int chap
     chapter.chapterId = chapterId;
     chapter.chapterIndex = chapterIndex;
     chapter.name = chapterName;
+    chapter.chapterNumber = chapterNumber;
     chapter.state = LocalDownloadState::QUEUED;
     manga->chapters.push_back(chapter);
     manga->totalChapters = static_cast<int>(manga->chapters.size());
@@ -250,6 +252,67 @@ bool DownloadsManager::queueChaptersDownload(int mangaId,
     if (addedCount > 0) {
         saveStateUnlocked();
         brls::Logger::info("DownloadsManager: Batch queued {} chapters successfully", addedCount);
+    }
+
+    return true;
+}
+
+bool DownloadsManager::queueChaptersDownload(int mangaId,
+                                              const std::vector<ChapterQueueInfo>& chapters,
+                                              const std::string& mangaTitle) {
+    if (chapters.empty()) return true;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    brls::Logger::info("DownloadsManager: Batch queueing {} chapters (with metadata) for manga {} ({})",
+                       chapters.size(), mangaId, mangaTitle);
+
+    // Find or create manga download item
+    DownloadItem* manga = nullptr;
+    for (auto& item : m_downloads) {
+        if (item.mangaId == mangaId) {
+            manga = &item;
+            break;
+        }
+    }
+
+    if (!manga) {
+        DownloadItem newItem;
+        newItem.mangaId = mangaId;
+        newItem.title = mangaTitle;
+        newItem.state = LocalDownloadState::QUEUED;
+        newItem.localPath = createMangaDir(mangaId, mangaTitle);
+        m_downloads.push_back(newItem);
+        manga = &m_downloads.back();
+    }
+
+    int addedCount = 0;
+    for (const auto& ch : chapters) {
+        bool exists = false;
+        for (const auto& existingCh : manga->chapters) {
+            if (existingCh.chapterIndex == ch.chapterIndex || existingCh.chapterId == ch.chapterId) {
+                exists = true;
+                break;
+            }
+        }
+
+        if (!exists) {
+            DownloadedChapter chapter;
+            chapter.chapterId = ch.chapterId;
+            chapter.chapterIndex = ch.chapterIndex;
+            chapter.name = ch.chapterName;
+            chapter.chapterNumber = ch.chapterNumber;
+            chapter.state = LocalDownloadState::QUEUED;
+            manga->chapters.push_back(chapter);
+            addedCount++;
+        }
+    }
+
+    manga->totalChapters = static_cast<int>(manga->chapters.size());
+
+    if (addedCount > 0) {
+        saveStateUnlocked();
+        brls::Logger::info("DownloadsManager: Batch queued {} chapters (with metadata) successfully", addedCount);
     }
 
     return true;

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -53,6 +53,7 @@ std::string ImageLoader::s_accessToken;
 std::mutex ImageLoader::s_authMutex;
 std::queue<ImageLoader::LoadRequest> ImageLoader::s_loadQueue;
 std::queue<ImageLoader::RotatableLoadRequest> ImageLoader::s_rotatableLoadQueue;
+std::set<std::string> ImageLoader::s_pendingFullSizeUrls;
 std::mutex ImageLoader::s_queueMutex;
 std::condition_variable ImageLoader::s_queueCV;
 int ImageLoader::s_maxConcurrentLoads = 3;  // Worker thread count - kept low for PS Vita memory limits
@@ -876,6 +877,14 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
     int totalSegments = request.totalSegments;
     std::shared_ptr<bool> alive = request.alive;
 
+    // Remove URL from the pending dedup set now that a worker has picked it up.
+    // This must happen before any early return so new requests for this URL can
+    // be queued if the current load is skipped (e.g., owner destroyed).
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        s_pendingFullSizeUrls.erase(url);
+    }
+
     // Early out if owner was destroyed before we started
     if (alive && !*alive) return;
 
@@ -1068,15 +1077,36 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
                     segSrcHeights.push_back(endY - startY);
                 }
 
-                if (allOK && !segmentDatas.empty() && (target || callback)) {
-                    brls::sync([segDatas = std::move(segmentDatas), origW, origH,
-                                segHeights = std::move(segSrcHeights), callback, target, alive]() {
-                        if (alive && !*alive) return;
-                        if (target) {
-                            target->setImageSegments(segDatas, origW, origH, segHeights);
-                            if (callback) callback(target);
-                        }
-                    });
+                if (allOK && !segmentDatas.empty()) {
+                    // Store compact metadata under the main cache key so that
+                    // loadAsyncFullSize can reconstruct from cached segments
+                    // without re-reading the file from disk.
+                    // Format: "ASEG" + uint16 count + uint16 origW + uint16 origH + uint16[] segHeights
+                    std::vector<uint8_t> meta;
+                    meta.resize(4 + 2 + 2 + 2 + 2 * autoSegments);
+                    meta[0] = 'A'; meta[1] = 'S'; meta[2] = 'E'; meta[3] = 'G';
+                    uint16_t cnt = static_cast<uint16_t>(autoSegments);
+                    uint16_t mw = static_cast<uint16_t>(std::min(origW, 65535));
+                    uint16_t mh = static_cast<uint16_t>(std::min(origH, 65535));
+                    memcpy(&meta[4], &cnt, 2);
+                    memcpy(&meta[6], &mw, 2);
+                    memcpy(&meta[8], &mh, 2);
+                    for (int s = 0; s < autoSegments; s++) {
+                        uint16_t sh = static_cast<uint16_t>(segSrcHeights[s]);
+                        memcpy(&meta[10 + s * 2], &sh, 2);
+                    }
+                    cachePut(url + "_full", meta);
+
+                    if (target || callback) {
+                        brls::sync([segDatas = std::move(segmentDatas), origW, origH,
+                                    segHeights = std::move(segSrcHeights), callback, target, alive]() {
+                            if (alive && !*alive) return;
+                            if (target) {
+                                target->setImageSegments(segDatas, origW, origH, segHeights);
+                                if (callback) callback(target);
+                            }
+                        });
+                    }
                     return;  // Done - skip normal single-texture path
                 }
 
@@ -1187,15 +1217,57 @@ void ImageLoader::loadAsyncFullSize(const std::string& url, RotatableLoadCallbac
     {
         std::vector<uint8_t> cachedData;
         if (cacheGet(cacheKey, cachedData)) {
-            target->setImageFromMem(cachedData.data(), cachedData.size());
-            if (callback) callback(target);
-            return;
+            // Check for auto-segment metadata marker (stored when tall images are split)
+            if (cachedData.size() >= 10 &&
+                cachedData[0] == 'A' && cachedData[1] == 'S' &&
+                cachedData[2] == 'E' && cachedData[3] == 'G') {
+                // Reconstruct from cached segments
+                uint16_t cnt, mw, mh;
+                memcpy(&cnt, &cachedData[4], 2);
+                memcpy(&mw, &cachedData[6], 2);
+                memcpy(&mh, &cachedData[8], 2);
+                int segCount = cnt;
+                int origW = mw, origH = mh;
+
+                std::vector<std::vector<uint8_t>> segDatas;
+                std::vector<int> segHeights;
+                bool allFound = true;
+
+                for (int s = 0; s < segCount && allFound; s++) {
+                    std::string segCK = url + "_full_autoseg" + std::to_string(s);
+                    std::vector<uint8_t> segData;
+                    if (cacheGet(segCK, segData)) {
+                        segDatas.push_back(std::move(segData));
+                        if (static_cast<size_t>(10 + s * 2 + 2) <= cachedData.size()) {
+                            uint16_t sh;
+                            memcpy(&sh, &cachedData[10 + s * 2], 2);
+                            segHeights.push_back(sh);
+                        }
+                    } else {
+                        allFound = false;  // Segment evicted, need full reload
+                    }
+                }
+
+                if (allFound && !segDatas.empty()) {
+                    target->setImageSegments(segDatas, origW, origH, segHeights);
+                    if (callback) callback(target);
+                    return;
+                }
+                // Segments evicted from cache, fall through to full reload
+                brls::Logger::debug("ImageLoader: Auto-seg cache partial miss for {}, reloading", url);
+            } else {
+                // Normal single-texture cache hit
+                target->setImageFromMem(cachedData.data(), cachedData.size());
+                if (callback) callback(target);
+                return;
+            }
         }
     }
 
-    // Add to rotatable queue
+    // Add to rotatable queue (also track in pending set for dedup)
     {
         std::lock_guard<std::mutex> lock(s_queueMutex);
+        s_pendingFullSizeUrls.insert(url);
         s_rotatableLoadQueue.push({url, callback, target, 0, 1, alive});
     }
 
@@ -1384,9 +1456,15 @@ void ImageLoader::preloadFullSize(const std::string& url) {
         }
     }
 
-    // Queue for full-size loading using rotatable queue (same as reader pages)
+    // Check if already queued or being processed to avoid duplicate disk I/O and decode work.
+    // On Vita's memory card, concurrent reads are serialized at the hardware level,
+    // so duplicate reads waste time and starve the worker pool.
     {
         std::lock_guard<std::mutex> lock(s_queueMutex);
+        if (s_pendingFullSizeUrls.count(url)) {
+            return;  // Already queued or being processed
+        }
+        s_pendingFullSizeUrls.insert(url);
         s_rotatableLoadQueue.push({url, nullptr, nullptr});  // No callback/target for preload
     }
 
@@ -1410,6 +1488,7 @@ void ImageLoader::cancelAll() {
         while (!s_rotatableLoadQueue.empty()) {
             s_rotatableLoadQueue.pop();
         }
+        s_pendingFullSizeUrls.clear();
     }
     // Also clear pending texture uploads
     {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2091,7 +2091,7 @@ void LibrarySectionTab::downloadChapters(const std::vector<Manga>& mangaList, co
             std::reverse(chapters.begin(), chapters.end());
 
             std::vector<int> serverChapterIds;
-            std::vector<std::pair<int, int>> localChapterPairs;
+            std::vector<DownloadsManager::ChapterQueueInfo> localChapterPairs;
 
             auto collectChapter = [&](const Chapter& ch) {
                 if ((downloadMode == DownloadMode::SERVER_ONLY || downloadMode == DownloadMode::BOTH) && !ch.downloaded) {
@@ -2099,7 +2099,7 @@ void LibrarySectionTab::downloadChapters(const std::vector<Manga>& mangaList, co
                 }
                 if ((downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) &&
                     !localMgr.isChapterDownloaded(manga.id, ch.index)) {
-                    localChapterPairs.push_back({ch.id, ch.index});
+                    localChapterPairs.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
                 }
             };
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -241,10 +241,10 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
         return true;
     });
 
-    // Select button to start reading
+    // Select button to continue reading (same as Continue Reading button)
     cell->registerAction("Read", brls::ControllerButton::BUTTON_BACK,
-        [view, capturedChapter](brls::View*) {
-        view->onRead(capturedChapter.id);
+        [view](brls::View*) {
+        view->onRead();
         return true;
     });
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -241,13 +241,6 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
         return true;
     });
 
-    // Select button to continue reading (same as Continue Reading button)
-    cell->registerAction("Read", brls::ControllerButton::BUTTON_BACK,
-        [view](brls::View*) {
-        view->onRead();
-        return true;
-    });
-
     // Download button click
     cell->dlBtn->registerClickAction([view, capturedChapter, isLocallyDownloaded, isLocallyQueued,
                                        isLocallyDownloading, mangaId, chapterIdx, dlState](brls::View*) {
@@ -520,6 +513,12 @@ MangaDetailView::MangaDetailView(const Manga& manga)
         return true;
     }, false, false, brls::Sound::SOUND_BACK);
 
+    // Select button always triggers continue reading, no matter what is focused
+    this->registerAction("Read", brls::ControllerButton::BUTTON_BACK, [this](brls::View*) {
+        onRead();
+        return true;
+    });
+
     // Load saved chapter sort order
     m_sortDescending = Application::getInstance().getSettings().chapterSortDescending;
 
@@ -623,10 +622,6 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     }
     m_readButton->setText(readText);
     m_readButton->registerClickAction([this](brls::View* view) {
-        onRead();
-        return true;
-    });
-    m_readButton->registerAction("Read", brls::ControllerButton::BUTTON_BACK, [this](brls::View*) {
         onRead();
         return true;
     });

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -278,7 +278,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
     bool localDownloading = isLocallyDownloading;
 
     cell->addGestureRecognizer(new brls::PanGestureRecognizer(
-        [view, cell, mangaId, chapterIndex, chapterId, chapterRead,
+        [view, cell, mangaId, chapterIndex, chapterId, chapterNum, chapterRead,
          localDownloaded, localQueued, localDownloading, serverDownloaded,
          mangaTitle, chapterName](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
             static brls::Point touchStart;

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -268,6 +268,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
     // Swipe gesture support (Komikku-style)
     int chapterId = capturedChapter.id;
     int chapterIndex = capturedChapter.index;
+    float chapterNum = capturedChapter.chapterNumber;
     std::string mangaTitle = m_view->m_manga.title;
     std::string chapterName = capturedChapter.name;
     bool serverDownloaded = capturedChapter.downloaded;
@@ -371,7 +372,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                 });
                             });
                         } else {
-                            asyncRun([view, mangaId, chapterId, chapterIndex, mangaTitle,
+                            asyncRun([view, mangaId, chapterId, chapterIndex, chapterNum, mangaTitle,
                                       chapterName, downloadMode]() {
                                 SuwayomiClient& client = SuwayomiClient::getInstance();
                                 DownloadsManager& dm = DownloadsManager::getInstance();
@@ -384,7 +385,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                 if (downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) {
                                     dm.init();
                                     localQueued = dm.queueChapterDownload(mangaId, chapterId, chapterIndex,
-                                                                          mangaTitle, chapterName);
+                                                                          mangaTitle, chapterName, chapterNum);
                                     if (localQueued) { dm.startDownloads(); }
                                 }
                                 brls::sync([view, serverQueued, localQueued]() {
@@ -1180,16 +1181,16 @@ void MangaDetailView::loadDetails() {
                             client.startDownloads();
                         }
                         if (autoDownloadMode == DownloadMode::LOCAL_ONLY || autoDownloadMode == DownloadMode::BOTH) {
-                            std::vector<std::pair<int, int>> localPairs;
+                            std::vector<DownloadsManager::ChapterQueueInfo> localChapters;
                             for (const auto& ch : chapters) {
                                 if (!ch.read && !ch.downloaded &&
                                     !localMgr.isChapterDownloaded(combinedMangaId, ch.index)) {
-                                    localPairs.emplace_back(ch.id, ch.index);
+                                    localChapters.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
                                 }
                             }
-                            if (!localPairs.empty()) {
+                            if (!localChapters.empty()) {
                                 std::string mangaTitle = updatedManga.title.empty() ? "" : updatedManga.title;
-                                localMgr.queueChaptersDownload(combinedMangaId, localPairs, mangaTitle);
+                                localMgr.queueChaptersDownload(combinedMangaId, localChapters, mangaTitle);
                                 localMgr.startDownloads();
                             }
                         }
@@ -1438,15 +1439,15 @@ void MangaDetailView::loadChapters() {
                         client.startDownloads();
                     }
                     if (autoDownloadMode == DownloadMode::LOCAL_ONLY || autoDownloadMode == DownloadMode::BOTH) {
-                        std::vector<std::pair<int, int>> localPairs;
+                        std::vector<DownloadsManager::ChapterQueueInfo> localChapters;
                         for (const auto& ch : chapters) {
                             if (!ch.read && !ch.downloaded &&
                                 !localMgr.isChapterDownloaded(mangaId, ch.index)) {
-                                localPairs.emplace_back(ch.id, ch.index);
+                                localChapters.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
                             }
                         }
-                        if (!localPairs.empty()) {
-                            localMgr.queueChaptersDownload(mangaId, localPairs, m_manga.title);
+                        if (!localChapters.empty()) {
+                            localMgr.queueChaptersDownload(mangaId, localChapters, m_manga.title);
                             localMgr.startDownloads();
                         }
                     }
@@ -2171,7 +2172,7 @@ void MangaDetailView::downloadAllChapters() {
     localMgr.init();
 
     std::vector<int> serverChapterIds;
-    std::vector<std::pair<int, int>> localChapterPairs;  // (chapterId, chapterIndex)
+    std::vector<DownloadsManager::ChapterQueueInfo> localChapterPairs;
 
     for (const auto& ch : m_chapters) {
         bool needsServerDownload = !ch.downloaded;
@@ -2182,7 +2183,7 @@ void MangaDetailView::downloadAllChapters() {
         }
 
         if ((downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) && needsLocalDownload) {
-            localChapterPairs.push_back({ch.id, ch.index});
+            localChapterPairs.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
         }
     }
 
@@ -2346,7 +2347,7 @@ void MangaDetailView::downloadUnreadChapters() {
     localMgr.init();
 
     std::vector<int> serverChapterIds;
-    std::vector<std::pair<int, int>> localChapterPairs;
+    std::vector<DownloadsManager::ChapterQueueInfo> localChapterPairs;
 
     for (const auto& ch : m_chapters) {
         if (ch.read) continue;  // Skip read chapters
@@ -2359,7 +2360,7 @@ void MangaDetailView::downloadUnreadChapters() {
         }
 
         if ((downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) && needsLocalDownload) {
-            localChapterPairs.push_back({ch.id, ch.index});
+            localChapterPairs.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
         }
     }
 
@@ -2629,13 +2630,14 @@ void MangaDetailView::downloadChapter(const Chapter& chapter) {
     int mangaId = m_manga.id;
     int chapterId = chapter.id;
     int chapterIndex = chapter.index;
+    float chapterNum = chapter.chapterNumber;
     std::string mangaTitle = m_manga.title;
     std::string chapterName = chapter.name;
 
     // Get download mode setting
     DownloadMode downloadMode = Application::getInstance().getSettings().downloadMode;
 
-    asyncRun([this, mangaId, chapterId, chapterIndex, mangaTitle, chapterName, downloadMode,
+    asyncRun([this, mangaId, chapterId, chapterIndex, chapterNum, mangaTitle, chapterName, downloadMode,
               aliveWeak = std::weak_ptr<bool>(m_alive)]() {
         bool serverQueued = false;
         bool localQueued = false;
@@ -2651,7 +2653,7 @@ void MangaDetailView::downloadChapter(const Chapter& chapter) {
         if (downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) {
             DownloadsManager& dm = DownloadsManager::getInstance();
             dm.init();
-            localQueued = dm.queueChapterDownload(mangaId, chapterId, chapterIndex, mangaTitle, chapterName);
+            localQueued = dm.queueChapterDownload(mangaId, chapterId, chapterIndex, mangaTitle, chapterName, chapterNum);
             if (localQueued) {
                 dm.startDownloads();
             }
@@ -3654,14 +3656,14 @@ void MangaDetailView::downloadSelected() {
     int mangaId = m_manga.id;
     std::string mangaTitle = m_manga.title;
     std::vector<int> chapterIds;
-    std::vector<std::pair<int, int>> localChapterPairs;
+    std::vector<DownloadsManager::ChapterQueueInfo> localChapterPairs;
 
     for (int idx : m_selectedChapters) {
         if (idx >= 0 && idx < static_cast<int>(m_chapters.size())) {
             const auto& ch = m_chapters[idx];
             if (!ch.downloaded) {
                 chapterIds.push_back(ch.id);
-                localChapterPairs.push_back({ch.id, ch.index});
+                localChapterPairs.push_back({ch.id, ch.index, ch.chapterNumber, ch.name});
             }
         }
     }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -619,10 +619,14 @@ MangaDetailView::MangaDetailView(const Manga& manga)
 
     std::string readText = "Start Reading";
     if (m_manga.lastChapterRead > 0) {
-        readText = "Continue Ch. " + std::to_string(m_manga.lastChapterRead);
+        readText = "Continue Reading";
     }
     m_readButton->setText(readText);
     m_readButton->registerClickAction([this](brls::View* view) {
+        onRead();
+        return true;
+    });
+    m_readButton->registerAction("Read", brls::ControllerButton::BUTTON_BACK, [this](brls::View*) {
         onRead();
         return true;
     });


### PR DESCRIPTION
Optimizes reader page loading for downloaded and server content, fixes the reader showing 'chapter 0' by storing the chapter number in downloads, and wires the Select button on chapter cells to continue-reading.

---
_Generated by [Claude Code](https://claude.ai/code)_