### PR TITLE
Add touch screen horizontal scrolling for category/source tabs

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -113,6 +113,7 @@ private:
     std::vector<brls::Button*> m_categoryButtons;
     int m_selectedCategoryIndex = 0;               // Index in m_categories
     float m_categoryScrollOffset = 0.0f;           // Current scroll offset
+    float m_tabPanStartOffset = 0.0f;              // Pan gesture start offset
 
     // Action buttons
     brls::Box* m_updateContainer = nullptr;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -77,6 +77,29 @@ LibrarySectionTab::LibrarySectionTab() {
     m_categoryScrollContainer->setShrink(0);  // Don't shrink - allow scrolling beyond visible area
     m_categoryTabsBox->addView(m_categoryScrollContainer);
 
+    // Add horizontal pan gesture for touch scrolling on category/source tabs
+    m_categoryTabsBox->addGestureRecognizer(new brls::PanGestureRecognizer(
+        [this](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            if (!m_categoryScrollContainer) return;
+
+            if (status.state == brls::GestureState::START) {
+                m_tabPanStartOffset = m_categoryScrollOffset;
+            }
+            else if (status.state == brls::GestureState::STAY || status.state == brls::GestureState::END) {
+                float deltaX = status.position.x - status.startPosition.x;
+                float newOffset = m_tabPanStartOffset + deltaX;
+
+                // Clamp to valid range
+                float contentWidth = m_categoryScrollContainer->getWidth();
+                float visibleWidth = m_categoryTabsBox->getWidth();
+                if (visibleWidth <= 0) visibleWidth = 500.0f;
+                float minOffset = std::min(0.0f, -(contentWidth - visibleWidth));
+
+                m_categoryScrollOffset = std::max(minOffset, std::min(newOffset, 0.0f));
+                m_categoryScrollContainer->setTranslationX(m_categoryScrollOffset);
+            }
+        }, brls::PanAxis::HORIZONTAL));
+
     topRow->addView(m_categoryTabsBox);
 
     // R button hint (after category tabs)


### PR DESCRIPTION
Add touch screen horizontal scrolling for category/source tabs

The category tabs row only supported controller navigation (L/R bumpers
and d-pad focus). This adds a horizontal PanGestureRecognizer to the
tabs container so touch users can swipe left/right to scroll through
tabs. Works for both Category and Source grouping modes since they
share the same scroll container.

---
_Generated by [Claude Code](https://claude.ai/code)_