### PR TITLE
Fix library covers showing wrong manga after leaving and returning with sort active

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -158,6 +158,7 @@ private:
     bool m_loaded = false;
     bool m_categoriesLoaded = false;
     bool m_focusGridAfterLoad = false;  // Focus first grid item after loading new category
+    bool m_thumbnailsInvalidated = false;  // Set in willDisappear after cancelAll, cleared on reload
     int m_combinedQueryCategoryId = -1; // Category being fetched by combined query (skip redundant fetch)
 
     // Shared pointer to track if this object is still alive

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -21,6 +21,7 @@ public:
     void updateMangaData(const Manga& manga);   // Update data in place without reloading thumbnail
     void loadThumbnailIfNeeded();  // Load image if not already loaded
     void unloadThumbnail();        // Free GPU texture for off-screen cells (can reload later)
+    void resetThumbnailLoadState();  // Mark thumbnail as not loaded (allows reload without clearing image)
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -69,6 +69,10 @@ public:
     // Load thumbnails around a specific cell index (called on focus change)
     void loadThumbnailsNearIndex(int index);
 
+    // Reset m_thumbnailLoaded on all cells so they can reload.
+    // Called after ImageLoader::cancelAll() to fix stale thumbnail states.
+    void resetThumbnailLoadStates();
+
     // Override draw to check scroll position and load visible thumbnails
     void draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) override;
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -428,15 +428,37 @@ LibrarySectionTab::~LibrarySectionTab() {
 void LibrarySectionTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 
-    // Invalidate alive flag BEFORE destruction so pending async callbacks bail out
-    if (m_alive) *m_alive = false;
-
     // Cancel pending image loads to free up worker threads and network bandwidth
     ImageLoader::cancelAll();
+
+    // Reset thumbnail load states on all grid cells. cancelAll() may have cancelled
+    // pending loads that already set m_thumbnailLoaded=true (set optimistically in
+    // loadThumbnail). Without this reset, cells would show stale/wrong covers and
+    // refuse to reload because they think they're already loaded.
+    if (m_contentGrid) {
+        m_contentGrid->resetThumbnailLoadStates();
+    }
+    m_thumbnailsInvalidated = true;
 }
 
 void LibrarySectionTab::onFocusGained() {
     brls::Box::onFocusGained();
+
+    // Re-create the alive flag so new async callbacks (server refreshes, etc.) work.
+    // willDisappear() previously set *m_alive=false; old callbacks that captured the
+    // old weak_ptr will still bail out, while new ones will use the fresh flag.
+    m_alive = std::make_shared<bool>(true);
+
+    // Reload thumbnails that were invalidated by willDisappear's cancelAll().
+    // The cell load states were reset there, so loadThumbnailsNearIndex will
+    // reload visible covers from the LRU memory cache (fast, no network hit).
+    if (m_thumbnailsInvalidated && m_contentGrid) {
+        int focusedIdx = m_contentGrid->getFocusedIndex();
+        if (focusedIdx >= 0) {
+            m_contentGrid->loadThumbnailsNearIndex(focusedIdx);
+        }
+        m_thumbnailsInvalidated = false;
+    }
 
     // Show/hide update button + hint icon based on connectivity
     if (m_updateContainer) {
@@ -2539,75 +2561,12 @@ void LibrarySectionTab::updateMangaCellsIncrementally(const std::vector<Manga>& 
 
     brls::Logger::debug("LibrarySectionTab: Metadata changed, updating cells in place");
 
-    // Update the manga list
+    // Update the manga list and apply sort via sortMangaList(), which uses
+    // updateDataOrder() to properly handle thumbnail updates when manga
+    // change positions. Previously used updateCellData() here which preserved
+    // old thumbnails even when the sort order changed, causing cover mismatches.
     m_mangaList = newManga;
-
-    // Apply current sort mode to get the correct order
-    // But use updateCellData to avoid reloading thumbnails
-    LibrarySortMode effectiveMode = m_sortMode;
-    if (effectiveMode == LibrarySortMode::DEFAULT) {
-        int defaultSort = Application::getInstance().getSettings().defaultLibrarySortMode;
-        effectiveMode = static_cast<LibrarySortMode>(defaultSort);
-    }
-
-    // For DOWNLOADED_ONLY mode, we need to re-filter
-    if (effectiveMode == LibrarySortMode::DOWNLOADED_ONLY) {
-        // This requires full sort since filtering changes structure
-        sortMangaList();
-    } else if (m_contentGrid && m_contentGrid->getItemCount() == static_cast<int>(m_mangaList.size())) {
-        // Same size and not filtering, can update in place
-        // Apply the sort to m_mangaList first
-        switch (effectiveMode) {
-            case LibrarySortMode::TITLE_ASC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.title < b.title; });
-                break;
-            case LibrarySortMode::TITLE_DESC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.title > b.title; });
-                break;
-            case LibrarySortMode::UNREAD_DESC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.unreadCount > b.unreadCount; });
-                break;
-            case LibrarySortMode::UNREAD_ASC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.unreadCount < b.unreadCount; });
-                break;
-            case LibrarySortMode::RECENTLY_ADDED_DESC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.inLibraryAt > b.inLibraryAt; });
-                break;
-            case LibrarySortMode::RECENTLY_ADDED_ASC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.inLibraryAt < b.inLibraryAt; });
-                break;
-            case LibrarySortMode::LAST_READ:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.lastReadAt > b.lastReadAt; });
-                break;
-            case LibrarySortMode::DATE_UPDATED_DESC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.latestChapterUploadDate > b.latestChapterUploadDate; });
-                break;
-            case LibrarySortMode::DATE_UPDATED_ASC:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.latestChapterUploadDate < b.latestChapterUploadDate; });
-                break;
-            case LibrarySortMode::TOTAL_CHAPTERS:
-                std::sort(m_mangaList.begin(), m_mangaList.end(),
-                    [](const Manga& a, const Manga& b) { return a.chapterCount > b.chapterCount; });
-                break;
-            default:
-                break;
-        }
-
-        // Update cells in place without reloading thumbnails
-        m_contentGrid->updateCellData(m_mangaList);
-    } else {
-        // Size mismatch, need full rebuild
-        sortMangaList();
-    }
+    sortMangaList();
 
     // Update cache
     m_cachedMangaList.clear();

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -321,6 +321,13 @@ void MangaItemCell::unloadThumbnail() {
     m_thumbnailLoaded = false;
 }
 
