### PR TITLE
Fix network test dialog: use simple text dialog instead of complex view hierarchy

### DIFF
--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1631,7 +1631,7 @@ void SettingsTab::runNetworkTest() {
                 contentBox->addView(label);
             }
 
-            scrollView->setContent(contentBox);
+            scrollView->setContentView(contentBox);
             dialogBox->addView(scrollView);
 
             auto* closeBtn = new brls::Button();

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -13,7 +13,6 @@
 #include <algorithm>
 #include <chrono>
 #include <ctime>
-#include <sstream>
 #include <thread>
 
 #ifdef __vita__
@@ -1526,7 +1525,7 @@ void SettingsTab::runNetworkTest() {
         wifiLevel = 100;
 #endif
 
-        results += "=== WiFi ===\n";
+        results += "-- WiFi --\n";
         if (wifiConnected) {
             results += "Status: Connected\n";
             results += "IP: " + ipAddress + "\n";
@@ -1534,11 +1533,10 @@ void SettingsTab::runNetworkTest() {
             results += "Signal: " + std::to_string(wifiLevel) + "%\n";
         } else {
             results += "Status: Not Connected\n";
-            results += "No WiFi connection detected.\n";
         }
 
         // --- Internet Check (DNS resolve + HTTP) ---
-        results += "\n=== Internet ===\n";
+        results += "\n-- Internet --\n";
         if (wifiConnected) {
             HttpClient http;
             http.setTimeout(10);
@@ -1559,7 +1557,7 @@ void SettingsTab::runNetworkTest() {
         }
 
         // --- Server Check ---
-        results += "\n=== Server ===\n";
+        results += "\n-- Server --\n";
         Application& app = Application::getInstance();
         std::string serverUrl = app.getServerUrl();
         if (serverUrl.empty()) serverUrl = app.getActiveServerUrl();
@@ -1587,90 +1585,10 @@ void SettingsTab::runNetworkTest() {
             }
         }
 
-        // Show results dialog on main thread
+        // Show results dialog on main thread using simple text dialog
         brls::sync([results]() {
-            brls::Dialog* dialog = new brls::Dialog("Network Test Results");
+            brls::Dialog* dialog = new brls::Dialog(results);
             dialog->setCancelable(true);
-
-            auto* scrollView = new brls::ScrollingFrame();
-            scrollView->setHeight(400);
-
-            auto* contentBox = new brls::Box();
-            contentBox->setAxis(brls::Axis::COLUMN);
-            contentBox->setPadding(20);
-
-            // Helper to add a section
-            auto addSection = [&](const std::string& title, const std::vector<std::pair<std::string, std::string>>& items) {
-                auto* header = new brls::Label();
-                header->setText(title);
-                header->setFontSize(22);
-                header->setHorizontalAlign(brls::HorizontalAlign::CENTER);
-                header->setMargins(8, 0, 4, 0);
-                contentBox->addView(header);
-
-                for (const auto& [key, value] : items) {
-                    auto* row = new brls::Box();
-                    row->setAxis(brls::Axis::ROW);
-                    row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-                    row->setAlignItems(brls::AlignItems::CENTER);
-                    row->setPaddingLeft(12);
-                    row->setPaddingRight(12);
-                    row->setMargins(2, 0, 2, 0);
-
-                    auto* keyLabel = new brls::Label();
-                    keyLabel->setText(key);
-                    keyLabel->setFontSize(18);
-                    keyLabel->setTextColor(nvgRGB(180, 180, 180));
-                    row->addView(keyLabel);
-
-                    auto* valueLabel = new brls::Label();
-                    valueLabel->setText(value);
-                    valueLabel->setFontSize(18);
-                    valueLabel->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
-                    row->addView(valueLabel);
-
-                    contentBox->addView(row);
-                }
-            };
-
-            // Parse results and build structured sections
-            // We'll re-parse the results string by sections
-            std::vector<std::pair<std::string, std::string>> currentItems;
-            std::string currentSection;
-            std::istringstream stream(results);
-            std::string line;
-            while (std::getline(stream, line)) {
-                if (line.empty()) continue;
-                if (line.find("===") != std::string::npos) {
-                    // Flush previous section
-                    if (!currentSection.empty() && !currentItems.empty()) {
-                        addSection(currentSection, currentItems);
-                        currentItems.clear();
-                    }
-                    // Extract section name between === markers
-                    size_t start = line.find("=== ");
-                    size_t end = line.find(" ===", start + 4);
-                    if (start != std::string::npos && end != std::string::npos) {
-                        currentSection = line.substr(start + 4, end - start - 4);
-                    }
-                } else {
-                    size_t colonPos = line.find(": ");
-                    if (colonPos != std::string::npos) {
-                        std::string key = line.substr(0, colonPos);
-                        std::string value = line.substr(colonPos + 2);
-                        currentItems.push_back({key, value});
-                    } else {
-                        currentItems.push_back({"", line});
-                    }
-                }
-            }
-            // Flush last section
-            if (!currentSection.empty() && !currentItems.empty()) {
-                addSection(currentSection, currentItems);
-            }
-
-            scrollView->setContentView(contentBox);
-            dialog->addView(scrollView);
             dialog->addButton("Close", []() {});
             dialog->open();
         });

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1586,47 +1586,14 @@ void SettingsTab::runNetworkTest() {
             }
         }
 
-        // Show results in a custom box layout so newlines render properly
+        // Show results in a brls::Dialog (proper overlay, no page transition)
         brls::sync([results]() {
-            // Full-screen overlay to block hover/touch on background items
-            auto* overlay = new brls::Box();
-            overlay->setAxis(brls::Axis::COLUMN);
-            overlay->setWidth(960);
-            overlay->setHeight(544);
-            overlay->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
-            overlay->setAlignItems(brls::AlignItems::CENTER);
-            overlay->setJustifyContent(brls::JustifyContent::CENTER);
-            overlay->setFocusable(false);
-
-            // Intercept all touch events on the overlay background
-            overlay->addGestureRecognizer(new brls::TapGestureRecognizer(
-                [](brls::TapGestureStatus status, brls::Sound* soundToPlay) {
-                    // Consume tap - do nothing
-                }));
-            overlay->addGestureRecognizer(new brls::PanGestureRecognizer(
-                [](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
-                    // Consume pan - do nothing
-                }, brls::PanAxis::ANY));
-
-            auto* dialogBox = new brls::Box();
-            dialogBox->setAxis(brls::Axis::COLUMN);
-            dialogBox->setWidth(500);
-            dialogBox->setHeight(420);
-            dialogBox->setPadding(20);
-            dialogBox->setBackgroundColor(nvgRGBA(30, 30, 30, 255));
-            dialogBox->setCornerRadius(12);
-
-            auto* titleLabel = new brls::Label();
-            titleLabel->setText("Network Test Results");
-            titleLabel->setFontSize(22);
-            titleLabel->setMarginBottom(15);
-            dialogBox->addView(titleLabel);
-
-            auto* scrollView = new brls::ScrollingFrame();
-            scrollView->setGrow(1.0f);
+            brls::Dialog* dialog = new brls::Dialog("Network Test Results");
+            dialog->setCancelable(true);
 
             auto* contentBox = new brls::Box();
             contentBox->setAxis(brls::Axis::COLUMN);
+            contentBox->setPadding(16);
 
             // Split results by newline and add each as a separate label
             std::istringstream stream(results);
@@ -1637,7 +1604,6 @@ void SettingsTab::runNetworkTest() {
                     label->setText(" ");
                     label->setFontSize(8);
                 } else if (line.find("--") == 0) {
-                    // Section headers
                     label->setText(line);
                     label->setFontSize(16);
                     label->setTextColor(nvgRGB(100, 180, 255));
@@ -1651,30 +1617,9 @@ void SettingsTab::runNetworkTest() {
                 contentBox->addView(label);
             }
 
-            scrollView->setContentView(contentBox);
-            dialogBox->addView(scrollView);
-
-            auto* closeBtn = new brls::Button();
-            closeBtn->setText("Close");
-            closeBtn->setMarginTop(15);
-            closeBtn->registerClickAction([](brls::View* view) {
-                brls::Application::popActivity();
-                return true;
-            });
-            closeBtn->addGestureRecognizer(new brls::TapGestureRecognizer(closeBtn));
-            closeBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-                brls::Application::popActivity();
-                return true;
-            }, true);
-            dialogBox->addView(closeBtn);
-
-            overlay->addView(dialogBox);
-
-            auto* activity = new brls::Activity(overlay);
-            brls::Application::pushActivity(activity);
-
-            // Give the close button focus/hover
-            brls::Application::giveFocus(closeBtn);
+            dialog->addView(contentBox);
+            dialog->addButton("Close", []() {});
+            dialog->open();
         });
     }).detach();
 }

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <chrono>
 #include <ctime>
