### PR TITLE
Fix auth lockout when server switches from JWT to Basic auth mode

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -188,6 +188,7 @@ struct AppSettings {
     int authMode = 0;
     std::string accessToken;           // JWT access token (for ui_login/simple_login)
     std::string refreshToken;          // JWT refresh token (for ui_login/simple_login)
+    std::string sessionCookie;         // Session cookie (for simple_login)
 
     // Display Settings
     bool showUnreadBadge = true;

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -728,8 +728,9 @@ private:
     // hit 401 simultaneously and all try to refresh the token
     time_t m_lastTokenRefreshTime = 0;
 
-    // Login GraphQL methods
+    // Login methods
     bool loginGraphQL(const std::string& username, const std::string& password);
+    bool loginSimpleREST(const std::string& username, const std::string& password);
     bool refreshTokenGraphQL();
 };
 

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -31,10 +31,14 @@ public:
     // Set JWT access token for Bearer auth
     static void setAccessToken(const std::string& token);
 
+    // Set session cookie for SIMPLE_LOGIN mode
+    static void setSessionCookie(const std::string& cookie);
+
     // Get authentication credentials (thread-safe copies for use from worker threads)
     static std::string getAuthUsername();
     static std::string getAuthPassword();
     static std::string getAccessToken();
+    static std::string getSessionCookie();
 
     // Load image asynchronously from URL (with thumbnail downscaling) - for brls::Image
     static void loadAsync(const std::string& url, LoadCallback callback, brls::Image* target);
@@ -120,8 +124,9 @@ private:
     static bool cacheGet(const std::string& url, std::vector<uint8_t>& data);
     static std::string s_authUsername;
     static std::string s_authPassword;
