### PR TITLE
Show actual manga pages during chapter transition swipe

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -216,8 +216,6 @@ private:
     int m_negPreviewIdx = -1;             // Page index loaded in negative-side preview
     bool m_posIsTransition = false;       // Positive side is a transition page (uses transitionBox)
     bool m_negIsTransition = false;       // Negative side is a transition page
-    bool m_posSkipTransition = false;     // Positive side: cross-chapter image loaded, skip transition
-    bool m_negSkipTransition = false;     // Negative side: cross-chapter image loaded, skip transition
     void updateSwipePreview(float offset);
     void loadPreviewPage(int index);
     void loadPreviewInto(RotatableImage* target, int index);

--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -216,6 +216,8 @@ private:
     int m_negPreviewIdx = -1;             // Page index loaded in negative-side preview
     bool m_posIsTransition = false;       // Positive side is a transition page (uses transitionBox)
     bool m_negIsTransition = false;       // Negative side is a transition page
+    bool m_posSkipTransition = false;     // Positive side: cross-chapter image loaded, skip transition
+    bool m_negSkipTransition = false;     // Negative side: cross-chapter image loaded, skip transition
     void updateSwipePreview(float offset);
     void loadPreviewPage(int index);
     void loadPreviewInto(RotatableImage* target, int index);

--- a/include/view/rotatable_box.hpp
+++ b/include/view/rotatable_box.hpp
@@ -33,12 +33,25 @@ public:
     void setSlideOffset(float x, float y);
     void resetSlideOffset();
 
+    /**
+     * Set a custom background color drawn via NanoVG inside draw().
+     * This replaces the borealis backgroundColor XML attribute, which is
+     * drawn at the view's layout position BEFORE draw() is called and
+     * therefore ignores slide offsets. By drawing the background manually
+     * inside draw(), it correctly follows the slide offset transform.
+     */
+    void setCustomBackground(NVGcolor color);
+
     static brls::View* create();
 
 private:
     float m_rotationDegrees = 0.0f;
     float m_slideX = 0.0f;
     float m_slideY = 0.0f;
+
+    // Custom NanoVG background (drawn inside draw() so it follows slide offset)
+    bool m_hasCustomBg = false;
+    NVGcolor m_customBgColor = {};
 };
 
 } // namespace vitasuwayomi

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -16,26 +16,6 @@
         height="100%"
         grow="1"/>
 
-    <!-- Preview page (positive swipe direction) - hidden by default -->
-    <RotatableImage
-        id="reader/preview_image"
-        width="100%"
-        height="100%"
-        positionType="absolute"
-        positionTop="0"
-        positionLeft="0"
-        visibility="gone"/>
-
-    <!-- Preview page (negative swipe direction) - hidden by default -->
-    <RotatableImage
-        id="reader/preview_image_b"
-        width="100%"
-        height="100%"
-        positionType="absolute"
-        positionTop="0"
-        positionLeft="0"
-        visibility="gone"/>
-
     <!-- Webtoon continuous scroll view - hidden by default, shown in webtoon mode -->
     <WebtoonScrollView
         id="reader/webtoon_scroll"
@@ -92,6 +72,28 @@
             scalingType="fit"
             visibility="gone"/>
     </RotatableBox>
+
+    <!-- Preview pages: placed AFTER transition_box so they draw on top during swipes.
+         Use "invisible" (not "gone") so borealis always calculates their layout
+         dimensions — GONE views have 0x0 size until the next layout pass after
+         becoming VISIBLE, which causes a blank frame during swipe previews. -->
+    <RotatableImage
+        id="reader/preview_image"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="invisible"/>
+
+    <RotatableImage
+        id="reader/preview_image_b"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="invisible"/>
 
     <!-- Page counter overlay (top-right, auto-hides, rotates with content) -->
     <RotatableLabel

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -54,7 +54,6 @@
         axis="column"
         justifyContent="center"
         alignItems="center"
-        backgroundColor="#14141e"
         positionType="absolute"
         positionTop="0"
         positionLeft="0"

--- a/resources/xml/activity/reader.xml
+++ b/resources/xml/activity/reader.xml
@@ -16,6 +16,26 @@
         height="100%"
         grow="1"/>
 
