### PR TITLE
Fix hover transfer when dropdown menu is open during async data load

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -93,6 +93,10 @@ private:
     // Check if this tab is still valid (not destroyed)
     bool isValid() const { return m_alive && *m_alive; }
 
+    // Check if the current focus is within this tab's view hierarchy.
+    // Returns false when a dropdown/overlay is on top (focus is outside this tab).
+    bool hasFocusWithin() const;
+
     // Currently selected category
     int m_currentCategoryId = 0;
     std::string m_currentCategoryName = "Library";

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -425,6 +425,19 @@ LibrarySectionTab::~LibrarySectionTab() {
     brls::Logger::debug("LibrarySectionTab: Destroyed");
 }
 
+bool LibrarySectionTab::hasFocusWithin() const {
+    brls::View* focused = brls::Application::getCurrentFocus();
+    if (!focused) return false;
+
+    // Walk up from the focused view to see if it's a descendant of this tab
+    brls::View* current = focused;
+    while (current) {
+        if (current == this) return true;
+        current = current->hasParent() ? current->getParent() : nullptr;
+    }
+    return false;
+}
+
 void LibrarySectionTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 
@@ -1550,6 +1563,14 @@ void LibrarySectionTab::sortMangaList() {
         } else {
             // Items were filtered out or list size changed, need full rebuild
             m_contentGrid->setDataSource(m_mangaList);
+        }
+
+        // Skip focus transfer when an overlay (dropdown/dialog) is on top.
+        // Background async completions (category load, etc.) update the grid data
+        // above, but must not steal focus from the active dropdown menu.
+        if (!hasFocusWithin()) {
+            m_focusGridAfterLoad = false;
+            return;
         }
 
         // Handle empty state after filtering (e.g., "Downloads Only" with no local downloads)


### PR DESCRIPTION
Fix hover transfer when dropdown menu is open during async data load

When a sort/group/context menu dropdown is active and a background async
operation completes (category load, source grouping, etc.), sortMangaList()
would call focusIndex()/giveFocus() which steals focus from the dropdown
back to the grid. This causes a jarring hover transfer on the library tab.

Add hasFocusWithin() to detect when focus is outside this tab's hierarchy
(i.e. on a dropdown overlay) and skip focus transfers in sortMangaList().
Grid data is still updated so it's correct when the dropdown closes.

---
_Generated by [Claude Code](https://claude.ai/code)_