### PR TITLE
Show update progress beside category title and fix tile title cutoff

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -49,6 +49,7 @@ private:
     void selectCategory(int categoryId);
     void onMangaSelected(const Manga& manga);
     void triggerLibraryUpdate();
+    void pollUpdateProgress(int generation);
     void updateCategoryButtonStyles();
     void sortMangaList();
     void cycleSortMode();
@@ -104,6 +105,12 @@ private:
 
     // UI Components
     brls::Label* m_titleLabel = nullptr;
+    brls::Label* m_updateStatusLabel = nullptr;  // "Updating X%" beside title
+
+    // Update progress tracking
+    bool m_isUpdating = false;
+    int m_updateTotalJobs = 0;        // Total jobs when update started
+    int m_updatePollGeneration = 0;   // Generation counter to cancel stale polls
 
     // Category tabs row
     brls::Box* m_categoryTabsBox = nullptr;        // Outer container (clips)

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -28,6 +28,7 @@ public:
     void setCompactMode(bool compact);  // Hide title overlay (covers only)
     void setListMode(bool listMode);    // Horizontal list layout
     void setListRowSize(int rowSize);   // List row size: 0=small, 1=medium, 2=large, 3=auto
+    void setGridColumns(int columns);   // Set grid column count (adapts title font/truncation)
     void setShowLibraryBadge(bool show);  // Show star badge for library items (browser/search only)
 
     void onFocusGained() override;
@@ -51,6 +52,7 @@ private:
     bool m_listMode = false;
     bool m_showLibraryBadge = false;  // Whether to show star badge for library items
     int m_listRowSize = 1;  // 0=small, 1=medium, 2=large, 3=auto
