### PR TITLE
Fix reconnect button to perform full auth restoration like app restart

### DIFF
--- a/include/activity/login_activity.hpp
+++ b/include/activity/login_activity.hpp
@@ -21,7 +21,6 @@ public:
 
 private:
     void onConnectPressed();
-    void onTestConnectionPressed();
     void onOfflinePressed();
 
     BRLS_BIND(brls::Label, titleLabel, "login/title");
@@ -30,7 +29,6 @@ private:
     BRLS_BIND(brls::Label, usernameLabel, "login/username_label");
     BRLS_BIND(brls::Label, passwordLabel, "login/password_label");
     BRLS_BIND(brls::Button, loginButton, "login/login_button");
-    BRLS_BIND(brls::Button, testButton, "login/pin_button");
     BRLS_BIND(brls::Button, offlineButton, "login/offline_button");
     BRLS_BIND(brls::Label, statusLabel, "login/status");
 

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -549,7 +549,7 @@ public:
     void clearAuth();
 
     // Authentication mode
-    void setAuthMode(AuthMode mode) { m_authMode = mode; }
+    void setAuthMode(AuthMode mode) { m_authMode = mode; m_lastTokenRefreshTime = 0; }
     AuthMode getAuthMode() const { return m_authMode; }
 
     // Login methods for different auth modes

--- a/resources/xml/activity/login.xml
+++ b/resources/xml/activity/login.xml
@@ -64,12 +64,6 @@
             marginRight="15"/>
 
         <brls:Button
-            id="login/pin_button"
-            text="Test"
-            width="100"
-            marginRight="15"/>
-
-        <brls:Button
             id="login/offline_button"
             text="Offline"
             width="120"/>

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -97,15 +97,6 @@ void LoginActivity::onContentAvailable() {
         });
     }
 
-    // Test connection button
-    if (testButton) {
-        testButton->setText("Test");
-        testButton->registerClickAction([this](brls::View* view) {
-            onTestConnectionPressed();
-            return true;
-        });
-    }
-
     // Offline mode button
     if (offlineButton) {
         offlineButton->setText("Offline");
@@ -114,68 +105,6 @@ void LoginActivity::onContentAvailable() {
             return true;
         });
     }
