### PR TITLE
Fix teal check mark on first item in library context menu

### DIFF
--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2034,7 +2034,8 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
                 }
             }
             }); // end brls::sync
-        }
+        },
+        -1
     );
     brls::Application::pushActivity(new brls::Activity(dropdown));
 }


### PR DESCRIPTION
Fix teal check mark on first item in library context menu

Pass -1 as the selected index to brls::Dropdown so no item is
pre-selected when opening the context menu. Previously it defaulted
to 0, causing a teal check mark on the "Select" option.

---
_Generated by [Claude Code](https://claude.ai/code)_