+#include <sstream>
 #include <thread>
 
 #ifdef __vita__
@@ -1585,12 +1586,70 @@ void SettingsTab::runNetworkTest() {
             }
         }
 
-        // Show results dialog on main thread using simple text dialog
+        // Show results in a custom box layout so newlines render properly
         brls::sync([results]() {
-            brls::Dialog* dialog = new brls::Dialog(results);
-            dialog->setCancelable(true);
-            dialog->addButton("Close", []() {});
-            dialog->open();
+            auto* dialogBox = new brls::Box();
+            dialogBox->setAxis(brls::Axis::COLUMN);
+            dialogBox->setWidth(500);
+            dialogBox->setHeight(420);
+            dialogBox->setPadding(20);
+            dialogBox->setBackgroundColor(nvgRGBA(30, 30, 30, 255));
+            dialogBox->setCornerRadius(12);
+
+            auto* titleLabel = new brls::Label();
+            titleLabel->setText("Network Test Results");
+            titleLabel->setFontSize(22);
+            titleLabel->setMarginBottom(15);
+            dialogBox->addView(titleLabel);
+
+            auto* scrollView = new brls::ScrollingFrame();
+            scrollView->setGrow(1.0f);
+
+            auto* contentBox = new brls::Box();
+            contentBox->setAxis(brls::Axis::COLUMN);
+
+            // Split results by newline and add each as a separate label
+            std::istringstream stream(results);
+            std::string line;
+            while (std::getline(stream, line)) {
+                auto* label = new brls::Label();
+                if (line.empty()) {
+                    label->setText(" ");
+                    label->setFontSize(8);
+                } else if (line.find("--") == 0) {
+                    // Section headers
+                    label->setText(line);
+                    label->setFontSize(16);
+                    label->setTextColor(nvgRGB(100, 180, 255));
+                    label->setMarginTop(5);
+                } else {
+                    label->setText(line);
+                    label->setFontSize(15);
+                    label->setTextColor(nvgRGB(200, 200, 200));
+                }
+                label->setMarginBottom(2);
+                contentBox->addView(label);
+            }
+
+            scrollView->setContent(contentBox);
+            dialogBox->addView(scrollView);
+
+            auto* closeBtn = new brls::Button();
+            closeBtn->setText("Close");
+            closeBtn->setMarginTop(15);
+            closeBtn->registerClickAction([](brls::View* view) {
+                brls::Application::popActivity();
+                return true;
+            });
+            closeBtn->addGestureRecognizer(new brls::TapGestureRecognizer(closeBtn));
+            closeBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
+                brls::Application::popActivity();
+                return true;
+            }, true);
+            dialogBox->addView(closeBtn);
+
+            auto* activity = new brls::Activity(dialogBox);
+            brls::Application::pushActivity(activity);
         });
     }).detach();
 }

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1588,6 +1588,26 @@ void SettingsTab::runNetworkTest() {
 
         // Show results in a custom box layout so newlines render properly
         brls::sync([results]() {
+            // Full-screen overlay to block hover/touch on background items
+            auto* overlay = new brls::Box();
+            overlay->setAxis(brls::Axis::COLUMN);
+            overlay->setWidth(960);
+            overlay->setHeight(544);
+            overlay->setBackgroundColor(nvgRGBA(0, 0, 0, 128));
+            overlay->setAlignItems(brls::AlignItems::CENTER);
+            overlay->setJustifyContent(brls::JustifyContent::CENTER);
+            overlay->setFocusable(false);
+
+            // Intercept all touch events on the overlay background
+            overlay->addGestureRecognizer(new brls::TapGestureRecognizer(
+                [](brls::TapGestureStatus status, brls::Sound* soundToPlay) {
+                    // Consume tap - do nothing
+                }));
+            overlay->addGestureRecognizer(new brls::PanGestureRecognizer(
+                [](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+                    // Consume pan - do nothing
+                }, brls::PanAxis::ANY));
+
             auto* dialogBox = new brls::Box();
             dialogBox->setAxis(brls::Axis::COLUMN);
             dialogBox->setWidth(500);
@@ -1648,7 +1668,9 @@ void SettingsTab::runNetworkTest() {
             }, true);
             dialogBox->addView(closeBtn);
 
-            auto* activity = new brls::Activity(dialogBox);
+            overlay->addView(dialogBox);
+
+            auto* activity = new brls::Activity(overlay);
             brls::Application::pushActivity(activity);
         });
     }).detach();

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1593,7 +1593,7 @@ void SettingsTab::runNetworkTest() {
             overlay->setAxis(brls::Axis::COLUMN);
             overlay->setWidth(960);
             overlay->setHeight(544);
-            overlay->setBackgroundColor(nvgRGBA(0, 0, 0, 128));
+            overlay->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
             overlay->setAlignItems(brls::AlignItems::CENTER);
             overlay->setJustifyContent(brls::JustifyContent::CENTER);
             overlay->setFocusable(false);
@@ -1672,6 +1672,9 @@ void SettingsTab::runNetworkTest() {
 
             auto* activity = new brls::Activity(overlay);
             brls::Application::pushActivity(activity);
+
+            // Give the close button focus/hover
+            brls::Application::giveFocus(closeBtn);
         });
     }).detach();
 }


### PR DESCRIPTION
Reworks the network-test dialog to a simple text dialog: fixes results showing on one line, hover passing through to background items, and the dark overlay, ultimately using `brls::Dialog` with the close button focused.

---
_Generated by [Claude Code](https://claude.ai/code)_