+    <!-- Preview page (positive swipe direction) - hidden by default -->
+    <RotatableImage
+        id="reader/preview_image"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="gone"/>
+
+    <!-- Preview page (negative swipe direction) - hidden by default -->
+    <RotatableImage
+        id="reader/preview_image_b"
+        width="100%"
+        height="100%"
+        positionType="absolute"
+        positionTop="0"
+        positionLeft="0"
+        visibility="gone"/>
+
     <!-- Webtoon continuous scroll view - hidden by default, shown in webtoon mode -->
     <WebtoonScrollView
         id="reader/webtoon_scroll"
@@ -72,28 +92,6 @@
             scalingType="fit"
             visibility="gone"/>
     </RotatableBox>
-
-    <!-- Preview pages: placed AFTER transition_box so they draw on top during swipes.
-         Use "invisible" (not "gone") so borealis always calculates their layout
-         dimensions — GONE views have 0x0 size until the next layout pass after
-         becoming VISIBLE, which causes a blank frame during swipe previews. -->
-    <RotatableImage
-        id="reader/preview_image"
-        width="100%"
-        height="100%"
-        positionType="absolute"
-        positionTop="0"
-        positionLeft="0"
-        visibility="invisible"/>
-
-    <RotatableImage
-        id="reader/preview_image_b"
-        width="100%"
-        height="100%"
-        positionType="absolute"
-        positionTop="0"
-        positionLeft="0"
-        visibility="invisible"/>
 
     <!-- Page counter overlay (top-right, auto-hides, rotates with content) -->
     <RotatableLabel

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -556,10 +556,17 @@ void ReaderActivity::onContentAvailable() {
                             m_swipingToNext = wantNextPage;
 
                             // Check if active side is a transition page for chapter navigation
-                            bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
-                            m_previewIsTransition = activeIsTransition;
-                            if (activeIsTransition && transitionBox) {
-                                loadPreviewPage(activeIdx);  // Populate transitionBox text
+                            bool activeSkipTrans = rawDelta > 0 ? m_posSkipTransition : m_negSkipTransition;
+                            if (activeSkipTrans) {
+                                // Cross-chapter image loaded in preview — skip text card
+                                m_previewIsTransition = false;
+                                m_swipeToChapter = true;
+                            } else {
+                                bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
+                                m_previewIsTransition = activeIsTransition;
+                                if (activeIsTransition && transitionBox) {
+                                    loadPreviewPage(activeIdx);  // Populate transitionBox text
+                                }
                             }
                         }
 
@@ -3021,12 +3028,47 @@ void ReaderActivity::preloadAdjacentPreviews() {
     int posIdx = positiveIsNext ? m_currentPage + 1 : m_currentPage - 1;
     int negIdx = positiveIsNext ? m_currentPage - 1 : m_currentPage + 1;
 
+    // Helper: try to load a cross-chapter page into a preview image.
+    // Returns true if a real page image was loaded (skip the text transition).
+    auto tryLoadCrossChapter = [&](int idx, RotatableImage* target) -> bool {
+        if (!target || idx < 0 || idx >= static_cast<int>(m_pages.size())) return false;
+        if (!isTransitionPage(idx)) return false;
+        // Skip webtoon/continuous mode — transition text is fine there
+        if (m_continuousScrollMode) return false;
+
+        const std::string& url = m_pages[idx].imageUrl;
+        std::string crossUrl;
+
+        if (url == TRANSITION_NEXT && m_nextChapterLoaded && !m_nextChapterPages.empty()) {
+            crossUrl = m_nextChapterPages[0].imageUrl;
+        } else if (url == TRANSITION_PREV && m_prevChapterLoaded && !m_prevChapterPages.empty()) {
+            crossUrl = m_prevChapterPages.back().imageUrl;
+        }
+
+        if (crossUrl.empty()) return false;
+
+        target->setRotation(static_cast<float>(m_settings.rotation));
+        auto previewAlive = m_previewLoadAlive ? m_previewLoadAlive : m_alive;
+        std::weak_ptr<bool> aliveWeak = m_alive;
+        ImageLoader::loadAsyncFullSize(crossUrl, [aliveWeak](RotatableImage*) {
+            auto a = aliveWeak.lock();
+            if (!a || !*a) return;
+        }, target, previewAlive);
+        return true;
+    };
+
     // Load positive side
     m_posIsTransition = false;
+    m_posSkipTransition = false;
     if (posIdx >= 0 && posIdx < static_cast<int>(m_pages.size())) {
         m_posPreviewIdx = posIdx;
         if (isTransitionPage(posIdx)) {
-            m_posIsTransition = true;
+            if (tryLoadCrossChapter(posIdx, previewImage)) {
+                // Real page loaded — swipe shows the image, not the text card
+                m_posSkipTransition = true;
+            } else {
+                m_posIsTransition = true;
+            }
         } else if (previewImage) {
             loadPreviewInto(previewImage, posIdx);
         }
@@ -3036,10 +3078,15 @@ void ReaderActivity::preloadAdjacentPreviews() {
 
     // Load negative side
     m_negIsTransition = false;
+    m_negSkipTransition = false;
     if (negIdx >= 0 && negIdx < static_cast<int>(m_pages.size())) {
         m_negPreviewIdx = negIdx;
         if (isTransitionPage(negIdx)) {
-            m_negIsTransition = true;
+            if (tryLoadCrossChapter(negIdx, previewImageB)) {
+                m_negSkipTransition = true;
+            } else {
+                m_negIsTransition = true;
+            }
         } else if (previewImageB) {
             loadPreviewInto(previewImageB, negIdx);
         }

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -691,6 +691,13 @@ void ReaderActivity::onContentAvailable() {
     // Transition page gestures - tap and swipe like a regular page
     if (transitionBox) {
         transitionBox->setFocusable(true);
+        // Draw background via NanoVG inside draw() so it follows the slide offset.
+        // The XML backgroundColor attribute is drawn by borealis BEFORE draw() is
+        // called, at the layout position, covering views below in z-order during swipes.
+        transitionBox->setCustomBackground(nvgRGBA(20, 20, 30, 255));
+        // Also clear borealis-level background to fully transparent so the
+        // framework doesn't draw anything at the layout position before draw().
+        transitionBox->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
 
         // Tap gesture on transition page - toggle controls or tap-to-navigate
         transitionBox->addGestureRecognizer(new brls::TapGestureRecognizer(

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -356,10 +356,10 @@ void ReaderActivity::onContentAvailable() {
 
     // Hide preview images initially
     if (previewImage) {
-        previewImage->setVisibility(brls::Visibility::GONE);
+        previewImage->setVisibility(brls::Visibility::INVISIBLE);
     }
     if (previewImageB) {
-        previewImageB->setVisibility(brls::Visibility::GONE);
+        previewImageB->setVisibility(brls::Visibility::INVISIBLE);
     }
 
     // NOBORU-style touch handling with swipe controls
@@ -1363,7 +1363,7 @@ void ReaderActivity::loadPages() {
                 pageImage->setVisibility(brls::Visibility::GONE);
             }
             if (previewImage) {
-                previewImage->setVisibility(brls::Visibility::GONE);
+                previewImage->setVisibility(brls::Visibility::INVISIBLE);
             }
             if (webtoonScroll) {
                 webtoonScroll->setVisibility(brls::Visibility::VISIBLE);
@@ -2947,7 +2947,7 @@ void ReaderActivity::loadPreviewPage(int index) {
         m_previewIsTransition = true;
 
         // Hide previewImage since we're using transitionBox as the incoming view
-        previewImage->setVisibility(brls::Visibility::GONE);
+        previewImage->setVisibility(brls::Visibility::INVISIBLE);
 
         brls::Logger::debug("Loading transition preview for page {}", index);
         return;
@@ -3270,11 +3270,11 @@ void ReaderActivity::resetSwipeState() {
 
     // Hide both preview images and reset slide offsets
     if (previewImage) {
-        previewImage->setVisibility(brls::Visibility::GONE);
+        previewImage->setVisibility(brls::Visibility::INVISIBLE);
         previewImage->resetSlideOffset();
     }
     if (previewImageB) {
-        previewImageB->setVisibility(brls::Visibility::GONE);
+        previewImageB->setVisibility(brls::Visibility::INVISIBLE);
         previewImageB->resetSlideOffset();
     }
 }
@@ -3456,7 +3456,7 @@ void ReaderActivity::updateReaderMode() {
             pageImage->setVisibility(brls::Visibility::GONE);
         }
         if (previewImage) {
-            previewImage->setVisibility(brls::Visibility::GONE);
+            previewImage->setVisibility(brls::Visibility::INVISIBLE);
         }
         if (webtoonScroll) {
             webtoonScroll->setVisibility(brls::Visibility::VISIBLE);

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -2852,17 +2852,22 @@ void ReaderActivity::updateSwipePreview(float offset) {
     }
 
     // Positive side preview
+    // Show preview if it has a valid in-bounds index OR a cross-chapter image was preloaded
+    bool posInBounds = m_posPreviewIdx >= 0 && m_posPreviewIdx < static_cast<int>(m_pages.size());
+    bool posCrossLoaded = !posInBounds && onTransition && previewImage && previewImage->hasImage();
     if (m_posIsTransition && transitionBox && !onTransition) {
         transitionBox->setSlideOffset(posX, posY);
-    } else if (previewImage && m_posPreviewIdx >= 0) {
+    } else if (previewImage && (posInBounds || posCrossLoaded)) {
         previewImage->setVisibility(brls::Visibility::VISIBLE);
         previewImage->setSlideOffset(posX, posY);
     }
 
     // Negative side preview
+    bool negInBounds = m_negPreviewIdx >= 0 && m_negPreviewIdx < static_cast<int>(m_pages.size());
+    bool negCrossLoaded = !negInBounds && onTransition && previewImageB && previewImageB->hasImage();
     if (m_negIsTransition && transitionBox && !onTransition && !m_posIsTransition) {
         transitionBox->setSlideOffset(negX, negY);
-    } else if (previewImageB && m_negPreviewIdx >= 0) {
+    } else if (previewImageB && (negInBounds || negCrossLoaded)) {
         previewImageB->setVisibility(brls::Visibility::VISIBLE);
         previewImageB->setSlideOffset(negX, negY);
     }
@@ -3021,6 +3026,31 @@ void ReaderActivity::preloadAdjacentPreviews() {
     int posIdx = positiveIsNext ? m_currentPage + 1 : m_currentPage - 1;
     int negIdx = positiveIsNext ? m_currentPage - 1 : m_currentPage + 1;
 
+    // Helper: when on a transition page and the adjacent slot is out of bounds,
+    // preload the cross-chapter page so the preview is ready before the user swipes.
+    auto preloadCrossChapter = [&](int idx, RotatableImage* target, bool isNext) -> bool {
+        if (!target || !isTransitionPage(m_currentPage) || m_continuousScrollMode) return false;
+        if (idx >= 0 && idx < static_cast<int>(m_pages.size())) return false; // in-bounds, not needed
+
+        const std::string& tUrl = m_pages[m_currentPage].imageUrl;
+        std::string crossUrl;
+        if (isNext && tUrl == TRANSITION_NEXT && m_nextChapterLoaded && !m_nextChapterPages.empty()) {
+            crossUrl = m_nextChapterPages[0].imageUrl;
+        } else if (!isNext && tUrl == TRANSITION_PREV && m_prevChapterLoaded && !m_prevChapterPages.empty()) {
+            crossUrl = m_prevChapterPages.back().imageUrl;
+        }
+        if (crossUrl.empty()) return false;
+
+        target->setRotation(static_cast<float>(m_settings.rotation));
+        auto previewAlive = m_previewLoadAlive ? m_previewLoadAlive : m_alive;
+        std::weak_ptr<bool> aliveWeak = m_alive;
+        ImageLoader::loadAsyncFullSize(crossUrl, [aliveWeak](RotatableImage*) {
+            auto a = aliveWeak.lock();
+            if (!a || !*a) return;
+        }, target, previewAlive);
+        return true;
+    };
+
     // Load positive side
     m_posIsTransition = false;
     if (posIdx >= 0 && posIdx < static_cast<int>(m_pages.size())) {
@@ -3030,6 +3060,9 @@ void ReaderActivity::preloadAdjacentPreviews() {
         } else if (previewImage) {
             loadPreviewInto(previewImage, posIdx);
         }
+    } else if (preloadCrossChapter(posIdx, previewImage, positiveIsNext)) {
+        // Cross-chapter page preloaded — use a sentinel so updateSwipePreview shows it
+        m_posPreviewIdx = posIdx;
     } else {
         m_posPreviewIdx = -1;
     }
@@ -3043,6 +3076,8 @@ void ReaderActivity::preloadAdjacentPreviews() {
         } else if (previewImageB) {
             loadPreviewInto(previewImageB, negIdx);
         }
+    } else if (preloadCrossChapter(negIdx, previewImageB, !positiveIsNext)) {
+        m_negPreviewIdx = negIdx;
     } else {
         m_negPreviewIdx = -1;
     }

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -556,17 +556,10 @@ void ReaderActivity::onContentAvailable() {
                             m_swipingToNext = wantNextPage;
 
                             // Check if active side is a transition page for chapter navigation
-                            bool activeSkipTrans = rawDelta > 0 ? m_posSkipTransition : m_negSkipTransition;
-                            if (activeSkipTrans) {
-                                // Cross-chapter image loaded in preview — skip text card
-                                m_previewIsTransition = false;
-                                m_swipeToChapter = true;
-                            } else {
-                                bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
-                                m_previewIsTransition = activeIsTransition;
-                                if (activeIsTransition && transitionBox) {
-                                    loadPreviewPage(activeIdx);  // Populate transitionBox text
-                                }
+                            bool activeIsTransition = rawDelta > 0 ? m_posIsTransition : m_negIsTransition;
+                            m_previewIsTransition = activeIsTransition;
+                            if (activeIsTransition && transitionBox) {
+                                loadPreviewPage(activeIdx);  // Populate transitionBox text
                             }
                         }
 
@@ -3028,47 +3021,12 @@ void ReaderActivity::preloadAdjacentPreviews() {
     int posIdx = positiveIsNext ? m_currentPage + 1 : m_currentPage - 1;
     int negIdx = positiveIsNext ? m_currentPage - 1 : m_currentPage + 1;
 
-    // Helper: try to load a cross-chapter page into a preview image.
-    // Returns true if a real page image was loaded (skip the text transition).
-    auto tryLoadCrossChapter = [&](int idx, RotatableImage* target) -> bool {
-        if (!target || idx < 0 || idx >= static_cast<int>(m_pages.size())) return false;
-        if (!isTransitionPage(idx)) return false;
-        // Skip webtoon/continuous mode — transition text is fine there
-        if (m_continuousScrollMode) return false;
-
-        const std::string& url = m_pages[idx].imageUrl;
-        std::string crossUrl;
-
-        if (url == TRANSITION_NEXT && m_nextChapterLoaded && !m_nextChapterPages.empty()) {
-            crossUrl = m_nextChapterPages[0].imageUrl;
-        } else if (url == TRANSITION_PREV && m_prevChapterLoaded && !m_prevChapterPages.empty()) {
-            crossUrl = m_prevChapterPages.back().imageUrl;
-        }
-
-        if (crossUrl.empty()) return false;
-
-        target->setRotation(static_cast<float>(m_settings.rotation));
-        auto previewAlive = m_previewLoadAlive ? m_previewLoadAlive : m_alive;
-        std::weak_ptr<bool> aliveWeak = m_alive;
-        ImageLoader::loadAsyncFullSize(crossUrl, [aliveWeak](RotatableImage*) {
-            auto a = aliveWeak.lock();
-            if (!a || !*a) return;
-        }, target, previewAlive);
-        return true;
-    };
-
     // Load positive side
     m_posIsTransition = false;
-    m_posSkipTransition = false;
     if (posIdx >= 0 && posIdx < static_cast<int>(m_pages.size())) {
         m_posPreviewIdx = posIdx;
         if (isTransitionPage(posIdx)) {
-            if (tryLoadCrossChapter(posIdx, previewImage)) {
-                // Real page loaded — swipe shows the image, not the text card
-                m_posSkipTransition = true;
-            } else {
-                m_posIsTransition = true;
-            }
+            m_posIsTransition = true;
         } else if (previewImage) {
             loadPreviewInto(previewImage, posIdx);
         }
@@ -3078,15 +3036,10 @@ void ReaderActivity::preloadAdjacentPreviews() {
 
     // Load negative side
     m_negIsTransition = false;
-    m_negSkipTransition = false;
     if (negIdx >= 0 && negIdx < static_cast<int>(m_pages.size())) {
         m_negPreviewIdx = negIdx;
         if (isTransitionPage(negIdx)) {
-            if (tryLoadCrossChapter(negIdx, previewImageB)) {
-                m_negSkipTransition = true;
-            } else {
-                m_negIsTransition = true;
-            }
+            m_negIsTransition = true;
         } else if (previewImageB) {
             loadPreviewInto(previewImageB, negIdx);
         }

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -356,10 +356,10 @@ void ReaderActivity::onContentAvailable() {
 
     // Hide preview images initially
     if (previewImage) {
-        previewImage->setVisibility(brls::Visibility::INVISIBLE);
+        previewImage->setVisibility(brls::Visibility::GONE);
     }
     if (previewImageB) {
-        previewImageB->setVisibility(brls::Visibility::INVISIBLE);
+        previewImageB->setVisibility(brls::Visibility::GONE);
     }
 
     // NOBORU-style touch handling with swipe controls
@@ -1363,7 +1363,7 @@ void ReaderActivity::loadPages() {
                 pageImage->setVisibility(brls::Visibility::GONE);
             }
             if (previewImage) {
-                previewImage->setVisibility(brls::Visibility::INVISIBLE);
+                previewImage->setVisibility(brls::Visibility::GONE);
             }
             if (webtoonScroll) {
                 webtoonScroll->setVisibility(brls::Visibility::VISIBLE);
@@ -1449,6 +1449,9 @@ void ReaderActivity::loadPage(int index) {
     bool wasOnTransition = transitionBox && transitionBox->getVisibility() != brls::Visibility::GONE;
     if (wasOnTransition) {
         transitionBox->setVisibility(brls::Visibility::GONE);
+        // Clear stale image from the previous chapter so the old page
+        // doesn't flash briefly while the new page loads asynchronously.
+        if (pageImage) pageImage->clearImage();
     }
     if (pageImage && pageImage->getVisibility() != brls::Visibility::VISIBLE) {
         pageImage->setVisibility(brls::Visibility::VISIBLE);
@@ -2942,12 +2945,12 @@ void ReaderActivity::loadPreviewPage(int index) {
             transitionPreview->setVisibility(brls::Visibility::GONE);
         }
 
-        // Make transitionBox visible but it will be positioned off-screen by updateSwipePreview
+        // Pre-position transitionBox far off-screen BEFORE making it visible,
+        // so its opaque background never covers pageImage even for a single frame.
+        // updateSwipePreview() will set the correct slide offset right after.
+        transitionBox->setSlideOffset(10000.0f, 0.0f);
         transitionBox->setVisibility(brls::Visibility::VISIBLE);
         m_previewIsTransition = true;
-
-        // Hide previewImage since we're using transitionBox as the incoming view
-        previewImage->setVisibility(brls::Visibility::INVISIBLE);
 
         brls::Logger::debug("Loading transition preview for page {}", index);
         return;
@@ -3270,11 +3273,11 @@ void ReaderActivity::resetSwipeState() {
 
     // Hide both preview images and reset slide offsets
     if (previewImage) {
-        previewImage->setVisibility(brls::Visibility::INVISIBLE);
+        previewImage->setVisibility(brls::Visibility::GONE);
         previewImage->resetSlideOffset();
     }
     if (previewImageB) {
-        previewImageB->setVisibility(brls::Visibility::INVISIBLE);
+        previewImageB->setVisibility(brls::Visibility::GONE);
         previewImageB->resetSlideOffset();
     }
 }
@@ -3456,7 +3459,7 @@ void ReaderActivity::updateReaderMode() {
             pageImage->setVisibility(brls::Visibility::GONE);
         }
         if (previewImage) {
-            previewImage->setVisibility(brls::Visibility::INVISIBLE);
+            previewImage->setVisibility(brls::Visibility::GONE);
         }
         if (webtoonScroll) {
             webtoonScroll->setVisibility(brls::Visibility::VISIBLE);

--- a/src/view/rotatable_box.cpp
+++ b/src/view/rotatable_box.cpp
@@ -45,6 +45,11 @@ void RotatableBox::resetSlideOffset() {
     m_slideY = 0.0f;
 }
 
+void RotatableBox::setCustomBackground(NVGcolor color) {
+    m_hasCustomBg = true;
+    m_customBgColor = color;
+}
+
 void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
     // Apply slide offset for swipe carousel if active
@@ -63,6 +68,17 @@ void RotatableBox::draw(NVGcontext* vg, float x, float y, float width, float hei
         }
         nvgScissor(vg, clipX, clipY, clipW, clipH);
         nvgTranslate(vg, m_slideX, m_slideY);
+    }
+
+    // Draw custom background via NanoVG AFTER the slide offset is applied.
+    // This replaces the borealis backgroundColor XML attribute, which is drawn
+    // at the view's layout position BEFORE draw() is called and therefore
+    // covers views below in z-order regardless of slide offset.
+    if (m_hasCustomBg) {
+        nvgBeginPath(vg);
+        nvgRect(vg, x, y, width, height);
+        nvgFillColor(vg, m_customBgColor);
+        nvgFill(vg);
     }
 
     if (m_rotationDegrees == 0.0f) {


### PR DESCRIPTION
Reworks cross-chapter preview during transition-page swipes: shows the actual adjacent chapter page, fixes blank previews, and fixes the transition box background covering page images during the swipe.

---
_Generated by [Claude Code](https://claude.ai/code)_