### PR TITLE
Update chapter read state locally on reader exit without full refresh

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -152,6 +152,7 @@ private:
     int m_chapterPosition = -1;  // Position of current chapter in m_chapters list
     std::string m_mangaTitle;
     std::string m_chapterName;
+    std::vector<int> m_readChapterIds;  // Chapter IDs marked read during this session
 
     // Find position of current chapter in m_chapters by matching chapter ID
     void findChapterPosition();

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -275,6 +275,7 @@ public:
         int lastPageRead = 0;    // Last page position
         bool markedRead = false;  // Whether chapter was marked as read
         int64_t timestamp = 0;   // When this was updated (milliseconds)
+        std::vector<int> chaptersRead;  // All chapter IDs marked read during session
     };
     void setLastReaderResult(const ReaderResult& result) {
         m_lastReaderResult = result;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1861,6 +1861,11 @@ void ReaderActivity::markChapterAsRead() {
     int chapterPos = m_chapterPosition;
     int totalChapters = m_totalChapters;
 
+    // Track every chapter marked read so the detail view can update all of them
+    if (std::find(m_readChapterIds.begin(), m_readChapterIds.end(), chapterId) == m_readChapterIds.end()) {
+        m_readChapterIds.push_back(chapterId);
+    }
+
     // Always mark locally in downloads manager (works offline)
     DownloadsManager::getInstance().markChapterReadLocally(mangaId, chapterId);
 
@@ -3488,6 +3493,7 @@ void ReaderActivity::willDisappear(bool resetState) {
     result.markedRead = (!m_pages.empty() && adjustedPage >= m_realPageCount - 1);
     result.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
+    result.chaptersRead = m_readChapterIds;
     Application::getInstance().setLastReaderResult(result);
 
     // If user finished the chapter (on last page), mark it as read

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -472,15 +472,20 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     Application::getInstance().setReaderResultCallback(
         [this, mangaId, aliveWeak = std::weak_ptr<bool>(m_alive)](const Application::ReaderResult& result) {
             if (result.mangaId != mangaId) return;
-            // Defer to next frame so the reader activity finishes popping first
+            // Defer to next frame so the reader activity finishes popping first.
+            // Restore m_alive now — willAppear may not fire for Box views,
+            // so the deferred lambda needs the flag set before it runs.
+            auto alive = aliveWeak.lock();
+            if (alive) *alive = true;
             brls::sync([this, aliveWeak]() {
-                auto alive = aliveWeak.lock();
-                if (!alive || !*alive) return;
+                auto a = aliveWeak.lock();
+                if (!a || !*a) return;
+                const auto& r = Application::getInstance().getLastReaderResult();
+                if (r.timestamp <= 0) return;  // Already consumed by willAppear
                 applyReaderResult();
                 Application::getInstance().clearLastReaderResult();
                 updateChapterDownloadStates();
                 updateReadButtonText();
-                // Also refresh chapter list cells to show updated read state
                 populateChaptersList();
             });
         });
@@ -1044,17 +1049,23 @@ void MangaDetailView::willAppear(bool resetState) {
 
     // On first appearance, chapters are loaded via loadDetails() (called from constructor).
     // Skip loadChapters() here to avoid duplicate network requests and UI rebuilds.
-    // On subsequent appearances (returning from reader), refresh chapters from server.
+    // On subsequent appearances (returning from reader), apply the reader result
+    // locally — no full server refresh needed since we track all reads in-session.
     if (!m_firstAppearance) {
-        if (!m_chapters.empty()) {
-            // Apply last reader result to update chapter state immediately
-            // (don't clear yet - loadChapters will re-apply after server data arrives)
+        const auto& result = Application::getInstance().getLastReaderResult();
+        if (result.mangaId == m_manga.id && result.timestamp > 0 && !m_chapters.empty()) {
+            // Returning from reader for this manga — apply reads locally
             applyReaderResult();
+            Application::getInstance().clearLastReaderResult();
             updateChapterDownloadStates();
             updateReadButtonText();
+            populateChaptersList();
+        } else if (!m_chapters.empty()) {
+            // Returning from somewhere else — do a server refresh
+            updateChapterDownloadStates();
+            updateReadButtonText();
+            loadChapters();
         }
-        // Refresh from server for full accuracy
-        loadChapters();
     }
     m_firstAppearance = false;
 }
@@ -3344,9 +3355,10 @@ void MangaDetailView::applyReaderResult() {
     const auto& result = Application::getInstance().getLastReaderResult();
     if (result.mangaId != m_manga.id || result.timestamp <= 0) return;
 
+    // Mark all chapters that were read during the session
     for (auto& ch : m_chapters) {
+        // Current chapter: update page progress + read flag
         if (ch.id == result.chapterId) {
-            // Only apply if our reader result is more recent than what we have
             if (result.timestamp >= ch.lastReadAt) {
                 ch.lastPageRead = result.lastPageRead;
                 ch.lastReadAt = result.timestamp;
@@ -3356,7 +3368,15 @@ void MangaDetailView::applyReaderResult() {
                 brls::Logger::info("MangaDetailView: Applied reader result - ch={} page={} read={}",
                                   ch.id, ch.lastPageRead, ch.read);
             }
-            break;
+        }
+        // Chapters read during transitions (swiping through multiple chapters)
+        for (int readId : result.chaptersRead) {
+            if (ch.id == readId && !ch.read) {
+                ch.read = true;
+                ch.lastReadAt = result.timestamp;
+                brls::Logger::info("MangaDetailView: Marked chapter {} as read (session)", ch.id);
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Update chapter read state locally on reader exit without full refresh

When returning from the reader, chapter progress (read/unread) now
updates immediately without a full server refresh:

- Track all chapter IDs marked read during a reading session
  (not just the last chapter) in ReaderResult.chaptersRead
- applyReaderResult() now marks ALL session-read chapters, so
  swiping through ch 5→6→7→8 shows all four as read
- willAppear() skips loadChapters() server fetch when returning
  from reader — the local state is already accurate
- Fix m_alive flag in callback so updates work even if willAppear
  doesn't fire for Box-based views

---
_Generated by [Claude Code](https://claude.ai/code)_