### PR TITLE
Remove list row size setting and always auto-adapt to title length

### DIFF
--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -129,6 +129,11 @@ private:
     int m_incrementalBuildRow = 0;
     int m_totalRowsNeeded = 0;
     bool m_incrementalBuildActive = false;
+
+    // Pending focus - when focusIndex is called during incremental build and the
+    // target cell doesn't exist yet, store the index here. buildNextRowBatch
+    // applies it once the cell is created, preventing focus from jumping to cell 0.
+    int m_pendingFocusIndex = -1;
 };
 
 } // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -339,9 +339,6 @@ LibrarySectionTab::LibrarySectionTab() {
     // Apply library display settings from user preferences
     const auto& settings = Application::getInstance().getSettings();
 
-    // Apply list row size first (before list mode, so it's ready when list mode is set)
-    m_contentGrid->setListRowSize(static_cast<int>(settings.listRowSize));
-
     // Apply display mode (Grid/Compact/List)
     switch (settings.libraryDisplayMode) {
         case LibraryDisplayMode::GRID_NORMAL:

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1357,12 +1357,16 @@ void LibrarySectionTab::pollUpdateProgress(int generation) {
 }
 
 void LibrarySectionTab::sortMangaList() {
-    // Preserve focus: get currently focused manga ID before sorting
+    // Preserve focus: get currently focused manga ID before sorting.
+    // Read from the grid's internal items (not m_mangaList) because the caller
+    // may have already replaced m_mangaList with new server data while the grid
+    // still holds the old items. Using m_mangaList[idx] would read the wrong manga.
     int focusedMangaId = -1;
     if (m_contentGrid) {
         int focusedIdx = m_contentGrid->getFocusedIndex();
-        if (focusedIdx >= 0 && focusedIdx < static_cast<int>(m_mangaList.size())) {
-            focusedMangaId = m_mangaList[focusedIdx].id;
+        const Manga* focusedItem = m_contentGrid->getItem(focusedIdx);
+        if (focusedItem) {
+            focusedMangaId = focusedItem->id;
         }
     }
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -210,30 +210,9 @@ void MangaItemCell::updateDisplay() {
         m_titleLabel->setText(title);
     }
 
-    // Update list mode title as well
+    // Update list mode title - show full title (row auto-adapts to fit)
     if (m_listTitleLabel) {
-        std::string listTitle = m_manga.title;
-        // In auto mode (3), show full title without truncation
-        // In other modes, truncate based on row size
-        if (m_listRowSize != 3) {
-            int maxChars = 60;  // Default (medium)
-            switch (m_listRowSize) {
-                case 0:  // Small
-                    maxChars = 45;
-                    break;
-                case 1:  // Medium
-                    maxChars = 60;
-                    break;
-                case 2:  // Large
-                    maxChars = 80;
-                    break;
-            }
-            if (static_cast<int>(listTitle.length()) > maxChars) {
-                listTitle = listTitle.substr(0, maxChars - 2) + "..";
-            }
-        }
-        // In auto mode, show full title (no truncation)
-        m_listTitleLabel->setText(listTitle);
+        m_listTitleLabel->setText(m_manga.title);
     }
 
     // Set subtitle (author or chapter count)
@@ -510,12 +489,8 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
 }
 
 void MangaItemCell::setListRowSize(int rowSize) {
-    if (m_listRowSize == rowSize) return;
-    m_listRowSize = rowSize;
-    // Update display if already in list mode
-    if (m_listMode) {
-        updateDisplay();
-    }
+    // No-op: list mode always auto-adapts row height to title length
+    (void)rowSize;
 }
 
 void MangaItemCell::applyDisplayMode() {
@@ -540,25 +515,9 @@ void MangaItemCell::applyDisplayMode() {
             m_listInfoBox->setVisibility(brls::Visibility::VISIBLE);
         }
 
-        // Adjust title font size based on row size
+        // Font size for list mode
         if (m_listTitleLabel) {
-            switch (m_listRowSize) {
-                case 0:  // Small
-                    m_listTitleLabel->setFontSize(12);
-                    break;
-                case 1:  // Medium (default)
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-                case 2:  // Large
-                    m_listTitleLabel->setFontSize(16);
-                    break;
-                case 3:  // Auto - use medium font, text will wrap if needed
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-                default:
-                    m_listTitleLabel->setFontSize(14);
-                    break;
-            }
+            m_listTitleLabel->setFontSize(14);
         }
 
         // Position badges for list mode (left side)

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -354,17 +354,47 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
         int startIdx = row * m_columns;
         int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
 
-        // For list mode, auto-adapt row height based on title length
+        // For list mode, auto-adapt row height based on title width
         int rowHeight = m_cellHeight;
         if (m_listMode) {
-            int maxTitleLen = 0;
+            int maxWidthUnits = 0;
             for (int i = startIdx; i < endIdx; i++) {
-                int titleLen = static_cast<int>(m_items[i].title.length());
-                if (titleLen > maxTitleLen) {
-                    maxTitleLen = titleLen;
+                // Estimate visual width in "width units" (1 unit ≈ 1 Latin char width).
+                // CJK / wide characters (multi-byte UTF-8) count as 2 units since
+                // they render roughly twice as wide as Latin characters.
+                const std::string& title = m_items[i].title;
+                int widthUnits = 0;
+                for (size_t j = 0; j < title.size(); ) {
+                    unsigned char c = static_cast<unsigned char>(title[j]);
+                    if (c < 0x80) {
+                        // ASCII: 1 byte, 1 width unit
+                        widthUnits += 1;
+                        j += 1;
+                    } else if (c < 0xC0) {
+                        // Continuation byte (shouldn't appear here), skip
+                        j += 1;
+                    } else if (c < 0xE0) {
+                        // 2-byte sequence (Latin extended, etc): 1 width unit
+                        widthUnits += 1;
+                        j += 2;
+                    } else if (c < 0xF0) {
+                        // 3-byte sequence (CJK, Japanese, Korean, etc): 2 width units
+                        widthUnits += 2;
+                        j += 3;
+                    } else {
+                        // 4-byte sequence (emoji, etc): 2 width units
+                        widthUnits += 2;
+                        j += 4;
+                    }
+                }
+                if (widthUnits > maxWidthUnits) {
+                    maxWidthUnits = widthUnits;
                 }
             }
-            int lines = (maxTitleLen + 44) / 45;
+            // At font 14 on the Vita (900px cell, ~32px padding), roughly 108
+            // Latin-width characters fit per line.
+            int charsPerLine = 100;  // Slightly conservative
+            int lines = (maxWidthUnits + charsPerLine - 1) / charsPerLine;
             if (lines < 1) lines = 1;
             if (lines > 3) lines = 3;
             rowHeight = 40 + (lines * 20);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -354,9 +354,9 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
         int startIdx = row * m_columns;
         int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
 
-        // For list mode with auto-size, calculate row height based on title length
+        // For list mode, auto-adapt row height based on title length
         int rowHeight = m_cellHeight;
-        if (m_listMode && m_listRowSize == 3) {  // Auto mode
+        if (m_listMode) {
             int maxTitleLen = 0;
             for (int i = startIdx; i < endIdx; i++) {
                 int titleLen = static_cast<int>(m_items[i].title.length());
@@ -383,7 +383,6 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
             // Apply display mode to cell
             if (m_listMode) {
                 cell->setListMode(true);
-                cell->setListRowSize(m_listRowSize);
             } else if (m_compactMode) {
                 cell->setCompactMode(true);
             }
@@ -749,27 +748,10 @@ void RecyclingGrid::setListMode(bool listMode) {
     m_compactMode = false;  // Disable compact mode if enabling list
 
     if (m_listMode) {
-        // List mode: 1 column, larger cells
+        // List mode: 1 column, auto-adapt row height to title length
         m_columns = 1;
         m_cellWidth = 900;
-        // Apply list row size setting
-        switch (m_listRowSize) {
-            case 0:  // Small
-                m_cellHeight = 60;
-                break;
-            case 1:  // Medium (default)
-                m_cellHeight = 80;
-                break;
-            case 2:  // Large
-                m_cellHeight = 100;
-                break;
-            case 3:  // Auto - will be handled per-cell in setupGrid
-                m_cellHeight = 0;  // Dynamic height
-                break;
-            default:
-                m_cellHeight = 80;
-                break;
-        }
+        m_cellHeight = 0;  // Dynamic height, calculated per-row in createRowRange
         m_rowMargin = 5;
     } else {
         // Reset to default grid
@@ -785,34 +767,8 @@ void RecyclingGrid::setListMode(bool listMode) {
 }
 
 void RecyclingGrid::setListRowSize(int rowSize) {
-    if (m_listRowSize == rowSize) return;
-    m_listRowSize = rowSize;
-
-    // If currently in list mode, update dimensions and rebuild
-    if (m_listMode) {
-        switch (m_listRowSize) {
-            case 0:  // Small
-                m_cellHeight = 60;
-                break;
-            case 1:  // Medium (default)
-                m_cellHeight = 80;
-                break;
-            case 2:  // Large
-                m_cellHeight = 100;
-                break;
-            case 3:  // Auto - dynamic height
-                m_cellHeight = 0;
-                break;
-            default:
-                m_cellHeight = 80;
-                break;
-        }
-
-        // Rebuild grid if we have items
-        if (!m_items.empty()) {
-            setupGrid();
-        }
-    }
+    // No-op: list mode always auto-adapts row height to title length
+    (void)rowSize;
 }
 
 void RecyclingGrid::setShowLibraryBadge(bool show) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -294,6 +294,7 @@ void RecyclingGrid::clearViews() {
 void RecyclingGrid::setupGrid() {
     // Cancel any ongoing incremental build
     m_incrementalBuildActive = false;
+    m_pendingFocusIndex = -1;
 
     // Reset scroll-based loading state
     m_lastScrollLoadY = 0.0f;
@@ -499,6 +500,13 @@ void RecyclingGrid::buildNextRowBatch() {
 
     createRowRange(m_incrementalBuildRow, endRow);
     m_incrementalBuildRow = endRow;
+
+    // Apply pending focus if the target cell was just created
+    if (m_pendingFocusIndex >= 0 && m_pendingFocusIndex < static_cast<int>(m_cells.size())) {
+        brls::Application::giveFocus(m_cells[m_pendingFocusIndex]);
+        m_focusedIndex = m_pendingFocusIndex;
+        m_pendingFocusIndex = -1;
+    }
 
     if (m_incrementalBuildRow < m_totalRowsNeeded) {
         // More rows to build - schedule next batch
@@ -822,10 +830,16 @@ void RecyclingGrid::focusIndex(int index) {
     if (index >= 0 && index < static_cast<int>(m_cells.size())) {
         brls::Application::giveFocus(m_cells[index]);
         m_focusedIndex = index;
+        m_pendingFocusIndex = -1;
+    } else if (index >= 0 && m_incrementalBuildActive) {
+        // Cell doesn't exist yet (still being built incrementally).
+        // Store as pending - buildNextRowBatch will apply it once the cell is created.
+        m_pendingFocusIndex = index;
     } else if (!m_cells.empty()) {
         // Fall back to first cell if index is out of range
         brls::Application::giveFocus(m_cells[0]);
         m_focusedIndex = 0;
+        m_pendingFocusIndex = -1;
     }
 }
 

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -623,17 +623,6 @@ void SettingsTab::createLibrarySection() {
         });
     m_contentBox->addView(gridSizeSelector);
 
-    // List row size selector (for list view mode)
-    auto* listRowSizeSelector = new brls::SelectorCell();
-    listRowSizeSelector->init("List Row Size",
-        {"Small (compact)", "Medium (default)", "Large (spacious)", "Auto (fit title)"},
-        static_cast<int>(settings.listRowSize),
-        [&settings](int index) {
-            settings.listRowSize = static_cast<ListRowSize>(index);
-            Application::getInstance().saveSettings();
-        });
-    m_contentBox->addView(listRowSizeSelector);
-
     // Library grouping mode selector
     auto* groupModeSelector = new brls::SelectorCell();
     groupModeSelector->init("Library Grouping",


### PR DESCRIPTION
Removes the list-row-size setting so rows always auto-adapt to title length, fixes list-mode titles not wrapping, and fixes focus/hover jumping during a library category update.

---
_Generated by [Claude Code](https://claude.ai/code)_