-    static std::string s_accessToken;  // JWT access token for Bearer auth
-    static std::mutex s_authMutex;     // Protects s_authUsername/Password/AccessToken
+    static std::string s_accessToken;    // JWT access token for Bearer auth
+    static std::string s_sessionCookie;  // Session cookie for SIMPLE_LOGIN
+    static std::mutex s_authMutex;       // Protects s_authUsername/Password/AccessToken/SessionCookie
 
     // Worker thread pool - persistent threads that reuse HTTP connections
     // Each worker has its own HttpClient for TCP connection reuse (keep-alive)

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -252,12 +252,8 @@ void LoginActivity::onConnectPressed() {
                     client.logout();
 
                     if (!client.login(username, password)) {
-                        brls::Logger::info("{}: login failed - bad credentials?", modeName);
-                        brls::sync([this]() {
-                            if (statusLabel) statusLabel->setText("Wrong username or password");
-                            m_connecting = false;
-                        });
-                        return;
+                        brls::Logger::info("{}: login call failed, trying next mode", modeName);
+                        continue;
                     }
 
                     if (client.validateAuthWithProtectedQuery()) {

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -324,6 +324,7 @@ void LoginActivity::onConnectPressed() {
                 settings.authMode = static_cast<int>(authMode);
                 settings.accessToken = client.getAccessToken();
                 settings.refreshToken = client.getRefreshToken();
+                settings.sessionCookie = client.getSessionCookie();
 
                 if (settings.localServerUrl.empty()) {
                     settings.localServerUrl = serverUrl;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -118,29 +118,45 @@ void Application::run() {
                 std::string password = getAuthPassword();
 
                 if (!username.empty() && !password.empty()) {
-                    // Try all modes: UI_LOGIN, SIMPLE_LOGIN, BASIC_AUTH
-                    AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::BASIC_AUTH };
-                    for (AuthMode tryMode : tryModes) {
-                        if (tryMode == authMode) continue;  // Already failed with this mode
-
-                        brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
-                        client.setAuthMode(tryMode);
+                    // First try a fresh login with the saved mode (cookies may have expired)
+                    if (authMode == AuthMode::SIMPLE_LOGIN || authMode == AuthMode::UI_LOGIN) {
+                        brls::Logger::info("Trying fresh login with saved mode {}", static_cast<int>(authMode));
+                        client.setAuthMode(authMode);
                         client.logout();
-
-                        if (tryMode == AuthMode::BASIC_AUTH) {
-                            client.setAuthCredentials(username, password);
-                        } else {
-                            if (!client.login(username, password)) continue;
-                        }
-
-                        if (client.validateAuthWithProtectedQuery()) {
-                            brls::Logger::info("Auth succeeded with mode {}", static_cast<int>(tryMode));
-                            m_settings.authMode = static_cast<int>(tryMode);
+                        if (client.login(username, password) && client.validateAuthWithProtectedQuery()) {
+                            brls::Logger::info("Fresh login succeeded with saved mode {}", static_cast<int>(authMode));
                             m_settings.accessToken = client.getAccessToken();
                             m_settings.refreshToken = client.getRefreshToken();
                             saveSettings();
                             authValid = true;
-                            break;
+                        }
+                    }
+
+                    if (!authValid) {
+                        // Try all modes: UI_LOGIN, SIMPLE_LOGIN, BASIC_AUTH
+                        AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::BASIC_AUTH };
+                        for (AuthMode tryMode : tryModes) {
+                            if (tryMode == authMode) continue;  // Already tried with fresh login above
+
+                            brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
+                            client.setAuthMode(tryMode);
+                            client.logout();
+
+                            if (tryMode == AuthMode::BASIC_AUTH) {
+                                client.setAuthCredentials(username, password);
+                            } else {
+                                if (!client.login(username, password)) continue;
+                            }
+
+                            if (client.validateAuthWithProtectedQuery()) {
+                                brls::Logger::info("Auth succeeded with mode {}", static_cast<int>(tryMode));
+                                m_settings.authMode = static_cast<int>(tryMode);
+                                m_settings.accessToken = client.getAccessToken();
+                                m_settings.refreshToken = client.getRefreshToken();
+                                saveSettings();
+                                authValid = true;
+                                break;
+                            }
                         }
                     }
                 }
@@ -161,31 +177,49 @@ void Application::run() {
 
             if (!username.empty() && !password.empty()) {
                 brls::Logger::info("Have credentials, trying auth mode fallback...");
-                // Try BASIC_AUTH first since it's the most common fallback from JWT
-                AuthMode tryModes[] = { AuthMode::BASIC_AUTH, AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::NONE };
-                for (AuthMode tryMode : tryModes) {
-                    if (tryMode == authMode) continue;  // Already failed with this mode
 
-                    brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
-                    client.setAuthMode(tryMode);
+                // First try a fresh login with the saved mode (cookies/tokens may have expired)
+                if (authMode == AuthMode::SIMPLE_LOGIN || authMode == AuthMode::UI_LOGIN) {
+                    brls::Logger::info("Trying fresh login with saved mode {}", static_cast<int>(authMode));
+                    client.setAuthMode(authMode);
                     client.logout();
-
-                    if (tryMode == AuthMode::BASIC_AUTH) {
-                        client.setAuthCredentials(username, password);
-                    } else if (tryMode == AuthMode::NONE) {
-                        // No credentials needed
-                    } else {
-                        if (!client.login(username, password)) continue;
-                    }
-
-                    if (client.testConnection() && client.validateAuthWithProtectedQuery()) {
-                        brls::Logger::info("Connection succeeded with auth mode {}", static_cast<int>(tryMode));
-                        m_settings.authMode = static_cast<int>(tryMode);
+                    if (client.login(username, password) &&
+                        client.testConnection() && client.validateAuthWithProtectedQuery()) {
+                        brls::Logger::info("Fresh login succeeded with saved mode {}", static_cast<int>(authMode));
                         m_settings.accessToken = client.getAccessToken();
                         m_settings.refreshToken = client.getRefreshToken();
                         saveSettings();
                         authValid = true;
-                        break;
+                    }
+                }
+
+                if (!authValid) {
+                    // Try BASIC_AUTH first since it's the most common fallback from JWT
+                    AuthMode tryModes[] = { AuthMode::BASIC_AUTH, AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::NONE };
+                    for (AuthMode tryMode : tryModes) {
+                        if (tryMode == authMode) continue;  // Already tried with fresh login above
+
+                        brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
+                        client.setAuthMode(tryMode);
+                        client.logout();
+
+                        if (tryMode == AuthMode::BASIC_AUTH) {
+                            client.setAuthCredentials(username, password);
+                        } else if (tryMode == AuthMode::NONE) {
+                            // No credentials needed
+                        } else {
+                            if (!client.login(username, password)) continue;
+                        }
+
+                        if (client.testConnection() && client.validateAuthWithProtectedQuery()) {
+                            brls::Logger::info("Connection succeeded with auth mode {}", static_cast<int>(tryMode));
+                            m_settings.authMode = static_cast<int>(tryMode);
+                            m_settings.accessToken = client.getAccessToken();
+                            m_settings.refreshToken = client.getRefreshToken();
+                            saveSettings();
+                            authValid = true;
+                            break;
+                        }
                     }
                 }
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -75,23 +75,34 @@ void Application::run() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         client.setServerUrl(m_serverUrl);
 
-        // If we have JWT tokens, try to refresh them first (they may be expired)
+        // Try to restore auth session
         AuthMode authMode = client.getAuthMode();
-        if ((authMode == AuthMode::SIMPLE_LOGIN || authMode == AuthMode::UI_LOGIN) &&
-            !client.getRefreshToken().empty()) {
+        if (authMode == AuthMode::SIMPLE_LOGIN) {
+            // SIMPLE_LOGIN uses server-side sessions via POST /login.html.
+            // Sessions expire, so always re-login with stored credentials.
+            std::string username = getAuthUsername();
+            std::string password = getAuthPassword();
+            if (!username.empty() && !password.empty()) {
+                brls::Logger::info("SIMPLE_LOGIN: re-establishing session...");
+                if (client.login(username, password)) {
+                    brls::Logger::info("SIMPLE_LOGIN: session established");
+                    m_settings.sessionCookie = client.getSessionCookie();
+                } else {
+                    brls::Logger::warning("SIMPLE_LOGIN: session login failed");
+                    client.setSessionCookie("");
+                    m_settings.sessionCookie = "";
+                }
+            }
+        } else if (authMode == AuthMode::UI_LOGIN && !client.getRefreshToken().empty()) {
+            // UI_LOGIN uses JWT tokens - try to refresh them (they may be expired)
             brls::Logger::info("Attempting to refresh JWT tokens...");
             if (client.refreshToken()) {
                 brls::Logger::info("Token refresh successful");
-                // Update stored tokens
                 m_settings.accessToken = client.getAccessToken();
                 m_settings.refreshToken = client.getRefreshToken();
                 m_settings.sessionCookie = client.getSessionCookie();
             } else {
                 brls::Logger::warning("Token refresh failed, clearing stale tokens for basic auth fallback");
-                // Clear stale JWT tokens so createHttpClient() falls back to Basic auth credentials.
-                // This handles the case where the server switched from JWT to Basic auth mode -
-                // without clearing, createHttpClient() keeps sending the stale Bearer token
-                // which the server rejects with 401 on every request.
                 client.setTokens("", "");
                 m_settings.accessToken = "";
                 m_settings.refreshToken = "";

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -85,6 +85,7 @@ void Application::run() {
                 // Update stored tokens
                 m_settings.accessToken = client.getAccessToken();
                 m_settings.refreshToken = client.getRefreshToken();
+                m_settings.sessionCookie = client.getSessionCookie();
             } else {
                 brls::Logger::warning("Token refresh failed, clearing stale tokens for basic auth fallback");
                 // Clear stale JWT tokens so createHttpClient() falls back to Basic auth credentials.
@@ -127,6 +128,7 @@ void Application::run() {
                             brls::Logger::info("Fresh login succeeded with saved mode {}", static_cast<int>(authMode));
                             m_settings.accessToken = client.getAccessToken();
                             m_settings.refreshToken = client.getRefreshToken();
+                            m_settings.sessionCookie = client.getSessionCookie();
                             saveSettings();
                             authValid = true;
                         }
@@ -153,6 +155,7 @@ void Application::run() {
                                 m_settings.authMode = static_cast<int>(tryMode);
                                 m_settings.accessToken = client.getAccessToken();
                                 m_settings.refreshToken = client.getRefreshToken();
+                                m_settings.sessionCookie = client.getSessionCookie();
                                 saveSettings();
                                 authValid = true;
                                 break;
@@ -188,6 +191,7 @@ void Application::run() {
                         brls::Logger::info("Fresh login succeeded with saved mode {}", static_cast<int>(authMode));
                         m_settings.accessToken = client.getAccessToken();
                         m_settings.refreshToken = client.getRefreshToken();
+                        m_settings.sessionCookie = client.getSessionCookie();
                         saveSettings();
                         authValid = true;
                     }
@@ -216,6 +220,7 @@ void Application::run() {
                             m_settings.authMode = static_cast<int>(tryMode);
                             m_settings.accessToken = client.getAccessToken();
                             m_settings.refreshToken = client.getRefreshToken();
+                            m_settings.sessionCookie = client.getSessionCookie();
                             saveSettings();
                             authValid = true;
                             break;
@@ -841,6 +846,7 @@ bool Application::loadSettings() {
     m_settings.authMode = extractInt("authMode");
     m_settings.accessToken = extractString("accessToken");
     m_settings.refreshToken = extractString("refreshToken");
+    m_settings.sessionCookie = extractString("sessionCookie");
 
     // Apply auth credentials and mode to SuwayomiClient
     SuwayomiClient& client = SuwayomiClient::getInstance();
@@ -855,6 +861,12 @@ bool Application::loadSettings() {
     if (!m_settings.accessToken.empty() || !m_settings.refreshToken.empty()) {
         client.setTokens(m_settings.accessToken, m_settings.refreshToken);
         brls::Logger::info("Restored auth tokens");
+    }
+
+    // Restore session cookie for simple_login
+    if (!m_settings.sessionCookie.empty()) {
+        client.setSessionCookie(m_settings.sessionCookie);
+        brls::Logger::info("Restored session cookie");
     }
 
     brls::Logger::info("Settings loaded successfully");
@@ -879,6 +891,7 @@ bool Application::saveSettings() {
     json += "  \"authMode\": " + std::to_string(m_settings.authMode) + ",\n";
     json += "  \"accessToken\": \"" + m_settings.accessToken + "\",\n";
     json += "  \"refreshToken\": \"" + m_settings.refreshToken + "\",\n";
+    json += "  \"sessionCookie\": \"" + m_settings.sessionCookie + "\",\n";
 
     // UI settings
     json += "  \"theme\": " + std::to_string(static_cast<int>(m_settings.theme)) + ",\n";

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -86,7 +86,14 @@ void Application::run() {
                 m_settings.accessToken = client.getAccessToken();
                 m_settings.refreshToken = client.getRefreshToken();
             } else {
-                brls::Logger::warning("Token refresh failed, will try basic connection test");
+                brls::Logger::warning("Token refresh failed, clearing stale tokens for basic auth fallback");
+                // Clear stale JWT tokens so createHttpClient() falls back to Basic auth credentials.
+                // This handles the case where the server switched from JWT to Basic auth mode -
+                // without clearing, createHttpClient() keeps sending the stale Bearer token
+                // which the server rejects with 401 on every request.
+                client.setTokens("", "");
+                m_settings.accessToken = "";
+                m_settings.refreshToken = "";
             }
         }
 
@@ -143,7 +150,54 @@ void Application::run() {
                 }
             }
         } else {
-            brls::Logger::warning("Server not reachable");
+            brls::Logger::warning("Server not reachable with current auth mode {}", static_cast<int>(authMode));
+
+            // testConnection() can fail due to auth mode mismatch (not just network issues).
+            // For example, if server switched from JWT to Basic auth and token clearing wasn't
+            // enough, or if the auth mode changed in other ways.
+            // Try all auth modes as fallback before giving up.
+            std::string username = getAuthUsername();
+            std::string password = getAuthPassword();
+
+            if (!username.empty() && !password.empty()) {
+                brls::Logger::info("Have credentials, trying auth mode fallback...");
+                // Try BASIC_AUTH first since it's the most common fallback from JWT
+                AuthMode tryModes[] = { AuthMode::BASIC_AUTH, AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::NONE };
+                for (AuthMode tryMode : tryModes) {
+                    if (tryMode == authMode) continue;  // Already failed with this mode
+
+                    brls::Logger::info("Trying auth mode: {}", static_cast<int>(tryMode));
+                    client.setAuthMode(tryMode);
+                    client.logout();
+
+                    if (tryMode == AuthMode::BASIC_AUTH) {
+                        client.setAuthCredentials(username, password);
+                    } else if (tryMode == AuthMode::NONE) {
+                        // No credentials needed
+                    } else {
+                        if (!client.login(username, password)) continue;
+                    }
+
+                    if (client.testConnection() && client.validateAuthWithProtectedQuery()) {
+                        brls::Logger::info("Connection succeeded with auth mode {}", static_cast<int>(tryMode));
+                        m_settings.authMode = static_cast<int>(tryMode);
+                        m_settings.accessToken = client.getAccessToken();
+                        m_settings.refreshToken = client.getRefreshToken();
+                        saveSettings();
+                        authValid = true;
+                        break;
+                    }
+                }
+
+                if (!authValid) {
+                    // Restore original auth mode so login screen starts from a known state
+                    client.setAuthMode(authMode);
+                    if (authMode == AuthMode::BASIC_AUTH) {
+                        client.setAuthCredentials(username, password);
+                    }
+                    brls::Logger::error("All auth mode fallbacks failed");
+                }
+            }
         }
 
         if (authValid) {

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -192,19 +192,14 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             break;
 
         case AuthMode::SIMPLE_LOGIN:
-            // Cookie-based session - use JWT token if available, otherwise try basic auth
-            if (!m_accessToken.empty()) {
-                http.setDefaultHeader("Authorization", "Bearer " + m_accessToken);
-                // Prefer actual session cookie from Set-Cookie header over synthetic token cookie
-                if (!m_sessionCookie.empty()) {
-                    http.setDefaultHeader("Cookie", m_sessionCookie);
-                } else {
-                    http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
-                }
-            } else if (!m_sessionCookie.empty()) {
+            // Session-based auth - send the session cookie from POST /login.html
+            // SIMPLE_LOGIN uses Javalin server-side sessions, NOT JWT tokens.
+            // The session cookie (e.g. JSESSIONID=xxx) tracks the server-side session
+            // that has the "logged-in" attribute set.
+            if (!m_sessionCookie.empty()) {
                 http.setDefaultHeader("Cookie", m_sessionCookie);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
-                // Fallback to basic auth for initial requests
+                // Fallback to basic auth if no session yet
                 std::string credentials = m_authUsername + ":" + m_authPassword;
                 http.setDefaultHeader("Authorization", "Basic " + base64Encode(credentials));
             }
@@ -2261,6 +2256,7 @@ void SuwayomiClient::setTokens(const std::string& accessToken, const std::string
 void SuwayomiClient::setSessionCookie(const std::string& cookie) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_sessionCookie = cookie;
+    ImageLoader::setSessionCookie(cookie);
 }
 
 bool SuwayomiClient::isAuthenticated() const {
@@ -2270,7 +2266,7 @@ bool SuwayomiClient::isAuthenticated() const {
         case AuthMode::BASIC_AUTH:
             return !m_authUsername.empty() && !m_authPassword.empty();
         case AuthMode::SIMPLE_LOGIN:
-            return !m_accessToken.empty() || !m_sessionCookie.empty();
+            return !m_sessionCookie.empty();
         case AuthMode::UI_LOGIN:
             return !m_accessToken.empty();
         default:
@@ -2283,6 +2279,9 @@ void SuwayomiClient::logout() {
     m_accessToken.clear();
     m_refreshToken.clear();
     m_sessionCookie.clear();
+    // Clear ImageLoader auth state
+    ImageLoader::setAccessToken("");
+    ImageLoader::setSessionCookie("");
     // Keep username/password for re-login if needed
 }
 
@@ -2302,9 +2301,13 @@ bool SuwayomiClient::login(const std::string& username, const std::string& passw
             return testConnection();
 
         case AuthMode::SIMPLE_LOGIN:
+            // SIMPLE_LOGIN uses session-based auth via POST /login.html
+            // The server sets a Javalin session attribute, tracked by session cookie
+            ImageLoader::setAuthCredentials(username, password);
+            return loginSimpleREST(username, password);
+
         case AuthMode::UI_LOGIN:
-            // Both use the same GraphQL login mutation
-            // The difference is in how the tokens/cookies are used
+            // UI_LOGIN uses JWT tokens via GraphQL login mutation
             ImageLoader::setAuthCredentials(username, password);
             return loginGraphQL(username, password);
 
@@ -2413,6 +2416,85 @@ bool SuwayomiClient::loginGraphQL(const std::string& username, const std::string
     return true;
 }
 
+bool SuwayomiClient::loginSimpleREST(const std::string& username, const std::string& password) {
+    // SIMPLE_LOGIN uses session-based auth via POST /login.html
+    // The Suwayomi server expects form params "user" and "pass",
+    // sets a Javalin session attribute "logged-in", and returns a
+    // 303 redirect with a session cookie (e.g. JSESSIONID).
+    brls::Logger::info("loginSimpleREST: Attempting session-based login...");
+
+    vitasuwayomi::HttpClient http;
+    http.setDefaultHeader("Accept", "text/html,application/json");
+
+    int timeout = Application::getInstance().getSettings().connectionTimeout;
+    if (timeout > 0) {
+        http.setTimeout(timeout);
+    }
+
+    std::string url = m_serverUrl + "/login.html";
+
+    // Build form-encoded body with server's expected param names
+    std::string body = "user=" + vitasuwayomi::HttpClient::urlEncode(username) +
+                       "&pass=" + vitasuwayomi::HttpClient::urlEncode(password);
+
+    // Use request() directly to disable redirect following.
+    // We need to capture Set-Cookie from the 303 redirect response.
+    vitasuwayomi::HttpRequest req;
+    req.url = url;
+    req.method = "POST";
+    req.body = body;
+    req.headers["Content-Type"] = "application/x-www-form-urlencoded";
+    req.followRedirects = false;
+    req.timeout = timeout > 0 ? timeout : 30;
+
+    vitasuwayomi::HttpResponse response = http.request(req);
+
+    brls::Logger::info("loginSimpleREST: response status={}", response.statusCode);
+
+    // Capture session cookie from Set-Cookie header
+    std::string setCookie;
+    auto cookieIt = response.headers.find("Set-Cookie");
+    if (cookieIt == response.headers.end()) {
+        cookieIt = response.headers.find("set-cookie");
+    }
+    if (cookieIt != response.headers.end() && !cookieIt->second.empty()) {
+        setCookie = cookieIt->second;
+        // Strip cookie attributes (Path, HttpOnly, etc.) - keep only name=value
+        size_t semicolonPos = setCookie.find(';');
+        if (semicolonPos != std::string::npos) {
+            setCookie = setCookie.substr(0, semicolonPos);
+        }
+        brls::Logger::info("loginSimpleREST: captured session cookie");
+    }
+
+    // 303 See Other = successful login (server redirects after setting session)
+    if (response.statusCode == 303 || response.statusCode == 302 || response.statusCode == 301) {
+        if (!setCookie.empty()) {
+            m_sessionCookie = setCookie;
+            // Clear JWT tokens - SIMPLE_LOGIN uses session cookies only
+            m_accessToken.clear();
+            m_refreshToken.clear();
+            // Update ImageLoader so image requests also use the session cookie
+            ImageLoader::setSessionCookie(m_sessionCookie);
+            ImageLoader::setAccessToken("");
+            brls::Logger::info("loginSimpleREST: login successful (redirect + session cookie)");
+            return true;
+        }
+        // Got redirect but no cookie - unusual, but try proceeding
+        brls::Logger::warning("loginSimpleREST: got redirect but no Set-Cookie header");
+        return false;
+    }
+
+    // 200 typically means the login page was returned with an error
+    if (response.statusCode == 200) {
+        brls::Logger::warning("loginSimpleREST: login failed (credentials rejected)");
+        return false;
+    }
+
+    brls::Logger::error("loginSimpleREST: unexpected status {}", response.statusCode);
+    return false;
+}
+
 bool SuwayomiClient::refreshToken() {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
@@ -2422,8 +2504,6 @@ bool SuwayomiClient::refreshToken() {
 
     // Dedup: if token was refreshed within the last 5 seconds by another thread,
     // skip the refresh and return success so the caller retries with the new token.
-    // This prevents the thundering herd when multiple worker threads all hit 401
-    // simultaneously and each tries to refresh independently.
     time_t now = time(nullptr);
     if (m_lastTokenRefreshTime > 0 && (now - m_lastTokenRefreshTime) < 5) {
         brls::Logger::info("Token was recently refreshed ({}s ago), skipping duplicate refresh",
@@ -2431,7 +2511,21 @@ bool SuwayomiClient::refreshToken() {
         return true;
     }
 
-    // Try GraphQL refresh if we have a refresh token
+    // SIMPLE_LOGIN: re-login via REST to get a new session cookie
+    if (m_authMode == AuthMode::SIMPLE_LOGIN) {
+        if (!m_authUsername.empty() && !m_authPassword.empty()) {
+            brls::Logger::info("SIMPLE_LOGIN: re-login via REST to refresh session...");
+            if (loginSimpleREST(m_authUsername, m_authPassword)) {
+                m_lastTokenRefreshTime = now;
+                brls::Logger::info("SIMPLE_LOGIN: session refreshed successfully");
+                return true;
+            }
+            brls::Logger::error("SIMPLE_LOGIN: session refresh failed");
+        }
+        return false;
+    }
+
+    // UI_LOGIN: try GraphQL refresh if we have a refresh token
     if (!m_refreshToken.empty()) {
         if (refreshTokenGraphQL()) {
             m_lastTokenRefreshTime = now;
@@ -2442,8 +2536,7 @@ bool SuwayomiClient::refreshToken() {
         brls::Logger::info("No refresh token available, skipping GraphQL refresh");
     }
 
-    // Fallback: re-login with stored credentials (important for simple_login mode
-    // where the server may not issue refresh tokens)
+    // Fallback: re-login with stored credentials
     if (!m_authUsername.empty() && !m_authPassword.empty()) {
         brls::Logger::info("Attempting re-login with stored credentials...");
         if (loginGraphQL(m_authUsername, m_authPassword)) {

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -195,8 +195,12 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             // Cookie-based session - use JWT token if available, otherwise try basic auth
             if (!m_accessToken.empty()) {
                 http.setDefaultHeader("Authorization", "Bearer " + m_accessToken);
-                // Also send as cookie for server compatibility
-                http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
+                // Prefer actual session cookie from Set-Cookie header over synthetic token cookie
+                if (!m_sessionCookie.empty()) {
+                    http.setDefaultHeader("Cookie", m_sessionCookie);
+                } else {
+                    http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
+                }
             } else if (!m_sessionCookie.empty()) {
                 http.setDefaultHeader("Cookie", m_sessionCookie);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
@@ -2266,7 +2270,7 @@ bool SuwayomiClient::isAuthenticated() const {
         case AuthMode::BASIC_AUTH:
             return !m_authUsername.empty() && !m_authPassword.empty();
         case AuthMode::SIMPLE_LOGIN:
-            return !m_sessionCookie.empty();
+            return !m_accessToken.empty() || !m_sessionCookie.empty();
         case AuthMode::UI_LOGIN:
             return !m_accessToken.empty();
         default:
@@ -2416,11 +2420,6 @@ bool SuwayomiClient::refreshToken() {
         return true;  // No token refresh needed for basic auth or no auth
     }
 
-    if (m_refreshToken.empty()) {
-        brls::Logger::error("Cannot refresh token: No refresh token available");
-        return false;
-    }
-
     // Dedup: if token was refreshed within the last 5 seconds by another thread,
     // skip the refresh and return success so the caller retries with the new token.
     // This prevents the thundering herd when multiple worker threads all hit 401
@@ -2432,10 +2431,29 @@ bool SuwayomiClient::refreshToken() {
         return true;
     }
 
-    if (refreshTokenGraphQL()) {
-        m_lastTokenRefreshTime = now;
-        return true;
+    // Try GraphQL refresh if we have a refresh token
+    if (!m_refreshToken.empty()) {
+        if (refreshTokenGraphQL()) {
+            m_lastTokenRefreshTime = now;
+            return true;
+        }
+        brls::Logger::warning("Token refresh failed via GraphQL");
+    } else {
+        brls::Logger::info("No refresh token available, skipping GraphQL refresh");
     }
+
+    // Fallback: re-login with stored credentials (important for simple_login mode
+    // where the server may not issue refresh tokens)
+    if (!m_authUsername.empty() && !m_authPassword.empty()) {
+        brls::Logger::info("Attempting re-login with stored credentials...");
+        if (loginGraphQL(m_authUsername, m_authPassword)) {
+            m_lastTokenRefreshTime = now;
+            brls::Logger::info("Re-login successful, tokens refreshed");
+            return true;
+        }
+        brls::Logger::error("Re-login with stored credentials also failed");
+    }
+
     return false;
 }
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2350,16 +2350,38 @@ bool SuwayomiClient::loginGraphQL(const std::string& username, const std::string
     m_accessToken = extractJsonValue(loginData, "accessToken");
     m_refreshToken = extractJsonValue(loginData, "refreshToken");
 
-    if (m_accessToken.empty()) {
-        brls::Logger::error("Login failed: No access token received");
+    // Capture Set-Cookie header for simple_login mode (cookie-based session)
+    // The server may return a session cookie instead of/in addition to JWT tokens
+    auto cookieIt = response.headers.find("Set-Cookie");
+    if (cookieIt == response.headers.end()) {
+        cookieIt = response.headers.find("set-cookie");
+    }
+    if (cookieIt != response.headers.end() && !cookieIt->second.empty()) {
+        m_sessionCookie = cookieIt->second;
+        // Strip cookie attributes (Path, HttpOnly, etc.) - only keep the cookie value
+        size_t semicolonPos = m_sessionCookie.find(';');
+        if (semicolonPos != std::string::npos) {
+            m_sessionCookie = m_sessionCookie.substr(0, semicolonPos);
+        }
+        brls::Logger::info("Login: captured session cookie");
+    }
+
+    if (m_accessToken.empty() && m_sessionCookie.empty()) {
+        brls::Logger::error("Login failed: No access token or session cookie received");
         return false;
     }
 
-    brls::Logger::info("Login successful, received tokens");
+    if (!m_accessToken.empty()) {
+        brls::Logger::info("Login successful, received JWT tokens");
+    } else {
+        brls::Logger::info("Login successful, received session cookie (simple_login)");
+    }
 
     // Update image loader with auth info and access token
     ImageLoader::setAuthCredentials(username, password);
-    ImageLoader::setAccessToken(m_accessToken);
+    if (!m_accessToken.empty()) {
+        ImageLoader::setAccessToken(m_accessToken);
+    }
 
     return true;
 }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -66,6 +66,12 @@ std::string SuwayomiClient::executeGraphQLInternal(const std::string& query, con
 
     std::string url = buildGraphQLUrl();
 
+    // Log auth state for debugging
+    brls::Logger::debug("GraphQL auth: mode={}, token_len={}, has_cookie={}",
+                       static_cast<int>(m_authMode),
+                       m_accessToken.length(),
+                       !m_sessionCookie.empty());
+
     // Build GraphQL request body
     std::string body = "{\"query\":\"";
 
@@ -165,6 +171,13 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
     }
 
     // Apply authentication based on auth mode
+    // The Suwayomi server accepts tokens from three sources (checked in order):
+    //   1. Authorization: Bearer <token>  header
+    //   2. Cookie: suwayomi-server-token=<token>  cookie
+    //   3. ?token=<token>  query parameter
+    // We send BOTH the header and the cookie to maximize compatibility,
+    // because some server versions/configs may not read the Authorization
+    // header properly for GraphQL endpoints.
     switch (m_authMode) {
         case AuthMode::NONE:
             // No authentication
@@ -182,6 +195,8 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             // Cookie-based session - use JWT token if available, otherwise try basic auth
             if (!m_accessToken.empty()) {
                 http.setDefaultHeader("Authorization", "Bearer " + m_accessToken);
+                // Also send as cookie for server compatibility
+                http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
             } else if (!m_sessionCookie.empty()) {
                 http.setDefaultHeader("Cookie", m_sessionCookie);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
@@ -195,6 +210,8 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             // JWT-based authentication
             if (!m_accessToken.empty()) {
                 http.setDefaultHeader("Authorization", "Bearer " + m_accessToken);
+                // Also send as cookie for server compatibility
+                http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
                 // Fallback to basic auth if no token yet
                 std::string credentials = m_authUsername + ":" + m_authPassword;
@@ -2371,8 +2388,14 @@ bool SuwayomiClient::loginGraphQL(const std::string& username, const std::string
         return false;
     }
 
+    // Reset refresh timestamp so the first refresh after login isn't skipped by dedup
+    m_lastTokenRefreshTime = 0;
+
     if (!m_accessToken.empty()) {
         brls::Logger::info("Login successful, received JWT tokens");
+        brls::Logger::debug("Login: accessToken length={}, first8={}...",
+                           m_accessToken.length(),
+                           m_accessToken.substr(0, 8));
     } else {
         brls::Logger::info("Login successful, received session cookie (simple_login)");
     }
@@ -2476,6 +2499,9 @@ bool SuwayomiClient::refreshTokenGraphQL() {
     m_accessToken = newAccessToken;
     ImageLoader::setAccessToken(m_accessToken);
     brls::Logger::info("Token refreshed successfully");
+    brls::Logger::debug("Refresh: new accessToken length={}, first8={}...",
+                       m_accessToken.length(),
+                       m_accessToken.substr(0, 8));
 
     return true;
 }

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -50,6 +50,7 @@ std::mutex ImageLoader::s_cacheMutex;
 std::string ImageLoader::s_authUsername;
 std::string ImageLoader::s_authPassword;
 std::string ImageLoader::s_accessToken;
+std::string ImageLoader::s_sessionCookie;
 std::mutex ImageLoader::s_authMutex;
 std::queue<ImageLoader::LoadRequest> ImageLoader::s_loadQueue;
 std::queue<ImageLoader::RotatableLoadRequest> ImageLoader::s_rotatableLoadQueue;
@@ -467,6 +468,16 @@ std::string ImageLoader::getAccessToken() {
     return s_accessToken;
 }
 
+void ImageLoader::setSessionCookie(const std::string& cookie) {
+    std::lock_guard<std::mutex> lock(s_authMutex);
+    s_sessionCookie = cookie;
+}
+
+std::string ImageLoader::getSessionCookie() {
+    std::lock_guard<std::mutex> lock(s_authMutex);
+    return s_sessionCookie;
+}
+
 // Helper for Base64 encoding
 static std::string base64EncodeImage(const std::string& input) {
     static const char* b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -487,13 +498,19 @@ static std::string base64EncodeImage(const std::string& input) {
 
 // Helper to apply authentication headers to HTTP client
 static void applyAuthHeaders(HttpClient& client) {
-    // Read tokens once into local variables to avoid TOCTOU races
+    // Read auth state once into local variables to avoid TOCTOU races
+    std::string sessionCookie = ImageLoader::getSessionCookie();
     std::string token = ImageLoader::getAccessToken();
-    if (!token.empty()) {
+
+    if (!sessionCookie.empty()) {
+        // SIMPLE_LOGIN: session cookie from POST /login.html
+        client.setDefaultHeader("Cookie", sessionCookie);
+    } else if (!token.empty()) {
+        // UI_LOGIN: JWT Bearer token
         client.setDefaultHeader("Authorization", "Bearer " + token);
-        // Also send as cookie for server compatibility (Suwayomi checks both)
         client.setDefaultHeader("Cookie", "suwayomi-server-token=" + token);
     } else {
+        // BASIC_AUTH fallback
         std::string username = ImageLoader::getAuthUsername();
         std::string password = ImageLoader::getAuthPassword();
         if (!username.empty() && !password.empty()) {

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -491,6 +491,8 @@ static void applyAuthHeaders(HttpClient& client) {
     std::string token = ImageLoader::getAccessToken();
     if (!token.empty()) {
         client.setDefaultHeader("Authorization", "Bearer " + token);
+        // Also send as cookie for server compatibility (Suwayomi checks both)
+        client.setDefaultHeader("Cookie", "suwayomi-server-token=" + token);
     } else {
         std::string username = ImageLoader::getAuthUsername();
         std::string password = ImageLoader::getAuthPassword();


### PR DESCRIPTION
Fixes authentication when the server switches auth modes: JWT-as-cookie for GraphQL, a working simple_login path using REST session login instead of GraphQL JWT, cookie persistence, and refresh fallback.

---
_Generated by [Claude Code](https://claude.ai/code)_