-}
-
-void LoginActivity::onTestConnectionPressed() {
-    if (m_serverUrl.empty()) {
-        if (statusLabel) statusLabel->setText("Please enter server URL first");
-        return;
-    }
-
-    if (m_connecting) return;
-    m_connecting = true;
-
-    if (statusLabel) statusLabel->setText("Testing connection...");
-
-    std::string serverUrl = m_serverUrl;
-    std::string username = m_username;
-    std::string password = m_password;
-
-    asyncRun([this, serverUrl, username, password]() {
-        SuwayomiClient& client = SuwayomiClient::getInstance();
-        client.setServerUrl(serverUrl);
-
-        // Step 1: Check basic reachability
-        if (!client.connectToServer(serverUrl)) {
-            brls::sync([this]() {
-                if (statusLabel) statusLabel->setText("Cannot reach server - check URL");
-                m_connecting = false;
-            });
-            return;
-        }
-
-        // Step 2: Fetch server info (public endpoint)
-        ServerInfo info;
-        bool hasInfo = client.fetchServerInfo(info);
-        std::string infoVersion = hasInfo ? info.version : "";
-
-        // Step 3: Auto-detect auth mode
-        bool serverRequiresAuth = client.checkServerRequiresAuth(serverUrl);
-        if (!serverRequiresAuth) {
-            brls::sync([this]() {
-                if (statusLabel) statusLabel->setText("Server OK - no auth required");
-                m_authMode = AuthMode::NONE;
-                m_connecting = false;
-            });
-            return;
-        }
-
-        // Server requires auth - detect the type
-        std::string errorMsg;
-        AuthMode detectedMode = client.detectServerAuthMode(serverUrl, errorMsg);
-        std::string modeName = getAuthModeName(detectedMode);
-
-        brls::sync([this, username, password, detectedMode, modeName]() {
-            m_authMode = detectedMode;
-            m_connecting = false;
-
-            if (username.empty() || password.empty()) {
-                if (statusLabel) statusLabel->setText("Auth required (" + modeName + ") - enter credentials");
-            } else {
-                if (statusLabel) statusLabel->setText("Server OK, auth: " + modeName);
-            }
-        });
-    });
 }
 
 void LoginActivity::onConnectPressed() {

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -197,7 +197,13 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             // The session cookie (e.g. JSESSIONID=xxx) tracks the server-side session
             // that has the "logged-in" attribute set.
             if (!m_sessionCookie.empty()) {
-                http.setDefaultHeader("Cookie", m_sessionCookie);
+                // Build cookie header: session cookie, plus JWT cookie if available
+                // (for cross-mode compatibility if server mode doesn't match client)
+                std::string cookies = m_sessionCookie;
+                if (!m_accessToken.empty()) {
+                    cookies += "; suwayomi-server-token=" + m_accessToken;
+                }
+                http.setDefaultHeader("Cookie", cookies);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
                 // Fallback to basic auth if no session yet
                 std::string credentials = m_authUsername + ":" + m_authPassword;
@@ -209,8 +215,16 @@ vitasuwayomi::HttpClient SuwayomiClient::createHttpClient() {
             // JWT-based authentication
             if (!m_accessToken.empty()) {
                 http.setDefaultHeader("Authorization", "Bearer " + m_accessToken);
-                // Also send as cookie for server compatibility
-                http.setDefaultHeader("Cookie", "suwayomi-server-token=" + m_accessToken);
+                // Send JWT as cookie, plus session cookie if available
+                // (for cross-mode compatibility if server mode doesn't match client)
+                std::string cookies = "suwayomi-server-token=" + m_accessToken;
+                if (!m_sessionCookie.empty()) {
+                    cookies += "; " + m_sessionCookie;
+                }
+                http.setDefaultHeader("Cookie", cookies);
+            } else if (!m_sessionCookie.empty()) {
+                // Have session cookie but no JWT - send session cookie
+                http.setDefaultHeader("Cookie", m_sessionCookie);
             } else if (!m_authUsername.empty() && !m_authPassword.empty()) {
                 // Fallback to basic auth if no token yet
                 std::string credentials = m_authUsername + ":" + m_authPassword;
@@ -2279,6 +2293,10 @@ void SuwayomiClient::logout() {
     m_accessToken.clear();
     m_refreshToken.clear();
     m_sessionCookie.clear();
+    // Reset refresh dedup timer so the next auth mode attempt can refresh immediately.
+    // Without this, switching from UI_LOGIN to SIMPLE_LOGIN in the fallback loop would
+    // be blocked by the dedup timer from the UI_LOGIN refresh.
+    m_lastTokenRefreshTime = 0;
     // Clear ImageLoader auth state
     ImageLoader::setAccessToken("");
     ImageLoader::setSessionCookie("");
@@ -2407,10 +2425,13 @@ bool SuwayomiClient::loginGraphQL(const std::string& username, const std::string
         brls::Logger::info("Login successful, received session cookie (simple_login)");
     }
 
-    // Update image loader with auth info and access token
+    // Update image loader with auth info
     ImageLoader::setAuthCredentials(username, password);
     if (!m_accessToken.empty()) {
         ImageLoader::setAccessToken(m_accessToken);
+    }
+    if (!m_sessionCookie.empty()) {
+        ImageLoader::setSessionCookie(m_sessionCookie);
     }
 
     return true;
@@ -2526,6 +2547,10 @@ bool SuwayomiClient::refreshToken() {
     }
 
     // UI_LOGIN: try GraphQL refresh if we have a refresh token
+    if (m_authMode != AuthMode::UI_LOGIN) {
+        return false;  // Only UI_LOGIN uses JWT refresh
+    }
+
     if (!m_refreshToken.empty()) {
         if (refreshTokenGraphQL()) {
             m_lastTokenRefreshTime = now;

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -502,13 +502,18 @@ static void applyAuthHeaders(HttpClient& client) {
     std::string sessionCookie = ImageLoader::getSessionCookie();
     std::string token = ImageLoader::getAccessToken();
 
-    if (!sessionCookie.empty()) {
-        // SIMPLE_LOGIN: session cookie from POST /login.html
-        client.setDefaultHeader("Cookie", sessionCookie);
-    } else if (!token.empty()) {
-        // UI_LOGIN: JWT Bearer token
-        client.setDefaultHeader("Authorization", "Bearer " + token);
-        client.setDefaultHeader("Cookie", "suwayomi-server-token=" + token);
+    if (!sessionCookie.empty() || !token.empty()) {
+        // Build cookie header with all available cookies for cross-mode compatibility
+        std::string cookies;
+        if (!sessionCookie.empty()) {
+            cookies = sessionCookie;
+        }
+        if (!token.empty()) {
+            if (!cookies.empty()) cookies += "; ";
+            cookies += "suwayomi-server-token=" + token;
+            client.setDefaultHeader("Authorization", "Bearer " + token);
+        }
+        client.setDefaultHeader("Cookie", cookies);
     } else {
         // BASIC_AUTH fallback
         std::string username = ImageLoader::getAuthUsername();

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -208,10 +208,10 @@ void SettingsTab::createAccountSection() {
     connectionStatusLabel->setMarginBottom(8);
     m_contentBox->addView(connectionStatusLabel);
 
-    // Reconnect button (try to connect to saved server)
+    // Reconnect button (full auth restoration, same as app restart)
     auto* reconnectCell = new brls::DetailCell();
     reconnectCell->setText("Reconnect");
-    reconnectCell->setDetailText("Try to connect to server");
+    reconnectCell->setDetailText("Restore connection (same as app restart)");
     reconnectCell->registerClickAction([this, connectionStatusLabel](brls::View* view) {
         Application& app = Application::getInstance();
         std::string url = app.getActiveServerUrl();
@@ -220,23 +220,189 @@ void SettingsTab::createAccountSection() {
             return true;
         }
 
-        brls::Application::notify("Connecting to " + url + "...");
+        brls::Application::notify("Reconnecting to " + url + "...");
 
         asyncRun([url, connectionStatusLabel]() {
+            Application& app = Application::getInstance();
             SuwayomiClient& client = SuwayomiClient::getInstance();
             client.setServerUrl(url);
 
-            bool success = client.testConnection();
+            // Step 1: Restore auth session (same as app startup)
+            AuthMode authMode = client.getAuthMode();
+            if (authMode == AuthMode::SIMPLE_LOGIN) {
+                std::string username = app.getAuthUsername();
+                std::string password = app.getAuthPassword();
+                if (!username.empty() && !password.empty()) {
+                    brls::Logger::info("Reconnect: SIMPLE_LOGIN re-establishing session...");
+                    if (client.login(username, password)) {
+                        brls::Logger::info("Reconnect: SIMPLE_LOGIN session established");
+                        app.getSettings().sessionCookie = client.getSessionCookie();
+                    } else {
+                        brls::Logger::warning("Reconnect: SIMPLE_LOGIN session login failed");
+                        client.setSessionCookie("");
+                        app.getSettings().sessionCookie = "";
+                    }
+                }
+            } else if (authMode == AuthMode::UI_LOGIN && !client.getRefreshToken().empty()) {
+                brls::Logger::info("Reconnect: Attempting to refresh JWT tokens...");
+                if (client.refreshToken()) {
+                    brls::Logger::info("Reconnect: Token refresh successful");
+                    app.getSettings().accessToken = client.getAccessToken();
+                    app.getSettings().refreshToken = client.getRefreshToken();
+                    app.getSettings().sessionCookie = client.getSessionCookie();
+                } else {
+                    brls::Logger::warning("Reconnect: Token refresh failed, clearing stale tokens");
+                    client.setTokens("", "");
+                    app.getSettings().accessToken = "";
+                    app.getSettings().refreshToken = "";
+                }
+            }
 
-            brls::sync([success, connectionStatusLabel]() {
-                if (success) {
-                    Application::getInstance().setConnected(true);
+            // Step 2: Test connection with protected query (not just public endpoint)
+            bool authValid = false;
+            if (client.testConnection()) {
+                brls::Logger::info("Reconnect: Server reachable, validating auth...");
+
+                if (authMode == AuthMode::NONE) {
+                    authValid = true;
+                } else if (client.validateAuthWithProtectedQuery()) {
+                    brls::Logger::info("Reconnect: Auth validated");
+                    authValid = true;
+                } else {
+                    // Auth failed - try all auth modes automatically
+                    brls::Logger::warning("Reconnect: Protected query failed, trying all modes...");
+                    std::string username = app.getAuthUsername();
+                    std::string password = app.getAuthPassword();
+
+                    if (!username.empty() && !password.empty()) {
+                        // Try fresh login with saved mode first
+                        if (authMode == AuthMode::SIMPLE_LOGIN || authMode == AuthMode::UI_LOGIN) {
+                            client.setAuthMode(authMode);
+                            client.logout();
+                            if (client.login(username, password) && client.validateAuthWithProtectedQuery()) {
+                                brls::Logger::info("Reconnect: Fresh login succeeded with saved mode");
+                                app.getSettings().accessToken = client.getAccessToken();
+                                app.getSettings().refreshToken = client.getRefreshToken();
+                                app.getSettings().sessionCookie = client.getSessionCookie();
+                                app.saveSettings();
+                                authValid = true;
+                            }
+                        }
+
+                        if (!authValid) {
+                            // Try all modes: UI_LOGIN, SIMPLE_LOGIN, BASIC_AUTH
+                            AuthMode tryModes[] = { AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::BASIC_AUTH };
+                            for (AuthMode tryMode : tryModes) {
+                                if (tryMode == authMode) continue;
+                                brls::Logger::info("Reconnect: Trying auth mode {}", static_cast<int>(tryMode));
+                                client.setAuthMode(tryMode);
+                                client.logout();
+
+                                if (tryMode == AuthMode::BASIC_AUTH) {
+                                    client.setAuthCredentials(username, password);
+                                } else {
+                                    if (!client.login(username, password)) continue;
+                                }
+
+                                if (client.validateAuthWithProtectedQuery()) {
+                                    brls::Logger::info("Reconnect: Auth succeeded with mode {}", static_cast<int>(tryMode));
+                                    app.getSettings().authMode = static_cast<int>(tryMode);
+                                    app.getSettings().accessToken = client.getAccessToken();
+                                    app.getSettings().refreshToken = client.getRefreshToken();
+                                    app.getSettings().sessionCookie = client.getSessionCookie();
+                                    app.saveSettings();
+                                    authValid = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // testConnection failed - could be auth mode mismatch
+                brls::Logger::warning("Reconnect: Server not reachable, trying auth fallback...");
+                std::string username = app.getAuthUsername();
+                std::string password = app.getAuthPassword();
+
+                if (!username.empty() && !password.empty()) {
+                    if (authMode == AuthMode::SIMPLE_LOGIN || authMode == AuthMode::UI_LOGIN) {
+                        client.setAuthMode(authMode);
+                        client.logout();
+                        if (client.login(username, password) &&
+                            client.testConnection() && client.validateAuthWithProtectedQuery()) {
+                            brls::Logger::info("Reconnect: Fresh login succeeded");
+                            app.getSettings().accessToken = client.getAccessToken();
+                            app.getSettings().refreshToken = client.getRefreshToken();
+                            app.getSettings().sessionCookie = client.getSessionCookie();
+                            app.saveSettings();
+                            authValid = true;
+                        }
+                    }
+
+                    if (!authValid) {
+                        AuthMode tryModes[] = { AuthMode::BASIC_AUTH, AuthMode::UI_LOGIN, AuthMode::SIMPLE_LOGIN, AuthMode::NONE };
+                        for (AuthMode tryMode : tryModes) {
+                            if (tryMode == authMode) continue;
+                            brls::Logger::info("Reconnect: Trying auth mode {}", static_cast<int>(tryMode));
+                            client.setAuthMode(tryMode);
+                            client.logout();
+
+                            if (tryMode == AuthMode::BASIC_AUTH) {
+                                client.setAuthCredentials(username, password);
+                            } else if (tryMode != AuthMode::NONE) {
+                                if (!client.login(username, password)) continue;
+                            }
+
+                            if (client.testConnection() && client.validateAuthWithProtectedQuery()) {
+                                brls::Logger::info("Reconnect: Succeeded with mode {}", static_cast<int>(tryMode));
+                                app.getSettings().authMode = static_cast<int>(tryMode);
+                                app.getSettings().accessToken = client.getAccessToken();
+                                app.getSettings().refreshToken = client.getRefreshToken();
+                                app.getSettings().sessionCookie = client.getSessionCookie();
+                                app.saveSettings();
+                                authValid = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!authValid) {
+                        // Restore original auth mode
+                        client.setAuthMode(authMode);
+                        if (authMode == AuthMode::BASIC_AUTH) {
+                            client.setAuthCredentials(app.getAuthUsername(), app.getAuthPassword());
+                        }
+                    }
+                }
+            }
+
+            // Step 3: Update state and sync
+            brls::sync([authValid, connectionStatusLabel]() {
+                Application& app = Application::getInstance();
+                if (authValid) {
+                    app.setConnected(true);
                     brls::Application::notify("Connected!");
                     if (connectionStatusLabel) {
                         connectionStatusLabel->setText("Status: Connected");
                     }
+
+                    // Sync offline reading progress to server
+                    DownloadsManager& dm = DownloadsManager::getInstance();
+                    if (!dm.getDownloads().empty()) {
+                        brls::Logger::info("Reconnect: Syncing offline reading progress...");
+                        vitasuwayomi::asyncRun([]() {
+                            DownloadsManager::getInstance().syncProgressToServer();
+                        });
+                    }
+
+                    // Resume incomplete downloads
+                    dm.resumeDownloadsIfNeeded();
                 } else {
+                    app.setConnected(false);
                     brls::Application::notify("Connection failed");
+                    if (connectionStatusLabel) {
+                        connectionStatusLabel->setText("Status: Offline");
+                    }
                 }
             });
         });


### PR DESCRIPTION
Makes the reconnect button perform a full auth restoration like an app restart and fixes auth-mode fallback (resetting the refresh dedup timer and sending all cookies).

---
_Generated by [Claude Code](https://claude.ai/code)_