### PR TITLE
Remove wrong URL notification and auth mode selector from login screen

### DIFF
--- a/include/activity/login_activity.hpp
+++ b/include/activity/login_activity.hpp
@@ -38,6 +38,7 @@ private:
     std::string m_username;
     std::string m_password;
     AuthMode m_authMode = AuthMode::NONE;
+    bool m_connecting = false;
 
     std::string getAuthModeName(AuthMode mode);
 };

--- a/include/activity/login_activity.hpp
+++ b/include/activity/login_activity.hpp
@@ -29,7 +29,6 @@ private:
     BRLS_BIND(brls::Label, serverLabel, "login/server_label");
     BRLS_BIND(brls::Label, usernameLabel, "login/username_label");
     BRLS_BIND(brls::Label, passwordLabel, "login/password_label");
-    BRLS_BIND(brls::Label, authModeLabel, "login/auth_mode_label");
     BRLS_BIND(brls::Button, loginButton, "login/login_button");
     BRLS_BIND(brls::Button, testButton, "login/pin_button");
     BRLS_BIND(brls::Button, offlineButton, "login/offline_button");

--- a/resources/xml/activity/login.xml
+++ b/resources/xml/activity/login.xml
@@ -49,14 +49,6 @@
             marginBottom="15"
             focusable="true"/>
 
-        <!-- Auth Mode -->
-        <brls:Label
-            id="login/auth_mode_label"
-            text="Auth Mode: None"
-            fontSize="18"
-            marginBottom="30"
-            focusable="true"/>
-
     </brls:Box>
 
     <!-- Buttons -->

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -122,47 +122,60 @@ void LoginActivity::onTestConnectionPressed() {
         return;
     }
 
+    if (m_connecting) return;
+    m_connecting = true;
+
     if (statusLabel) statusLabel->setText("Testing connection...");
 
-    SuwayomiClient& client = SuwayomiClient::getInstance();
-    client.setServerUrl(m_serverUrl);
+    std::string serverUrl = m_serverUrl;
+    std::string username = m_username;
+    std::string password = m_password;
 