+void MangaItemCell::resetThumbnailLoadState() {
+    // Just reset the load flag without clearing the existing image.
+    // This allows loadThumbnailIfNeeded() to reload the thumbnail from cache/network
+    // while keeping the old image visible until the new one arrives (no visual flash).
+    m_thumbnailLoaded = false;
+}
+
 void MangaItemCell::loadThumbnail() {
     if (!m_thumbnailImage || m_thumbnailLoaded) return;
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -279,6 +279,12 @@ void MangaItemCell::updateDisplay() {
 }
 
 void MangaItemCell::setManga(const Manga& manga) {
+    // Invalidate any in-flight thumbnail loads for the previous manga.
+    // Without this, a stale worker-thread load could finish after the new load
+    // and overwrite the correct cover (race condition during sort changes).
+    if (m_alive) *m_alive = false;
+    m_alive = std::make_shared<bool>(true);
+
     m_manga = manga;
     m_thumbnailLoaded = false;
     updateDisplay();
@@ -286,6 +292,10 @@ void MangaItemCell::setManga(const Manga& manga) {
 }
 
 void MangaItemCell::setMangaDeferred(const Manga& manga) {
+    // Invalidate any in-flight thumbnail loads for the previous manga.
+    if (m_alive) *m_alive = false;
+    m_alive = std::make_shared<bool>(true);
+
     // Set manga data but don't load thumbnail yet
     m_manga = manga;
     m_thumbnailLoaded = false;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -621,6 +621,20 @@ void RecyclingGrid::updateVisibleCells() {
     }
 }
 
+void RecyclingGrid::resetThumbnailLoadStates() {
+    // Reset m_thumbnailLoaded on all cells so they can reload via loadThumbnailIfNeeded().
+    // Called after ImageLoader::cancelAll() which may cancel pending thumbnail loads,
+    // leaving cells with m_thumbnailLoaded=true but no actual thumbnail applied.
+    // Uses resetThumbnailLoadState() (not unloadThumbnail) to keep the old image visible
+    // until the new one loads from cache, avoiding a visual flash.
+    for (auto* cell : m_cells) {
+        if (cell) {
+            cell->resetThumbnailLoadState();
+        }
+    }
+    brls::Logger::debug("RecyclingGrid: Reset thumbnail load states for {} cells", m_cells.size());
+}
+
 void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) {
     // Call parent draw first
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);


### PR DESCRIPTION
Fixes library covers showing the wrong manga after leaving and returning with a sort active by invalidating in-flight thumbnail loads when a cell's manga changes.

---
_Generated by [Claude Code](https://claude.ai/code)_