### PR TITLE
Fix manga tile title cutoff: allow 2-line wrapping for longer titles

### DIFF
--- a/resources/xml/view/manga_item.xml
+++ b/resources/xml/view/manga_item.xml
@@ -2,7 +2,7 @@
 <brls:Box
     id="manga_item/container"
     width="140"
-    height="220"
+    height="235"
     axis="column"
     focusable="true"
     marginRight="15"
@@ -64,14 +64,13 @@
 
     </brls:Box>
 
-    <!-- Title -->
+    <!-- Title (up to 2 lines for longer titles) -->
     <brls:Label
         id="manga_item/title"
         text="Manga Title"
         width="140"
         fontSize="12"
         marginTop="5"
-        singleLine="true"
         horizontalAlign="left"/>
 
     <!-- Subtitle (author/chapters) -->

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -88,18 +88,19 @@ MangaItemCell::MangaItemCell() {
     m_titleOverlay->setPositionLeft(0);
     m_titleOverlay->setPositionRight(0);  // Stretch to fill width
 
-    // Title label - at bottom of card
+    // Title label - at bottom of card, wraps to 2 lines for longer titles
     m_titleLabel = new brls::Label();
     m_titleLabel->setFontSize(11);
     m_titleLabel->setTextColor(nvgRGB(255, 255, 255));
     m_titleLabel->setHorizontalAlign(brls::HorizontalAlign::LEFT);
     m_titleOverlay->addView(m_titleLabel);
 
-    // Subtitle (author) - smaller, below title
+    // Subtitle (author) - smaller, below title, single line
     m_subtitleLabel = new brls::Label();
     m_subtitleLabel->setFontSize(9);
     m_subtitleLabel->setTextColor(nvgRGB(180, 180, 180));
     m_subtitleLabel->setHorizontalAlign(brls::HorizontalAlign::LEFT);
+    m_subtitleLabel->setSingleLine(true);
     m_titleOverlay->addView(m_subtitleLabel);
 
     this->addView(m_titleOverlay);
@@ -187,11 +188,12 @@ MangaItemCell::~MangaItemCell() {
 }
 
 void MangaItemCell::updateDisplay() {
-    // Set title - Komikku style, left-aligned
+    // Set title - Komikku style, left-aligned, up to 2 lines
     if (m_titleLabel) {
         std::string title = m_manga.title;
-        if (title.length() > 16) {
-            title = title.substr(0, 14) + "..";
+        // Allow enough characters for 2 lines (~20 chars per line at font 11)
+        if (title.length() > 40) {
+            title = title.substr(0, 38) + "..";
         }
         m_originalTitle = title;
         m_titleLabel->setText(title);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -719,7 +719,7 @@ void RecyclingGrid::setGridSize(int columns) {
     } else if (m_compactMode) {
         m_cellHeight = static_cast<int>(m_cellWidth * 1.4);  // Taller for compact (cover only)
     } else {
-        m_cellHeight = static_cast<int>(m_cellWidth * 1.3);  // Normal height with title
+        m_cellHeight = static_cast<int>(m_cellWidth * 1.4);  // Normal height with 2-line title
     }
 
     brls::Logger::info("RecyclingGrid: Grid size set to {} columns, cell {}x{}",


### PR DESCRIPTION
Fix manga tile title cutoff: allow 2-line wrapping for longer titles

Title was aggressively truncated to 16 characters, causing most titles
to be cut off. Now allows up to 40 characters with natural line wrapping
to 2 lines. Cell height ratio increased from 1.3x to 1.4x to accommodate.

---
_Generated by [Claude Code](https://claude.ai/code)_