+    int m_gridColumns = 6;  // Grid column count (affects title font/truncation)
 
     Manga m_manga;
     std::string m_originalTitle;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -339,9 +339,6 @@ LibrarySectionTab::LibrarySectionTab() {
     // Apply library display settings from user preferences
     const auto& settings = Application::getInstance().getSettings();
 
-    // Apply list row size first (before list mode, so it's ready when list mode is set)
-    m_contentGrid->setListRowSize(static_cast<int>(settings.listRowSize));
-
     // Apply display mode (Grid/Compact/List)
     switch (settings.libraryDisplayMode) {
         case LibraryDisplayMode::GRID_NORMAL:
@@ -1541,7 +1538,7 @@ void LibrarySectionTab::sortMangaList() {
         // If not found (e.g., switched categories), focus first item if:
         // - The grid currently has focus (user was navigating the library), OR
         // - We just switched categories via L/R buttons (m_focusGridAfterLoad flag)
-        if (newIndex >= 0) {
+        if (newIndex >= 0 && (m_contentGrid->hasCellFocus() || m_focusGridAfterLoad)) {
             m_contentGrid->focusIndex(newIndex);
         } else if (!m_mangaList.empty() && (m_contentGrid->hasCellFocus() || m_focusGridAfterLoad)) {
             // Previous focused manga not in new list, focus first item

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -34,12 +34,28 @@ LibrarySectionTab::LibrarySectionTab() {
     this->setPadding(20);
     this->setGrow(1.0f);
 
-    // Title
+    // Title row (title + update status side by side)
+    auto* titleRow = new brls::Box();
+    titleRow->setAxis(brls::Axis::ROW);
+    titleRow->setJustifyContent(brls::JustifyContent::FLEX_START);
+    titleRow->setAlignItems(brls::AlignItems::CENTER);
+    titleRow->setMarginBottom(10);
+
     m_titleLabel = new brls::Label();
     m_titleLabel->setText("Library");
     m_titleLabel->setFontSize(28);
-    m_titleLabel->setMarginBottom(10);
-    this->addView(m_titleLabel);
+    titleRow->addView(m_titleLabel);
+
+    // Update progress label (hidden by default, shown during updates)
+    m_updateStatusLabel = new brls::Label();
+    m_updateStatusLabel->setText("");
+    m_updateStatusLabel->setFontSize(18);
+    m_updateStatusLabel->setTextColor(nvgRGBA(0, 200, 170, 255));
+    m_updateStatusLabel->setMarginLeft(12);
+    m_updateStatusLabel->setVisibility(brls::Visibility::GONE);
+    titleRow->addView(m_updateStatusLabel);
+
+    this->addView(titleRow);
 
     // Top row with category tabs and buttons
     auto* topRow = new brls::Box();
@@ -1200,41 +1216,145 @@ void LibrarySectionTab::triggerLibraryUpdate() {
         return;
     }
 
+    // Don't start a new update if one is already in progress
+    if (m_isUpdating) {
+        return;
+    }
+
     brls::Logger::info("LibrarySectionTab: Triggering update for category {} ({})",
                       m_currentCategoryId, m_currentCategoryName);
 
-    std::string categoryName = m_currentCategoryName;
-    if (categoryName.empty() || m_currentCategoryId == 0) {
-        categoryName = "all manga";
+    // Show "Updating..." beside the title immediately
+    m_isUpdating = true;
+    m_updateTotalJobs = 0;
+    if (m_updateStatusLabel) {
+        m_updateStatusLabel->setText("Updating...");
+        m_updateStatusLabel->setVisibility(brls::Visibility::VISIBLE);
     }
-
-    std::string message = "Checking for new chapters in " + categoryName + "...";
-    brls::Application::notify(message);
 
     std::weak_ptr<bool> aliveWeak = m_alive;
     int categoryId = m_currentCategoryId;
+    int generation = ++m_updatePollGeneration;
 
-    asyncRun([categoryId, categoryName, aliveWeak]() {
+    asyncRun([categoryId, aliveWeak, generation, this]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
 
         bool success = false;
         if (categoryId == 0) {
-            // Update all library
             success = client.triggerLibraryUpdate();
         } else {
-            // Update specific category
             success = client.triggerLibraryUpdate(categoryId);
         }
 
-        brls::sync([success, categoryName, aliveWeak]() {
+        brls::sync([success, aliveWeak, generation, this]() {
             auto alive = aliveWeak.lock();
             if (!alive || !*alive) return;
+            if (generation != m_updatePollGeneration) return;
 
             if (success) {
-                brls::Application::notify("Update started for " + categoryName);
+                // Start polling for progress
+                pollUpdateProgress(generation);
             } else {
+                // Update failed - hide status and show error
+                m_isUpdating = false;
+                if (m_updateStatusLabel) {
+                    m_updateStatusLabel->setVisibility(brls::Visibility::GONE);
+                }
                 brls::Application::notify("Failed to start update");
             }
+        });
+    });
+}
+
+void LibrarySectionTab::pollUpdateProgress(int generation) {
+    if (generation != m_updatePollGeneration) return;
+    if (!isValid()) return;
+
+    std::weak_ptr<bool> aliveWeak = m_alive;
+
+    asyncRun([aliveWeak, generation, this]() {
+        // Small delay between polls to avoid hammering the server
+        std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        int pending = 0, running = 0;
+        bool isRunning = false;
+        bool gotStatus = client.fetchUpdateSummary(pending, running, isRunning);
+
+        brls::sync([aliveWeak, generation, gotStatus, pending, running, isRunning, this]() {
+            auto alive = aliveWeak.lock();
+            if (!alive || !*alive) return;
+            if (generation != m_updatePollGeneration) return;
+
+            if (!gotStatus) {
+                // Couldn't fetch status - stop polling, hide label
+                m_isUpdating = false;
+                if (m_updateStatusLabel) {
+                    m_updateStatusLabel->setVisibility(brls::Visibility::GONE);
+                }
+                return;
+            }
+
+            if (!isRunning) {
+                // Update finished
+                m_isUpdating = false;
+                if (m_updateStatusLabel) {
+                    m_updateStatusLabel->setText("Updated!");
+                    // Hide after a short moment via next poll cycle
+                    // Use a delayed sync to hide it
+                }
+
+                // Reload current view to show updated data
+                if (m_groupMode == LibraryGroupMode::BY_CATEGORY) {
+                    loadCategoryManga(m_currentCategoryId);
+                } else if (m_groupMode == LibraryGroupMode::NO_GROUPING) {
+                    loadAllManga();
+                } else if (m_groupMode == LibraryGroupMode::BY_SOURCE) {
+                    loadBySource();
+                }
+
+                // Hide the "Updated!" text after 2 seconds
+                std::weak_ptr<bool> hideAlive = m_alive;
+                int hideGen = generation;
+                asyncRun([hideAlive, hideGen, this]() {
+                    std::this_thread::sleep_for(std::chrono::seconds(2));
+                    brls::sync([hideAlive, hideGen, this]() {
+                        auto alive2 = hideAlive.lock();
+                        if (!alive2 || !*alive2) return;
+                        if (hideGen != m_updatePollGeneration) return;
+                        if (m_updateStatusLabel) {
+                            m_updateStatusLabel->setVisibility(brls::Visibility::GONE);
+                        }
+                    });
+                });
+                return;
+            }
+
+            // Update is still running - calculate progress
+            int totalActive = pending + running;
+            if (m_updateTotalJobs == 0 && totalActive > 0) {
+                // First poll - capture total
+                m_updateTotalJobs = totalActive;
+            }
+
+            if (m_updateTotalJobs > 0) {
+                int completed = m_updateTotalJobs - totalActive;
+                if (completed < 0) completed = 0;
+                int percent = (completed * 100) / m_updateTotalJobs;
+                if (percent > 100) percent = 100;
+
+                std::string statusText = "Updating " + std::to_string(percent) + "%";
+                if (m_updateStatusLabel) {
+                    m_updateStatusLabel->setText(statusText);
+                }
+            } else {
+                if (m_updateStatusLabel) {
+                    m_updateStatusLabel->setText("Updating...");
+                }
+            }
+
+            // Continue polling
+            pollUpdateProgress(generation);
         });
     });
 }

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -339,6 +339,9 @@ LibrarySectionTab::LibrarySectionTab() {
     // Apply library display settings from user preferences
     const auto& settings = Application::getInstance().getSettings();
 
+    // Apply list row size first (before list mode, so it's ready when list mode is set)
+    m_contentGrid->setListRowSize(static_cast<int>(settings.listRowSize));
+
     // Apply display mode (Grid/Compact/List)
     switch (settings.libraryDisplayMode) {
         case LibraryDisplayMode::GRID_NORMAL:
@@ -1538,7 +1541,7 @@ void LibrarySectionTab::sortMangaList() {
         // If not found (e.g., switched categories), focus first item if:
         // - The grid currently has focus (user was navigating the library), OR
         // - We just switched categories via L/R buttons (m_focusGridAfterLoad flag)
-        if (newIndex >= 0 && (m_contentGrid->hasCellFocus() || m_focusGridAfterLoad)) {
+        if (newIndex >= 0) {
             m_contentGrid->focusIndex(newIndex);
         } else if (!m_mangaList.empty() && (m_contentGrid->hasCellFocus() || m_focusGridAfterLoad)) {
             // Previous focused manga not in new list, focus first item

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -210,29 +210,14 @@ void MangaItemCell::updateDisplay() {
         m_titleLabel->setText(title);
     }
 
-    // Update list mode title as well
+    // Update list mode title
     if (m_listTitleLabel) {
         std::string listTitle = m_manga.title;
-        // In auto mode (3), show full title without truncation
-        // In other modes, truncate based on row size
-        if (m_listRowSize != 3) {
-            int maxChars = 60;  // Default (medium)
-            switch (m_listRowSize) {
-                case 0:  // Small
-                    maxChars = 45;
-                    break;
-                case 1:  // Medium
-                    maxChars = 60;
-                    break;
-                case 2:  // Large
-                    maxChars = 80;
-                    break;
-            }
-            if (static_cast<int>(listTitle.length()) > maxChars) {
-                listTitle = listTitle.substr(0, maxChars - 2) + "..";
-            }
+        // Truncate to fit alongside cover thumbnail
+        int maxChars = 55;
+        if (static_cast<int>(listTitle.length()) > maxChars) {
+            listTitle = listTitle.substr(0, maxChars - 2) + "..";
         }
-        // In auto mode, show full title (no truncation)
         m_listTitleLabel->setText(listTitle);
     }
 
@@ -510,24 +495,28 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
 }
 
 void MangaItemCell::setListRowSize(int rowSize) {
-    if (m_listRowSize == rowSize) return;
-    m_listRowSize = rowSize;
-    // Update display if already in list mode
-    if (m_listMode) {
-        updateDisplay();
-    }
+    // No-op: list row size is now auto-adapted with cover thumbnails
+    (void)rowSize;
 }
 
 void MangaItemCell::applyDisplayMode() {
     if (m_listMode) {
-        // List mode: simple horizontal layout with title only (no cover)
+        // List mode: horizontal layout with cover thumbnail + title
         this->setAxis(brls::Axis::ROW);
         this->setJustifyContent(brls::JustifyContent::FLEX_START);
         this->setAlignItems(brls::AlignItems::CENTER);
 
-        // Hide thumbnail in list mode - titles only
+        // Show cover thumbnail sized to fit the row height
         if (m_thumbnailImage) {
-            m_thumbnailImage->setVisibility(brls::Visibility::GONE);
+            m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
+            m_thumbnailImage->setPositionType(brls::PositionType::RELATIVE);
+            m_thumbnailImage->setGrow(0.0f);
+            // Cover sized to row: height matches cell, width is proportional (manga cover ~0.7 ratio)
+            m_thumbnailImage->setWidth(56);
+            m_thumbnailImage->setHeight(76);
+            m_thumbnailImage->setCornerRadius(4);
+            m_thumbnailImage->setMargins(2, 8, 2, 8);
+            m_thumbnailImage->setScalingType(brls::ImageScalingType::FIT);
         }
 
         // Hide grid title overlay
@@ -535,50 +524,34 @@ void MangaItemCell::applyDisplayMode() {
             m_titleOverlay->setVisibility(brls::Visibility::GONE);
         }
 
-        // Show list info box (title label is already added and updated by updateDisplay)
+        // Show list info box with title
         if (m_listInfoBox) {
             m_listInfoBox->setVisibility(brls::Visibility::VISIBLE);
         }
 
-        // Adjust title font size based on row size
+        // Fixed font size for list mode
         if (m_listTitleLabel) {
-            switch (m_listRowSize) {
-                case 0:  // Small
-                    m_listTitleLabel->setFontSize(12);
-                    break;
-                case 1:  // Medium (default)
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-                case 2:  // Large
-                    m_listTitleLabel->setFontSize(16);
-                    break;
-                case 3:  // Auto - use medium font, text will wrap if needed
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-                default:
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-            }
+            m_listTitleLabel->setFontSize(14);
         }
 
-        // Position badges for list mode (left side)
+        // Position badges after the cover thumbnail area
         if (m_unreadBadge) {
             m_unreadBadge->setPositionTop(4);
             m_unreadBadge->setPositionLeft(8);
         }
         if (m_newBadge) {
             m_newBadge->setPositionTop(4);
-            m_newBadge->setPositionLeft(40);  // Position next to unread badge
+            m_newBadge->setPositionLeft(40);
         }
         // Position start hint for list mode (top-right)
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(4);
             m_startHintIcon->setPositionRight(4);
         }
-        // Position star badge for list mode (top-right, below start hint)
+        // Position star badge for list mode (top-right)
         if (m_starBadge) {
             m_starBadge->setPositionTop(4);
-            m_starBadge->setPositionRight(72);  // Left of start hint
+            m_starBadge->setPositionRight(72);
         }
 
     } else if (m_compactMode) {
@@ -587,7 +560,7 @@ void MangaItemCell::applyDisplayMode() {
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore visibility if coming from list mode)
+        // Thumbnail - fill the cell (restore from list mode's relative layout)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -597,6 +570,8 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setPositionBottom(0);
             m_thumbnailImage->setGrow(1.0f);
             m_thumbnailImage->setCornerRadius(8);
+            m_thumbnailImage->setMargins(0, 0, 0, 0);
+            m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
         }
 
         // Hide title overlay in compact mode
@@ -635,7 +610,7 @@ void MangaItemCell::applyDisplayMode() {
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore visibility if coming from list mode)
+        // Thumbnail - fill the cell (restore from list mode's relative layout)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -645,6 +620,8 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setPositionBottom(0);
             m_thumbnailImage->setGrow(1.0f);
             m_thumbnailImage->setCornerRadius(8);
+            m_thumbnailImage->setMargins(0, 0, 0, 0);
+            m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
         }
 
         // Show title overlay

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -210,14 +210,29 @@ void MangaItemCell::updateDisplay() {
         m_titleLabel->setText(title);
     }
 
-    // Update list mode title
+    // Update list mode title as well
     if (m_listTitleLabel) {
         std::string listTitle = m_manga.title;
-        // Truncate to fit alongside cover thumbnail
-        int maxChars = 55;
-        if (static_cast<int>(listTitle.length()) > maxChars) {
-            listTitle = listTitle.substr(0, maxChars - 2) + "..";
+        // In auto mode (3), show full title without truncation
+        // In other modes, truncate based on row size
+        if (m_listRowSize != 3) {
+            int maxChars = 60;  // Default (medium)
+            switch (m_listRowSize) {
+                case 0:  // Small
+                    maxChars = 45;
+                    break;
+                case 1:  // Medium
+                    maxChars = 60;
+                    break;
+                case 2:  // Large
+                    maxChars = 80;
+                    break;
+            }
+            if (static_cast<int>(listTitle.length()) > maxChars) {
+                listTitle = listTitle.substr(0, maxChars - 2) + "..";
+            }
         }
+        // In auto mode, show full title (no truncation)
         m_listTitleLabel->setText(listTitle);
     }
 
@@ -495,28 +510,24 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
 }
 
 void MangaItemCell::setListRowSize(int rowSize) {
-    // No-op: list row size is now auto-adapted with cover thumbnails
-    (void)rowSize;
+    if (m_listRowSize == rowSize) return;
+    m_listRowSize = rowSize;
+    // Update display if already in list mode
+    if (m_listMode) {
+        updateDisplay();
+    }
 }
 
 void MangaItemCell::applyDisplayMode() {
     if (m_listMode) {
-        // List mode: horizontal layout with cover thumbnail + title
+        // List mode: simple horizontal layout with title only (no cover)
         this->setAxis(brls::Axis::ROW);
         this->setJustifyContent(brls::JustifyContent::FLEX_START);
         this->setAlignItems(brls::AlignItems::CENTER);
 
-        // Show cover thumbnail sized to fit the row height
+        // Hide thumbnail in list mode - titles only
         if (m_thumbnailImage) {
-            m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
-            m_thumbnailImage->setPositionType(brls::PositionType::RELATIVE);
-            m_thumbnailImage->setGrow(0.0f);
-            // Cover sized to row: height matches cell, width is proportional (manga cover ~0.7 ratio)
-            m_thumbnailImage->setWidth(56);
-            m_thumbnailImage->setHeight(76);
-            m_thumbnailImage->setCornerRadius(4);
-            m_thumbnailImage->setMargins(2, 8, 2, 8);
-            m_thumbnailImage->setScalingType(brls::ImageScalingType::FIT);
+            m_thumbnailImage->setVisibility(brls::Visibility::GONE);
         }
 
         // Hide grid title overlay
@@ -524,34 +535,50 @@ void MangaItemCell::applyDisplayMode() {
             m_titleOverlay->setVisibility(brls::Visibility::GONE);
         }
 
-        // Show list info box with title
+        // Show list info box (title label is already added and updated by updateDisplay)
         if (m_listInfoBox) {
             m_listInfoBox->setVisibility(brls::Visibility::VISIBLE);
         }
 
-        // Fixed font size for list mode
+        // Adjust title font size based on row size
         if (m_listTitleLabel) {
-            m_listTitleLabel->setFontSize(14);
+            switch (m_listRowSize) {
+                case 0:  // Small
+                    m_listTitleLabel->setFontSize(12);
+                    break;
+                case 1:  // Medium (default)
+                    m_listTitleLabel->setFontSize(14);
+                    break;
+                case 2:  // Large
+                    m_listTitleLabel->setFontSize(16);
+                    break;
+                case 3:  // Auto - use medium font, text will wrap if needed
+                    m_listTitleLabel->setFontSize(14);
+                    break;
+                default:
+                    m_listTitleLabel->setFontSize(14);
+                    break;
+            }
         }
 
-        // Position badges after the cover thumbnail area
+        // Position badges for list mode (left side)
         if (m_unreadBadge) {
             m_unreadBadge->setPositionTop(4);
             m_unreadBadge->setPositionLeft(8);
         }
         if (m_newBadge) {
             m_newBadge->setPositionTop(4);
-            m_newBadge->setPositionLeft(40);
+            m_newBadge->setPositionLeft(40);  // Position next to unread badge
         }
         // Position start hint for list mode (top-right)
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(4);
             m_startHintIcon->setPositionRight(4);
         }
-        // Position star badge for list mode (top-right)
+        // Position star badge for list mode (top-right, below start hint)
         if (m_starBadge) {
             m_starBadge->setPositionTop(4);
-            m_starBadge->setPositionRight(72);
+            m_starBadge->setPositionRight(72);  // Left of start hint
         }
 
     } else if (m_compactMode) {
@@ -560,7 +587,7 @@ void MangaItemCell::applyDisplayMode() {
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore from list mode's relative layout)
+        // Thumbnail - fill the cell (restore visibility if coming from list mode)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -570,8 +597,6 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setPositionBottom(0);
             m_thumbnailImage->setGrow(1.0f);
             m_thumbnailImage->setCornerRadius(8);
-            m_thumbnailImage->setMargins(0, 0, 0, 0);
-            m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
         }
 
         // Hide title overlay in compact mode
@@ -610,7 +635,7 @@ void MangaItemCell::applyDisplayMode() {
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore from list mode's relative layout)
+        // Thumbnail - fill the cell (restore visibility if coming from list mode)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -620,8 +645,6 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setPositionBottom(0);
             m_thumbnailImage->setGrow(1.0f);
             m_thumbnailImage->setCornerRadius(8);
-            m_thumbnailImage->setMargins(0, 0, 0, 0);
-            m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
         }
 
         // Show title overlay

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -189,11 +189,22 @@ MangaItemCell::~MangaItemCell() {
 
 void MangaItemCell::updateDisplay() {
     // Set title - Komikku style, left-aligned, up to 2 lines
+    // Truncation and font size adapt to grid column count
     if (m_titleLabel) {
         std::string title = m_manga.title;
-        // Allow enough characters for 2 lines (~20 chars per line at font 11)
-        if (title.length() > 40) {
-            title = title.substr(0, 38) + "..";
+
+        // Max characters depends on grid size (wider cells fit more text)
+        int maxChars = 40;  // Default for 6 columns
+        if (m_gridColumns <= 4) {
+            maxChars = 55;   // Wider cells: ~27 chars per line x 2 lines
+        } else if (m_gridColumns <= 6) {
+            maxChars = 40;   // Default: ~20 chars per line x 2 lines
+        } else {
+            maxChars = 28;   // Narrow cells: ~14 chars per line x 2 lines
+        }
+
+        if (static_cast<int>(title.length()) > maxChars) {
+            title = title.substr(0, maxChars - 2) + "..";
         }
         m_originalTitle = title;
         m_titleLabel->setText(title);
@@ -229,8 +240,17 @@ void MangaItemCell::updateDisplay() {
     if (m_subtitleLabel) {
         if (!m_manga.author.empty()) {
             std::string author = m_manga.author;
-            if (author.length() > 18) {
-                author = author.substr(0, 16) + "..";
+            // Max subtitle chars depends on grid size
+            int maxSubChars = 18;
+            if (m_gridColumns <= 4) {
+                maxSubChars = 28;
+            } else if (m_gridColumns <= 6) {
+                maxSubChars = 18;
+            } else {
+                maxSubChars = 14;
+            }
+            if (static_cast<int>(author.length()) > maxSubChars) {
+                author = author.substr(0, maxSubChars - 2) + "..";
             }
             m_subtitleLabel->setText(author);
         } else if (m_manga.chapterCount > 0) {
@@ -425,6 +445,35 @@ void MangaItemCell::updateFocusInfo(bool focused) {
         // Restore truncated title
         m_titleLabel->setText(m_originalTitle);
         m_descriptionLabel->setVisibility(brls::Visibility::GONE);
+    }
+}
+
+void MangaItemCell::setGridColumns(int columns) {
+    if (m_gridColumns == columns) return;
+    m_gridColumns = columns;
+
+    // Adapt title font size and re-truncate based on grid column count
+    if (m_titleLabel) {
+        int fontSize = 11;  // Default for 6 columns
+        if (columns <= 4) {
+            fontSize = 14;
+        } else if (columns <= 6) {
+            fontSize = 11;
+        } else {
+            fontSize = 9;
+        }
+        m_titleLabel->setFontSize(fontSize);
+    }
+    if (m_subtitleLabel) {
+        int subFontSize = 9;
+        if (columns <= 4) {
+            subFontSize = 11;
+        } else if (columns <= 6) {
+            subFontSize = 9;
+        } else {
+            subFontSize = 8;
+        }
+        m_subtitleLabel->setFontSize(subFontSize);
     }
 }
 

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -354,7 +354,23 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
         int startIdx = row * m_columns;
         int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
 
+        // For list mode with auto-size, calculate row height based on title length
         int rowHeight = m_cellHeight;
+        if (m_listMode && m_listRowSize == 3) {  // Auto mode
+            int maxTitleLen = 0;
+            for (int i = startIdx; i < endIdx; i++) {
+                int titleLen = static_cast<int>(m_items[i].title.length());
+                if (titleLen > maxTitleLen) {
+                    maxTitleLen = titleLen;
+                }
+            }
+            int lines = (maxTitleLen + 44) / 45;
+            if (lines < 1) lines = 1;
+            if (lines > 3) lines = 3;
+            rowHeight = 40 + (lines * 20);
+            if (rowHeight < 60) rowHeight = 60;
+            if (rowHeight > 120) rowHeight = 120;
+        }
 
         rowBox->setHeight(rowHeight);
 
@@ -733,10 +749,27 @@ void RecyclingGrid::setListMode(bool listMode) {
     m_compactMode = false;  // Disable compact mode if enabling list
 
     if (m_listMode) {
-        // List mode: 1 column, cover thumbnail + title
+        // List mode: 1 column, larger cells
         m_columns = 1;
         m_cellWidth = 900;
-        m_cellHeight = 80;  // Fixed height, cover auto-adapts
+        // Apply list row size setting
+        switch (m_listRowSize) {
+            case 0:  // Small
+                m_cellHeight = 60;
+                break;
+            case 1:  // Medium (default)
+                m_cellHeight = 80;
+                break;
+            case 2:  // Large
+                m_cellHeight = 100;
+                break;
+            case 3:  // Auto - will be handled per-cell in setupGrid
+                m_cellHeight = 0;  // Dynamic height
+                break;
+            default:
+                m_cellHeight = 80;
+                break;
+        }
         m_rowMargin = 5;
     } else {
         // Reset to default grid
@@ -752,8 +785,34 @@ void RecyclingGrid::setListMode(bool listMode) {
 }
 
 void RecyclingGrid::setListRowSize(int rowSize) {
-    // No-op: list row size is now auto-adapted with cover thumbnails
-    (void)rowSize;
+    if (m_listRowSize == rowSize) return;
+    m_listRowSize = rowSize;
+
+    // If currently in list mode, update dimensions and rebuild
+    if (m_listMode) {
+        switch (m_listRowSize) {
+            case 0:  // Small
+                m_cellHeight = 60;
+                break;
+            case 1:  // Medium (default)
+                m_cellHeight = 80;
+                break;
+            case 2:  // Large
+                m_cellHeight = 100;
+                break;
+            case 3:  // Auto - dynamic height
+                m_cellHeight = 0;
+                break;
+            default:
+                m_cellHeight = 80;
+                break;
+        }
+
+        // Rebuild grid if we have items
+        if (!m_items.empty()) {
+            setupGrid();
+        }
+    }
 }
 
 void RecyclingGrid::setShowLibraryBadge(bool show) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -354,23 +354,7 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
         int startIdx = row * m_columns;
         int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
 
-        // For list mode with auto-size, calculate row height based on title length
         int rowHeight = m_cellHeight;
-        if (m_listMode && m_listRowSize == 3) {  // Auto mode
-            int maxTitleLen = 0;
-            for (int i = startIdx; i < endIdx; i++) {
-                int titleLen = static_cast<int>(m_items[i].title.length());
-                if (titleLen > maxTitleLen) {
-                    maxTitleLen = titleLen;
-                }
-            }
-            int lines = (maxTitleLen + 44) / 45;
-            if (lines < 1) lines = 1;
-            if (lines > 3) lines = 3;
-            rowHeight = 40 + (lines * 20);
-            if (rowHeight < 60) rowHeight = 60;
-            if (rowHeight > 120) rowHeight = 120;
-        }
 
         rowBox->setHeight(rowHeight);
 
@@ -749,27 +733,10 @@ void RecyclingGrid::setListMode(bool listMode) {
     m_compactMode = false;  // Disable compact mode if enabling list
 
     if (m_listMode) {
-        // List mode: 1 column, larger cells
+        // List mode: 1 column, cover thumbnail + title
         m_columns = 1;
         m_cellWidth = 900;
-        // Apply list row size setting
-        switch (m_listRowSize) {
-            case 0:  // Small
-                m_cellHeight = 60;
-                break;
-            case 1:  // Medium (default)
-                m_cellHeight = 80;
-                break;
-            case 2:  // Large
-                m_cellHeight = 100;
-                break;
-            case 3:  // Auto - will be handled per-cell in setupGrid
-                m_cellHeight = 0;  // Dynamic height
-                break;
-            default:
-                m_cellHeight = 80;
-                break;
-        }
+        m_cellHeight = 80;  // Fixed height, cover auto-adapts
         m_rowMargin = 5;
     } else {
         // Reset to default grid
@@ -785,34 +752,8 @@ void RecyclingGrid::setListMode(bool listMode) {
 }
 
 void RecyclingGrid::setListRowSize(int rowSize) {
-    if (m_listRowSize == rowSize) return;
-    m_listRowSize = rowSize;
-
-    // If currently in list mode, update dimensions and rebuild
-    if (m_listMode) {
-        switch (m_listRowSize) {
-            case 0:  // Small
-                m_cellHeight = 60;
-                break;
-            case 1:  // Medium (default)
-                m_cellHeight = 80;
-                break;
-            case 2:  // Large
-                m_cellHeight = 100;
-                break;
-            case 3:  // Auto - dynamic height
-                m_cellHeight = 0;
-                break;
-            default:
-                m_cellHeight = 80;
-                break;
-        }
-
-        // Rebuild grid if we have items
-        if (!m_items.empty()) {
-            setupGrid();
-        }
-    }
+    // No-op: list row size is now auto-adapted with cover thumbnails
+    (void)rowSize;
 }
 
 void RecyclingGrid::setShowLibraryBadge(bool show) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -388,6 +388,9 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
                 cell->setCompactMode(true);
             }
 
+            // Pass grid column count so cell can adapt title font/truncation
+            cell->setGridColumns(m_columns);
+
             // Apply library badge setting (for browser/search tabs)
             if (m_showLibraryBadge) {
                 cell->setShowLibraryBadge(true);

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -623,17 +623,6 @@ void SettingsTab::createLibrarySection() {
         });
     m_contentBox->addView(gridSizeSelector);
 
-    // List row size selector (for list view mode)
-    auto* listRowSizeSelector = new brls::SelectorCell();
-    listRowSizeSelector->init("List Row Size",
-        {"Small (compact)", "Medium (default)", "Large (spacious)", "Auto (fit title)"},
-        static_cast<int>(settings.listRowSize),
-        [&settings](int index) {
-            settings.listRowSize = static_cast<ListRowSize>(index);
-            Application::getInstance().saveSettings();
-        });
-    m_contentBox->addView(listRowSizeSelector);
-
     // Library grouping mode selector
     auto* groupModeSelector = new brls::SelectorCell();
     groupModeSelector->init("Library Grouping",

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -623,6 +623,17 @@ void SettingsTab::createLibrarySection() {
         });
     m_contentBox->addView(gridSizeSelector);
 
+    // List row size selector (for list view mode)
+    auto* listRowSizeSelector = new brls::SelectorCell();
+    listRowSizeSelector->init("List Row Size",
+        {"Small (compact)", "Medium (default)", "Large (spacious)", "Auto (fit title)"},
+        static_cast<int>(settings.listRowSize),
+        [&settings](int index) {
+            settings.listRowSize = static_cast<ListRowSize>(index);
+            Application::getInstance().saveSettings();
+        });
+    m_contentBox->addView(listRowSizeSelector);
+
     // Library grouping mode selector
     auto* groupModeSelector = new brls::SelectorCell();
     groupModeSelector->init("Library Grouping",


### PR DESCRIPTION
Shows update progress beside the category title and fixes tile-title cutoff (with a revert of a focus-stealing list-mode change).

---
_Generated by [Claude Code](https://claude.ai/code)_