### PR TITLE
Auto-detect auth mode on login - no more manual Simple/UI Login selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/testing-checklist-v3.md
+++ b/.github/ISSUE_TEMPLATE/testing-checklist-v3.md
@@ -17,26 +17,42 @@ assignees: ''
 
 ## Authentication & Connection
 
-### Login & Credentials
+### Login & Auto-Detection
 - [ ] Connect to Suwayomi server with URL
-- [ ] Login with username/password (Basic Auth)
+- [ ] Auth mode auto-detected on connect (no manual selection needed)
 - [ ] Credentials persist after app restart
-- [ ] App handles invalid credentials gracefully
-- [ ] App handles server offline gracefully
-- [ ] Connection status shows correctly
+- [ ] Status label shows "Checking server..." then "Detecting auth mode..." during connect
+- [ ] Status shows detected auth mode on success: "Connected! (UI Login (JWT))"
 
-### Auth Modes
-- [ ] Auth mode cycles through: None, Basic Auth, Simple Login, UI Login
-- [ ] Selected auth mode displays on login screen
-- [ ] Wrong auth mode shows helpful error message
+### Error Messages
+- [ ] Empty URL shows: "Please enter server URL"
+- [ ] Server offline/wrong URL shows: "Server offline or wrong URL"
+- [ ] Auth required but no credentials shows: "Server requires auth - enter username & password"
+- [ ] Wrong credentials shows: "Wrong username or password"
+- [ ] Connection test (Test button) detects server reachability and auth type
+
+### Auto-Detection Flow
+- [ ] No-auth server: auto-detects None, connects without credentials
+- [ ] Basic Auth server: auto-detects Basic Auth, validates credentials
+- [ ] JWT server (UI Login): auto-detects UI Login, login + validates protected query
+- [ ] JWT server (Simple Login): tries UI Login first, falls back to Simple Login
+- [ ] Auth mode label updates to show detected mode after connect
+- [ ] Manual auth mode override still works (tap to cycle)
 
 ### JWT Authentication (Simple Login / UI Login)
 - [ ] JWT login sends username/password and receives tokens
 - [ ] Access token stored and used for API calls
+- [ ] Protected query validation after login (categories query)
+- [ ] If wrong JWT mode selected, auto-switches to correct mode
 - [ ] Refresh token stored for token renewal
 - [ ] JWT tokens persist after restart
-- [ ] Server JWT support auto-detected
-- [ ] Basic Auth selected but server uses JWT shows guidance
+
+### Connection Restore (App Restart)
+- [ ] Saved JWT tokens refreshed on startup
+- [ ] Auth validated with protected query (not just public aboutServer)
+- [ ] If saved auth mode wrong, auto-tries all modes (UI Login, Simple Login, Basic Auth)
+- [ ] Correct mode saved after auto-detection on restore
+- [ ] Falls back to login screen if all auth modes fail
 
 ### URL Configuration
 - [ ] Local server URL (LAN) works

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -402,6 +402,10 @@ public:
     // Also returns an error message if detection fails
     AuthMode detectServerAuthMode(const std::string& url, std::string& errorMessage);
 
+    // Validate that authentication works for protected queries (not just public ones like aboutServer)
+    // Returns true if a protected query (categories) succeeds with current auth
+    bool validateAuthWithProtectedQuery();
+
     // Extension Management
     bool fetchExtensionList(std::vector<Extension>& extensions);
     bool fetchInstalledExtensions(std::vector<Extension>& extensions);  // Server-side filtered: installed only

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -88,11 +88,16 @@ void LoginActivity::onContentAvailable() {
         passwordLabel->addGestureRecognizer(new brls::TapGestureRecognizer(passwordLabel));
     }
 