-    // Step 1: Check basic reachability
-    if (!client.connectToServer(m_serverUrl)) {
-        if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
-        return;
-    }
+    asyncRun([this, serverUrl, username, password]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        client.setServerUrl(serverUrl);
 
-    // Step 2: Fetch server info (public endpoint)
-    ServerInfo info;
-    if (client.fetchServerInfo(info)) {
-        std::string msg = "Reachable! Server v" + info.version;
-        if (statusLabel) statusLabel->setText(msg);
-    } else {
-        if (statusLabel) statusLabel->setText("Server is reachable!");
-    }
+        // Step 1: Check basic reachability
+        if (!client.connectToServer(serverUrl)) {
+            brls::sync([this]() {
+                if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
+                m_connecting = false;
+            });
+            return;
+        }
 
-    // Step 3: Auto-detect auth mode
-    bool serverRequiresAuth = client.checkServerRequiresAuth(m_serverUrl);
-    if (!serverRequiresAuth) {
-        if (statusLabel) statusLabel->setText("Server OK - no auth required");
-        m_authMode = AuthMode::NONE;
-        return;
-    }
+        // Step 2: Fetch server info (public endpoint)
+        ServerInfo info;
+        bool hasInfo = client.fetchServerInfo(info);
+        std::string infoVersion = hasInfo ? info.version : "";
 
-    // Server requires auth - detect the type
-    std::string errorMsg;
-    AuthMode detectedMode = client.detectServerAuthMode(m_serverUrl, errorMsg);
-    std::string modeName = getAuthModeName(detectedMode);
+        // Step 3: Auto-detect auth mode
+        bool serverRequiresAuth = client.checkServerRequiresAuth(serverUrl);
+        if (!serverRequiresAuth) {
+            brls::sync([this]() {
+                if (statusLabel) statusLabel->setText("Server OK - no auth required");
+                m_authMode = AuthMode::NONE;
+                m_connecting = false;
+            });
+            return;
+        }
 
-    if (m_username.empty() || m_password.empty()) {
-        if (statusLabel) statusLabel->setText("Auth required (" + modeName + ") - enter credentials");
-        m_authMode = detectedMode;
-        return;
-    }
+        // Server requires auth - detect the type
+        std::string errorMsg;
+        AuthMode detectedMode = client.detectServerAuthMode(serverUrl, errorMsg);
+        std::string modeName = getAuthModeName(detectedMode);
 
-    if (statusLabel) statusLabel->setText("Server OK, auth: " + modeName);
-    m_authMode = detectedMode;
+        brls::sync([this, username, password, detectedMode, modeName]() {
+            m_authMode = detectedMode;
+            m_connecting = false;
+
+            if (username.empty() || password.empty()) {
+                if (statusLabel) statusLabel->setText("Auth required (" + modeName + ") - enter credentials");
+            } else {
+                if (statusLabel) statusLabel->setText("Server OK, auth: " + modeName);
+            }
+        });
+    });
 }
 
 void LoginActivity::onConnectPressed() {
@@ -171,138 +184,166 @@ void LoginActivity::onConnectPressed() {
         return;
     }
 
+    if (m_connecting) return;
+    m_connecting = true;
+
     if (statusLabel) statusLabel->setText("Connecting...");
 
-    SuwayomiClient& client = SuwayomiClient::getInstance();
-    client.setServerUrl(m_serverUrl);
+    // Capture values for background thread
+    std::string serverUrl = m_serverUrl;
+    std::string username = m_username;
+    std::string password = m_password;
 
-    bool connected = false;
+    asyncRun([this, serverUrl, username, password]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        client.setServerUrl(serverUrl);
 
-    // Step 1: Check if server is reachable at all (using basic connectivity test)
-    if (statusLabel) statusLabel->setText("Checking server...");
-    if (!client.connectToServer(m_serverUrl)) {
-        // Server not reachable - provide specific error
-        if (statusLabel) statusLabel->setText("Cannot reach server");
-        return;
-    }
+        bool connected = false;
+        AuthMode authMode = AuthMode::NONE;
 
-    // Server is reachable - now check auth requirements
-    if (statusLabel) statusLabel->setText("Detecting auth mode...");
-    bool serverRequiresAuth = client.checkServerRequiresAuth(m_serverUrl);
-
-    if (!serverRequiresAuth) {
-        // No auth required - already connected from step 1
-        brls::Logger::info("Server does not require auth");
-        m_authMode = AuthMode::NONE;
-        client.setAuthMode(AuthMode::NONE);
-        connected = true;
-    } else {
-        // Server requires auth - need credentials
-        if (m_username.empty() || m_password.empty()) {
-            if (statusLabel) statusLabel->setText("Server requires auth - enter username & password");
+        // Step 1: Check if server is reachable at all
+        brls::sync([this]() {
+            if (statusLabel) statusLabel->setText("Checking server...");
+        });
+        if (!client.connectToServer(serverUrl)) {
+            brls::sync([this]() {
+                if (statusLabel) statusLabel->setText("Cannot reach server");
+                m_connecting = false;
+            });
             return;
         }
 
-        // Step 2: Detect if server supports JWT or only Basic Auth
-        bool supportsJWT = client.checkServerSupportsJWTLogin(m_serverUrl);
+        // Server is reachable - now check auth requirements
+        brls::sync([this]() {
+            if (statusLabel) statusLabel->setText("Detecting auth mode...");
+        });
+        bool serverRequiresAuth = client.checkServerRequiresAuth(serverUrl);
 
-        if (supportsJWT) {
-            // Server supports JWT - try UI_LOGIN first, then SIMPLE_LOGIN
-            AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN };
-            bool loginOk = false;
-
-            for (AuthMode tryMode : tryModes) {
-                std::string modeName = getAuthModeName(tryMode);
-                brls::Logger::info("Trying auth mode: {}", modeName);
-                if (statusLabel) statusLabel->setText("Trying " + modeName + "...");
-
-                client.setAuthMode(tryMode);
-                client.logout();  // Clear any previous tokens
-
-                if (!client.login(m_username, m_password)) {
-                    brls::Logger::info("{}: login failed - bad credentials?", modeName);
-                    // Login mutation failed - likely wrong credentials
-                    // Don't try more modes, credentials are the issue
-                    if (statusLabel) statusLabel->setText("Wrong username or password");
-                    brls::Application::notify("Check your credentials");
-                    return;
-                }
-
-                // Login succeeded - validate with a protected query
-                if (client.validateAuthWithProtectedQuery()) {
-                    brls::Logger::info("Auto-detected auth mode: {}", modeName);
-                    m_authMode = tryMode;
-                    loginOk = true;
-                    connected = true;
-                    break;
-                }
-
-                brls::Logger::info("{}: login ok but protected query failed, trying next", modeName);
-            }
-
-            if (!loginOk) {
-                // JWT modes didn't work - try Basic Auth as fallback
-                brls::Logger::info("JWT modes failed, trying Basic Auth fallback");
-                if (statusLabel) statusLabel->setText("Trying Basic Auth...");
-                client.setAuthMode(AuthMode::BASIC_AUTH);
-                client.logout();
-                client.setAuthCredentials(m_username, m_password);
-
-                if (client.validateAuthWithProtectedQuery()) {
-                    brls::Logger::info("Auth succeeded with Basic Auth fallback");
-                    m_authMode = AuthMode::BASIC_AUTH;
-                    connected = true;
-                } else {
-                    if (statusLabel) statusLabel->setText("Wrong username or password");
-                    brls::Application::notify("All auth modes failed - check credentials");
-                    return;
-                }
-            }
+        if (!serverRequiresAuth) {
+            brls::Logger::info("Server does not require auth");
+            authMode = AuthMode::NONE;
+            client.setAuthMode(AuthMode::NONE);
+            connected = true;
         } else {
-            // Server only supports Basic Auth
-            brls::Logger::info("Auto-detected: Basic Auth");
-            m_authMode = AuthMode::BASIC_AUTH;
-            client.setAuthMode(AuthMode::BASIC_AUTH);
-            client.setAuthCredentials(m_username, m_password);
-
-            // Validate credentials with a protected query
-            if (statusLabel) statusLabel->setText("Authenticating...");
-            if (!client.validateAuthWithProtectedQuery()) {
-                if (statusLabel) statusLabel->setText("Wrong username or password");
-                brls::Application::notify("Check your credentials");
+            // Server requires auth - need credentials
+            if (username.empty() || password.empty()) {
+                brls::sync([this]() {
+                    if (statusLabel) statusLabel->setText("Server requires auth - enter username & password");
+                    m_connecting = false;
+                });
                 return;
             }
-            connected = true;
+
+            // Step 2: Detect if server supports JWT or only Basic Auth
+            bool supportsJWT = client.checkServerSupportsJWTLogin(serverUrl);
+
+            if (supportsJWT) {
+                AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN };
+                bool loginOk = false;
+
+                for (AuthMode tryMode : tryModes) {
+                    std::string modeName = getAuthModeName(tryMode);
+                    brls::Logger::info("Trying auth mode: {}", modeName);
+                    brls::sync([this, modeName]() {
+                        if (statusLabel) statusLabel->setText("Trying " + modeName + "...");
+                    });
+
+                    client.setAuthMode(tryMode);
+                    client.logout();
+
+                    if (!client.login(username, password)) {
+                        brls::Logger::info("{}: login failed - bad credentials?", modeName);
+                        brls::sync([this]() {
+                            if (statusLabel) statusLabel->setText("Wrong username or password");
+                            m_connecting = false;
+                        });
+                        return;
+                    }
+
+                    if (client.validateAuthWithProtectedQuery()) {
+                        brls::Logger::info("Auto-detected auth mode: {}", modeName);
+                        authMode = tryMode;
+                        loginOk = true;
+                        connected = true;
+                        break;
+                    }
+
+                    brls::Logger::info("{}: login ok but protected query failed, trying next", modeName);
+                }
+
+                if (!loginOk) {
+                    brls::Logger::info("JWT modes failed, trying Basic Auth fallback");
+                    brls::sync([this]() {
+                        if (statusLabel) statusLabel->setText("Trying Basic Auth...");
+                    });
+                    client.setAuthMode(AuthMode::BASIC_AUTH);
+                    client.logout();
+                    client.setAuthCredentials(username, password);
+
+                    if (client.validateAuthWithProtectedQuery()) {
+                        brls::Logger::info("Auth succeeded with Basic Auth fallback");
+                        authMode = AuthMode::BASIC_AUTH;
+                        connected = true;
+                    } else {
+                        brls::sync([this]() {
+                            if (statusLabel) statusLabel->setText("Wrong username or password");
+                            m_connecting = false;
+                        });
+                        return;
+                    }
+                }
+            } else {
+                brls::Logger::info("Auto-detected: Basic Auth");
+                authMode = AuthMode::BASIC_AUTH;
+                client.setAuthMode(AuthMode::BASIC_AUTH);
+                client.setAuthCredentials(username, password);
+
+                brls::sync([this]() {
+                    if (statusLabel) statusLabel->setText("Authenticating...");
+                });
+                if (!client.validateAuthWithProtectedQuery()) {
+                    brls::sync([this]() {
+                        if (statusLabel) statusLabel->setText("Wrong username or password");
+                        m_connecting = false;
+                    });
+                    return;
+                }
+                connected = true;
+            }
         }
-    }
 
-    if (connected) {
-        // Save server URL and auth credentials
-        Application::getInstance().setServerUrl(m_serverUrl);
-        Application::getInstance().setAuthCredentials(m_username, m_password);
-        Application::getInstance().setConnected(true);
+        // Back to UI thread for final result
+        brls::sync([this, connected, authMode, serverUrl, username, password]() {
+            m_connecting = false;
 
-        // Save auto-detected auth mode and tokens
-        AppSettings& settings = Application::getInstance().getSettings();
-        settings.authMode = static_cast<int>(m_authMode);
-        settings.accessToken = client.getAccessToken();
-        settings.refreshToken = client.getRefreshToken();
+            if (connected) {
+                m_authMode = authMode;
 
-        if (settings.localServerUrl.empty()) {
-            settings.localServerUrl = m_serverUrl;
-        }
+                SuwayomiClient& client = SuwayomiClient::getInstance();
+                Application::getInstance().setServerUrl(serverUrl);
+                Application::getInstance().setAuthCredentials(username, password);
+                Application::getInstance().setConnected(true);
 
-        Application::getInstance().saveSettings();
+                AppSettings& settings = Application::getInstance().getSettings();
+                settings.authMode = static_cast<int>(authMode);
+                settings.accessToken = client.getAccessToken();
+                settings.refreshToken = client.getRefreshToken();
 
-        std::string modeName = getAuthModeName(m_authMode);
-        if (statusLabel) statusLabel->setText("Connected! (" + modeName + ")");
+                if (settings.localServerUrl.empty()) {
+                    settings.localServerUrl = serverUrl;
+                }
 
-        brls::sync([this]() {
-            Application::getInstance().pushMainActivity();
+                Application::getInstance().saveSettings();
+
+                std::string modeName = getAuthModeName(authMode);
+                if (statusLabel) statusLabel->setText("Connected! (" + modeName + ")");
+
+                Application::getInstance().pushMainActivity();
+            } else {
+                if (statusLabel) statusLabel->setText("Connection failed");
+            }
         });
-    } else {
-        if (statusLabel) statusLabel->setText("Connection failed");
-    }
+    });
 }
 
 void LoginActivity::onOfflinePressed() {

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -88,25 +88,6 @@ void LoginActivity::onContentAvailable() {
         passwordLabel->addGestureRecognizer(new brls::TapGestureRecognizer(passwordLabel));
     }
 
-    // Auth mode display (auto-detected on connect)
-    if (authModeLabel) {
-        if (m_authMode == AuthMode::NONE && m_serverUrl.empty()) {
-            authModeLabel->setText("Auth Mode: Auto-detect");
-        } else {
-            authModeLabel->setText("Auth Mode: " + getAuthModeName(m_authMode));
-        }
-        // Still allow manual override if user taps
-        authModeLabel->registerClickAction([this](brls::View* view) {
-            // Cycle through auth modes (manual override)
-            int currentMode = static_cast<int>(m_authMode);
-            currentMode = (currentMode + 1) % 4;
-            m_authMode = static_cast<AuthMode>(currentMode);
-            authModeLabel->setText("Auth Mode: " + getAuthModeName(m_authMode));
-            return true;
-        });
-        authModeLabel->addGestureRecognizer(new brls::TapGestureRecognizer(authModeLabel));
-    }
-
     // Connect button
     if (loginButton) {
         loginButton->setText("Connect");
@@ -166,7 +147,6 @@ void LoginActivity::onTestConnectionPressed() {
     if (!serverRequiresAuth) {
         if (statusLabel) statusLabel->setText("Server OK - no auth required");
         m_authMode = AuthMode::NONE;
-        if (authModeLabel) authModeLabel->setText("Auth Mode: None");
         return;
     }
 
@@ -178,13 +158,11 @@ void LoginActivity::onTestConnectionPressed() {
     if (m_username.empty() || m_password.empty()) {
         if (statusLabel) statusLabel->setText("Auth required (" + modeName + ") - enter credentials");
         m_authMode = detectedMode;
-        if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
         return;
     }
 
     if (statusLabel) statusLabel->setText("Server OK, auth: " + modeName);
     m_authMode = detectedMode;
-    if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
 }
 
 void LoginActivity::onConnectPressed() {
@@ -204,8 +182,7 @@ void LoginActivity::onConnectPressed() {
     if (statusLabel) statusLabel->setText("Checking server...");
     if (!client.connectToServer(m_serverUrl)) {
         // Server not reachable - provide specific error
-        if (statusLabel) statusLabel->setText("Server offline or wrong URL");
-        brls::Application::notify("Cannot reach " + m_serverUrl);
+        if (statusLabel) statusLabel->setText("Cannot reach server");
         return;
     }
 
@@ -217,7 +194,6 @@ void LoginActivity::onConnectPressed() {
         // No auth required - already connected from step 1
         brls::Logger::info("Server does not require auth");
         m_authMode = AuthMode::NONE;
-        if (authModeLabel) authModeLabel->setText("Auth Mode: None");
         client.setAuthMode(AuthMode::NONE);
         connected = true;
     } else {
@@ -256,7 +232,6 @@ void LoginActivity::onConnectPressed() {
                 if (client.validateAuthWithProtectedQuery()) {
                     brls::Logger::info("Auto-detected auth mode: {}", modeName);
                     m_authMode = tryMode;
-                    if (authModeLabel) authModeLabel->setText("Auth Mode: " + modeName);
                     loginOk = true;
                     connected = true;
                     break;
@@ -276,7 +251,6 @@ void LoginActivity::onConnectPressed() {
                 if (client.validateAuthWithProtectedQuery()) {
                     brls::Logger::info("Auth succeeded with Basic Auth fallback");
                     m_authMode = AuthMode::BASIC_AUTH;
-                    if (authModeLabel) authModeLabel->setText("Auth Mode: Basic Auth");
                     connected = true;
                 } else {
                     if (statusLabel) statusLabel->setText("Wrong username or password");
@@ -288,7 +262,6 @@ void LoginActivity::onConnectPressed() {
             // Server only supports Basic Auth
             brls::Logger::info("Auto-detected: Basic Auth");
             m_authMode = AuthMode::BASIC_AUTH;
-            if (authModeLabel) authModeLabel->setText("Auth Mode: Basic Auth");
             client.setAuthMode(AuthMode::BASIC_AUTH);
             client.setAuthCredentials(m_username, m_password);
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1959,17 +1959,20 @@ bool SuwayomiClient::connectToServer(const std::string& url) {
 }
 
 bool SuwayomiClient::checkServerRequiresAuth(const std::string& url) {
-    // Make a simple request WITHOUT authentication to check if server requires auth
-    // Returns true if server responds with 401 Unauthorized
+    // Make a request WITHOUT authentication to check if server requires auth
+    // Uses a PROTECTED query (categories) instead of a public one (aboutServer)
+    // so we can reliably detect when auth is needed
     brls::Logger::info("Checking if server requires authentication...");
 
     // Create a basic HTTP client without any auth headers
     vitasuwayomi::HttpClient http;
     http.setTimeout(10);
+    http.setDefaultHeader("Accept", "application/json");
 
-    // Try the GraphQL endpoint first (most common)
+    // Try the GraphQL endpoint with a PROTECTED query (categories requires auth)
+    // aboutServer is public and would return 200 even when auth is required
     std::string testUrl = url + "/api/graphql";
-    std::string body = R"({"query":"{ aboutServer { name } }"})";
+    std::string body = R"({"query":"{ categories { nodes { id } } }"})";
 
     vitasuwayomi::HttpResponse response = http.post(testUrl, body, "application/json");
 
@@ -1978,12 +1981,32 @@ bool SuwayomiClient::checkServerRequiresAuth(const std::string& url) {
         return true;
     }
 
+    // If we got a 200, verify it's a valid Suwayomi GraphQL response with actual data
+    // A non-Suwayomi server (e.g. nginx serving HTML) would return 200 but not valid GraphQL JSON
+    if (response.statusCode == 200 && response.body.find("\"data\"") != std::string::npos) {
+        brls::Logger::info("Server does not require authentication (protected query succeeded)");
+        return false;
+    }
+
     // Also try REST endpoint as fallback check
     testUrl = url + "/api/v1/settings/about";
     response = http.get(testUrl);
 
     if (response.statusCode == 401) {
         brls::Logger::info("Server requires authentication (got 401 from REST)");
+        return true;
+    }
+
+    // If REST returned 200, verify it contains Suwayomi JSON data
+    if (response.statusCode == 200) {
+        size_t firstChar = response.body.find_first_not_of(" \t\n\r");
+        if (firstChar != std::string::npos && response.body[firstChar] == '{' &&
+            response.body.find("\"version\"") != std::string::npos) {
+            brls::Logger::info("Server does not require authentication (REST about succeeded)");
+            return false;
+        }
+        // Response is 200 but not valid Suwayomi JSON - likely a web server returning HTML
+        brls::Logger::warning("REST response is not valid Suwayomi JSON, assuming auth required");
         return true;
     }
 
@@ -2126,6 +2149,14 @@ bool SuwayomiClient::fetchServerInfo(ServerInfo& info) {
             return false;
         }
 
+        // Validate the source list response is actually JSON (not HTML from a web server)
+        std::string trimmedBody = response.body;
+        size_t firstChar = trimmedBody.find_first_not_of(" \t\n\r");
+        if (firstChar == std::string::npos || trimmedBody[firstChar] != '[') {
+            brls::Logger::error("Source list response is not JSON - server may not be Suwayomi");
+            return false;
+        }
+
         // If source list works, server is reachable but about endpoint might not exist
         info.name = "Suwayomi";
         info.version = "Unknown";
@@ -2136,6 +2167,17 @@ bool SuwayomiClient::fetchServerInfo(ServerInfo& info) {
 
     brls::Logger::debug("Server response: {}", response.body.substr(0, 200));
 
+    // Validate the response is actually JSON (not HTML from a reverse proxy/web server)
+    // A non-Suwayomi server (e.g. nginx) may return 200 with HTML for any path
+    {
+        size_t firstChar = response.body.find_first_not_of(" \t\n\r");
+        if (firstChar == std::string::npos ||
+            (response.body[firstChar] != '{' && response.body[firstChar] != '[')) {
+            brls::Logger::warning("REST about response is not JSON (likely HTML from a web server)");
+            return false;
+        }
+    }
+
     // Parse About response (name, version, revision, buildType, buildTime, github, discord)
     info.name = extractJsonValue(response.body, "name");
     info.version = extractJsonValue(response.body, "version");
@@ -2144,6 +2186,13 @@ bool SuwayomiClient::fetchServerInfo(ServerInfo& info) {
     info.buildTime = extractJsonInt64(response.body, "buildTime");
     info.github = extractJsonValue(response.body, "github");
     info.discord = extractJsonValue(response.body, "discord");
+
+    // Validate the response actually contains Suwayomi data
+    // A real Suwayomi server always returns a version string
+    if (info.version.empty() && info.name.empty()) {
+        brls::Logger::warning("REST about response has no version or name - server may not be Suwayomi");
+        return false;
+    }
 
     // Fallback name if not set
     if (info.name.empty()) info.name = "Suwayomi";


### PR DESCRIPTION
Removes the wrong-URL notification and auth-mode selector from the login screen, fixes a UI freeze during login by moving network calls to a background thread, and fixes a false 'connected' result against non-Suwayomi servers on port 80.

---
_Generated by [Claude Code](https://claude.ai/code)_