### PR TITLE
Show Select/Deselect dynamically in library context menu based on book state

### DIFF
--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -50,6 +50,7 @@ public:
     void toggleSelection(int index);
     void clearSelection();
     std::vector<int> getSelectedIndices() const;
+    bool isIndexSelected(int index) const;
     std::vector<Manga> getSelectedManga() const;
     int getSelectionCount() const;
     void setOnSelectionChanged(std::function<void(int count)> callback);

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1931,7 +1931,9 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
 
     std::vector<std::string> options;
     if (m_selectionMode) {
-        options = {"Select / Deselect", "Download", "Mark as Read", "Mark as Unread",
+        bool isSelected = m_contentGrid && m_contentGrid->isIndexSelected(index);
+        std::string selectLabel = isSelected ? "Deselect" : "Select";
+        options = {selectLabel, "Download", "Mark as Read", "Mark as Unread",
                    "Change Categories", "Remove from Library", "Cancel Selection"};
     } else {
         options = {"Select", "Download", "Track", "Mark as Read", "Mark as Unread",

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -753,6 +753,10 @@ std::vector<int> RecyclingGrid::getSelectedIndices() const {
     return std::vector<int>(m_selectedIndices.begin(), m_selectedIndices.end());
 }
 
+bool RecyclingGrid::isIndexSelected(int index) const {
+    return m_selectedIndices.count(index) > 0;
+}
+
 std::vector<Manga> RecyclingGrid::getSelectedManga() const {
     std::vector<Manga> result;
     for (int idx : m_selectedIndices) {


### PR DESCRIPTION
Show Select/Deselect dynamically in library context menu based on book state

When in selection mode, the Start button context menu now shows "Select"
if the focused book is not selected, and "Deselect" if it is already
selected, instead of the combined "Select / Deselect" label.

---
_Generated by [Claude Code](https://claude.ai/code)_