-    // Auth mode selector
+    // Auth mode display (auto-detected on connect)
     if (authModeLabel) {
-        authModeLabel->setText("Auth Mode: " + getAuthModeName(m_authMode));
+        if (m_authMode == AuthMode::NONE && m_serverUrl.empty()) {
+            authModeLabel->setText("Auth Mode: Auto-detect");
+        } else {
+            authModeLabel->setText("Auth Mode: " + getAuthModeName(m_authMode));
+        }
+        // Still allow manual override if user taps
         authModeLabel->registerClickAction([this](brls::View* view) {
-            // Cycle through auth modes
+            // Cycle through auth modes (manual override)
             int currentMode = static_cast<int>(m_authMode);
             currentMode = (currentMode + 1) % 4;
             m_authMode = static_cast<AuthMode>(currentMode);
@@ -139,61 +144,47 @@ void LoginActivity::onTestConnectionPressed() {
     if (statusLabel) statusLabel->setText("Testing connection...");
 
     SuwayomiClient& client = SuwayomiClient::getInstance();
+    client.setServerUrl(m_serverUrl);
 
-    // Check if server requires authentication and detect the expected auth mode
-    bool serverRequiresAuth = client.checkServerRequiresAuth(m_serverUrl);
-
-    if (serverRequiresAuth && m_authMode == AuthMode::NONE) {
-        // User selected None but server requires auth - detect the correct mode
-        std::string errorMsg;
-        AuthMode detectedMode = client.detectServerAuthMode(m_serverUrl, errorMsg);
-        std::string modeName = getAuthModeName(detectedMode);
-        if (statusLabel) statusLabel->setText("Server requires auth! Try: " + modeName);
-        brls::Application::notify("Suggested auth mode: " + modeName);
+    // Step 1: Check basic reachability
+    if (!client.connectToServer(m_serverUrl)) {
+        if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
         return;
     }
 
-    // Check for auth mode mismatch
-    if (serverRequiresAuth) {
-        bool supportsJWT = client.checkServerSupportsJWTLogin(m_serverUrl);
-
-        if (m_authMode == AuthMode::BASIC_AUTH && supportsJWT) {
-            // User selected Basic Auth but server uses JWT
-            if (statusLabel) statusLabel->setText("Wrong auth mode! Try: UI Login (JWT)");
-            brls::Application::notify("Server uses JWT auth - select UI Login");
-            return;
-        }
-
-        if ((m_authMode == AuthMode::SIMPLE_LOGIN || m_authMode == AuthMode::UI_LOGIN) && !supportsJWT) {
-            // User selected JWT mode but server only supports Basic Auth
-            if (statusLabel) statusLabel->setText("Wrong auth mode! Try: Basic Auth");
-            brls::Application::notify("Server uses Basic Auth - select Basic Auth mode");
-            return;
-        }
-    }
-
-    // Set auth mode and credentials for the test
-    client.setAuthMode(m_authMode);
-    if (m_authMode == AuthMode::BASIC_AUTH && !m_username.empty() && !m_password.empty()) {
-        client.setAuthCredentials(m_username, m_password);
-    }
-
-    // Try to connect and fetch server info
-    if (client.connectToServer(m_serverUrl)) {
-        ServerInfo info;
-        if (client.fetchServerInfo(info)) {
-            std::string msg = "Connected! Server v" + info.version;
-            if (statusLabel) statusLabel->setText(msg);
-        } else {
-            if (statusLabel) statusLabel->setText("Server is reachable!");
-        }
+    // Step 2: Fetch server info (public endpoint)
+    ServerInfo info;
+    if (client.fetchServerInfo(info)) {
+        std::string msg = "Reachable! Server v" + info.version;
+        if (statusLabel) statusLabel->setText(msg);
     } else {
-        if (serverRequiresAuth) {
-            if (statusLabel) statusLabel->setText("Auth failed - check username/password");
-        } else {
-            if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
-        }
+        if (statusLabel) statusLabel->setText("Server is reachable!");
     }
+
+    // Step 3: Auto-detect auth mode
+    bool serverRequiresAuth = client.checkServerRequiresAuth(m_serverUrl);
+    if (!serverRequiresAuth) {
+        if (statusLabel) statusLabel->setText("Server OK - no auth required");
+        m_authMode = AuthMode::NONE;
+        if (authModeLabel) authModeLabel->setText("Auth Mode: None");
+        return;
+    }
+
+    // Server requires auth - detect the type
+    std::string errorMsg;
+    AuthMode detectedMode = client.detectServerAuthMode(m_serverUrl, errorMsg);
+    std::string modeName = getAuthModeName(detectedMode);
+
+    if (m_username.empty() || m_password.empty()) {
+        if (statusLabel) statusLabel->setText("Auth required (" + modeName + ") - enter credentials");
+        m_authMode = detectedMode;
+        if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
+        return;
+    }
+
+    if (statusLabel) statusLabel->setText("Server OK, auth: " + modeName);
+    m_authMode = detectedMode;
+    if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
 }
 
 void LoginActivity::onConnectPressed() {
@@ -205,67 +196,110 @@ void LoginActivity::onConnectPressed() {
     if (statusLabel) statusLabel->setText("Connecting...");
 
     SuwayomiClient& client = SuwayomiClient::getInstance();
-
-    // Set auth mode first
-    client.setAuthMode(m_authMode);
-
-    // Set server URL
     client.setServerUrl(m_serverUrl);
 
     bool connected = false;
 
-    // Handle authentication based on mode
-    if (m_authMode == AuthMode::NONE) {
-        // No auth mode selected - first check if server requires authentication
-        if (client.checkServerRequiresAuth(m_serverUrl)) {
-            // Server requires auth but user selected "None" - detect correct mode
-            std::string errorMsg;
-            AuthMode detectedMode = client.detectServerAuthMode(m_serverUrl, errorMsg);
-            std::string modeName = getAuthModeName(detectedMode);
-            if (statusLabel) statusLabel->setText("Server requires auth! Try: " + modeName);
-            brls::Application::notify("Suggested: " + modeName);
-            return;
-        }
-        // No auth required, just test connection
-        connected = client.connectToServer(m_serverUrl);
-    } else if (m_authMode == AuthMode::BASIC_AUTH) {
-        // Check if server actually uses JWT instead
-        if (client.checkServerRequiresAuth(m_serverUrl) && client.checkServerSupportsJWTLogin(m_serverUrl)) {
-            if (statusLabel) statusLabel->setText("Wrong auth mode! Try: UI Login (JWT)");
-            brls::Application::notify("Server uses JWT - select UI Login mode");
-            return;
-        }
-        // Basic auth - set credentials and connect
-        if (!m_username.empty() && !m_password.empty()) {
-            client.setAuthCredentials(m_username, m_password);
-        }
-        connected = client.connectToServer(m_serverUrl);
+    // Step 1: Check if server is reachable at all (using basic connectivity test)
+    if (statusLabel) statusLabel->setText("Checking server...");
+    if (!client.connectToServer(m_serverUrl)) {
+        // Server not reachable - provide specific error
+        if (statusLabel) statusLabel->setText("Server offline or wrong URL");
+        brls::Application::notify("Cannot reach " + m_serverUrl);
+        return;
+    }
+
+    // Server is reachable - now check auth requirements
+    if (statusLabel) statusLabel->setText("Detecting auth mode...");
+    bool serverRequiresAuth = client.checkServerRequiresAuth(m_serverUrl);
+
+    if (!serverRequiresAuth) {
+        // No auth required - already connected from step 1
+        brls::Logger::info("Server does not require auth");
+        m_authMode = AuthMode::NONE;
+        if (authModeLabel) authModeLabel->setText("Auth Mode: None");
+        client.setAuthMode(AuthMode::NONE);
+        connected = true;
     } else {
-        // JWT-based auth (simple_login or ui_login)
-        // Check if server actually uses Basic Auth instead
-        if (client.checkServerRequiresAuth(m_serverUrl) && !client.checkServerSupportsJWTLogin(m_serverUrl)) {
-            if (statusLabel) statusLabel->setText("Wrong auth mode! Try: Basic Auth");
-            brls::Application::notify("Server uses Basic Auth - select Basic Auth mode");
+        // Server requires auth - need credentials
+        if (m_username.empty() || m_password.empty()) {
+            if (statusLabel) statusLabel->setText("Server requires auth - enter username & password");
             return;
         }
-        // First try to connect to server
-        if (client.connectToServer(m_serverUrl)) {
-            // Then attempt login if credentials are provided
-            if (!m_username.empty() && !m_password.empty()) {
-                if (statusLabel) statusLabel->setText("Authenticating...");
-                connected = client.login(m_username, m_password);
-                if (!connected) {
-                    if (statusLabel) statusLabel->setText("Authentication failed - check credentials");
+
+        // Step 2: Detect if server supports JWT or only Basic Auth
+        bool supportsJWT = client.checkServerSupportsJWTLogin(m_serverUrl);
+
+        if (supportsJWT) {
+            // Server supports JWT - try UI_LOGIN first, then SIMPLE_LOGIN
+            AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN };
+            bool loginOk = false;
+
+            for (AuthMode tryMode : tryModes) {
+                std::string modeName = getAuthModeName(tryMode);
+                brls::Logger::info("Trying auth mode: {}", modeName);
+                if (statusLabel) statusLabel->setText("Trying " + modeName + "...");
+
+                client.setAuthMode(tryMode);
+                client.logout();  // Clear any previous tokens
+
+                if (!client.login(m_username, m_password)) {
+                    brls::Logger::info("{}: login failed - bad credentials?", modeName);
+                    // Login mutation failed - likely wrong credentials
+                    // Don't try more modes, credentials are the issue
+                    if (statusLabel) statusLabel->setText("Wrong username or password");
+                    brls::Application::notify("Check your credentials");
                     return;
                 }
-            } else {
-                // No credentials provided for JWT auth
-                if (statusLabel) statusLabel->setText("Username and password required for this auth mode");
-                return;
+
+                // Login succeeded - validate with a protected query
+                if (client.validateAuthWithProtectedQuery()) {
+                    brls::Logger::info("Auto-detected auth mode: {}", modeName);
+                    m_authMode = tryMode;
+                    if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
+                    loginOk = true;
+                    connected = true;
+                    break;
+                }
+
+                brls::Logger::info("{}: login ok but protected query failed, trying next", modeName);
+            }
+
+            if (!loginOk) {
+                // JWT modes didn't work - try Basic Auth as fallback
+                brls::Logger::info("JWT modes failed, trying Basic Auth fallback");
+                if (statusLabel) statusLabel->setText("Trying Basic Auth...");
+                client.setAuthMode(AuthMode::BASIC_AUTH);
+                client.logout();
+                client.setAuthCredentials(m_username, m_password);
+
+                if (client.validateAuthWithProtectedQuery()) {
+                    brls::Logger::info("Auth succeeded with Basic Auth fallback");
+                    m_authMode = AuthMode::BASIC_AUTH;
+                    if (authModeLabel) authModeLabel->setText("Auth Mode: Basic Auth");
+                    connected = true;
+                } else {
+                    if (statusLabel) statusLabel->setText("Wrong username or password");
+                    brls::Application::notify("All auth modes failed - check credentials");
+                    return;
+                }
             }
         } else {
-            if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
-            return;
+            // Server only supports Basic Auth
+            brls::Logger::info("Auto-detected: Basic Auth");
+            m_authMode = AuthMode::BASIC_AUTH;
+            if (authModeLabel) authModeLabel->setText("Auth Mode: Basic Auth");
+            client.setAuthMode(AuthMode::BASIC_AUTH);
+            client.setAuthCredentials(m_username, m_password);
+
+            // Validate credentials with a protected query
+            if (statusLabel) statusLabel->setText("Authenticating...");
+            if (!client.validateAuthWithProtectedQuery()) {
+                if (statusLabel) statusLabel->setText("Wrong username or password");
+                brls::Application::notify("Check your credentials");
+                return;
+            }
+            connected = true;
         }
     }
 
@@ -275,26 +309,26 @@ void LoginActivity::onConnectPressed() {
         Application::getInstance().setAuthCredentials(m_username, m_password);
         Application::getInstance().setConnected(true);
 
-        // Save auth mode and tokens
+        // Save auto-detected auth mode and tokens
         AppSettings& settings = Application::getInstance().getSettings();
         settings.authMode = static_cast<int>(m_authMode);
         settings.accessToken = client.getAccessToken();
         settings.refreshToken = client.getRefreshToken();
 
-        // Also save to localServerUrl in settings for proper persistence
         if (settings.localServerUrl.empty()) {
             settings.localServerUrl = m_serverUrl;
         }
 
         Application::getInstance().saveSettings();
 
-        if (statusLabel) statusLabel->setText("Connected!");
+        std::string modeName = getAuthModeName(m_authMode);
+        if (statusLabel) statusLabel->setText("Connected! (" + modeName + ")");
 
         brls::sync([this]() {
             Application::getInstance().pushMainActivity();
         });
     } else {
-        if (statusLabel) statusLabel->setText("Connection failed - check URL and server");
+        if (statusLabel) statusLabel->setText("Connection failed");
     }
 }
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -90,8 +90,63 @@ void Application::run() {
             }
         }
 
-        // Test connection before proceeding
+        // Test connection with a PROTECTED query (not just aboutServer which is public)
+        // This catches auth mode mismatches that testConnection() would miss
+        bool authValid = false;
         if (client.testConnection()) {
+            brls::Logger::info("Server reachable, validating auth with protected query...");
+
+            if (authMode == AuthMode::NONE) {
+                // No auth - if testConnection works, we're good
+                authValid = true;
+            } else if (client.validateAuthWithProtectedQuery()) {
+                brls::Logger::info("Auth validated with protected query");
+                authValid = true;
+            } else {
+                // Auth failed on protected query - try all auth modes automatically
+                brls::Logger::warning("Protected query failed with saved mode {}, trying all modes...",
+                    static_cast<int>(authMode));
+
+                std::string username = getAuthUsername();
+                std::string password = getAuthPassword();
+
+                if (!username.empty() && !password.empty()) {
+                    // Try all modes: UI_LOGIN, SIMPLE_LOGIN, BASIC_AUTH
+                    AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::BASIC_AUTH };
+                    for (AuthMode tryMode : tryModes) {
+                        if (tryMode == authMode) continue;  // Already failed with this mode
+
+                        brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
+                        client.setAuthMode(tryMode);
+                        client.logout();
+
+                        if (tryMode == AuthMode::BASIC_AUTH) {
+                            client.setAuthCredentials(username, password);
+                        } else {
+                            if (!client.login(username, password)) continue;
+                        }
+
+                        if (client.validateAuthWithProtectedQuery()) {
+                            brls::Logger::info("Auth succeeded with mode {}", static_cast<int>(tryMode));
+                            m_settings.authMode = static_cast<int>(tryMode);
+                            m_settings.accessToken = client.getAccessToken();
+                            m_settings.refreshToken = client.getRefreshToken();
+                            saveSettings();
+                            authValid = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!authValid) {
+                    brls::Logger::error("All auth modes failed, showing login screen");
+                }
+            }
+        } else {
+            brls::Logger::warning("Server not reachable");
+        }
+
+        if (authValid) {
             brls::Logger::info("Connection restored successfully");
             m_isConnected = true;
 
@@ -113,7 +168,7 @@ void Application::run() {
 
             pushMainActivity();
         } else {
-            // Connection failed - could be offline or auth expired
+            // Connection or auth failed - could be offline or auth expired
             // Check if we have downloads, if so go to main activity (offline mode)
             auto downloads = DownloadsManager::getInstance().getDownloads();
             if (!downloads.empty()) {

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2066,6 +2066,36 @@ AuthMode SuwayomiClient::detectServerAuthMode(const std::string& url, std::strin
     }
 }
 
+bool SuwayomiClient::validateAuthWithProtectedQuery() {
+    // Use a lightweight protected query to verify auth actually works
+    // aboutServer is public and always succeeds - we need to test a protected endpoint
+    const char* query = R"(
+        query {
+            categories {
+                nodes {
+                    id
+                }
+            }
+        }
+    )";
+
+    std::string response = executeGraphQL(query);
+    if (response.empty()) {
+        brls::Logger::warning("validateAuthWithProtectedQuery: query returned empty (auth likely failed)");
+        return false;
+    }
+
+    // Check if response contains data (not just errors)
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) {
+        brls::Logger::warning("validateAuthWithProtectedQuery: no data in response");
+        return false;
+    }
+
+    brls::Logger::info("validateAuthWithProtectedQuery: auth validated successfully");
+    return true;
+}
+
 bool SuwayomiClient::fetchServerInfo(ServerInfo& info) {
     // Try GraphQL first (primary API)
     brls::Logger::info("Fetching server info via GraphQL...");


### PR DESCRIPTION
Auto-detect auth mode on login - no more manual Simple/UI Login selection

The login page now automatically detects the correct auth mode:
- Checks if server requires auth at all
- Detects JWT vs Basic Auth support
- Tries UI Login then Simple Login, validates with protected query
- Falls back through all modes until one works
- Shows clear errors: "Server offline or wrong URL", "Wrong username or password"

Connection restore on app restart also validates auth with a protected
query (categories) instead of just the public aboutServer endpoint,
and auto-switches auth modes if the saved mode no longer works.

---
_Generated by [Claude Code](https://claude.ai/code)_