### PR TITLE
Fix group-by-source not showing all books due to hard-coded 500 limit

### DIFF
--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -920,9 +920,9 @@ bool SuwayomiClient::fetchLibraryMangaGraphQL(std::vector<Manga>& manga) {
     const char* query = R"(
         query GetLibraryManga {
             mangas(
-                filter: {
-                    inLibrary: { equalTo: true }
-                }
+                condition: { inLibrary: true }
+                first: 500
+                orderBy: TITLE
             ) {
                 nodes {
                     id

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -322,9 +322,15 @@ std::string SuwayomiClient::extractJsonArray(const std::string& json, const std:
 
     int bracketCount = 1;
     size_t arrEnd = arrStart + 1;
+    bool inString = false;
     while (bracketCount > 0 && arrEnd < json.length()) {
-        if (json[arrEnd] == '[') bracketCount++;
-        else if (json[arrEnd] == ']') bracketCount--;
+        char c = json[arrEnd];
+        if (c == '"' && (arrEnd == 0 || json[arrEnd - 1] != '\\')) {
+            inString = !inString;
+        } else if (!inString) {
+            if (c == '[') bracketCount++;
+            else if (c == ']') bracketCount--;
+        }
         arrEnd++;
     }
 
@@ -352,9 +358,15 @@ std::string SuwayomiClient::extractJsonObject(const std::string& json, const std
 
     int braceCount = 1;
     size_t objEnd = objStart + 1;
+    bool inString = false;
     while (braceCount > 0 && objEnd < json.length()) {
-        if (json[objEnd] == '{') braceCount++;
-        else if (json[objEnd] == '}') braceCount--;
+        char c = json[objEnd];
+        if (c == '"' && (objEnd == 0 || json[objEnd - 1] != '\\')) {
+            inString = !inString;
+        } else if (!inString) {
+            if (c == '{') braceCount++;
+            else if (c == '}') braceCount--;
+        }
         objEnd++;
     }
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -920,9 +920,9 @@ bool SuwayomiClient::fetchLibraryMangaGraphQL(std::vector<Manga>& manga) {
     const char* query = R"(
         query GetLibraryManga {
             mangas(
-                condition: { inLibrary: true }
-                first: 500
-                orderBy: TITLE
+                filter: {
+                    inLibrary: { equalTo: true }
+                }
             ) {
                 nodes {
                     id

--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -108,7 +108,7 @@ bool LibraryCache::ensureDirectoryExists(const std::string& path) {
 
 std::string LibraryCache::serializeManga(const Manga& manga) {
     std::ostringstream ss;
-    // Format: id|title|author|artist|description|thumbnailUrl|status|inLibrary|chapterCount|unreadCount|downloadCount|sourceName
+    // Format: id|title|author|artist|description|thumbnailUrl|status|inLibrary|chapterCount|unreadCount|downloadCount|sourceName|inLibraryAt|lastReadAt|latestChapterUploadDate
     ss << manga.id << "|"
        << manga.title << "|"
        << manga.author << "|"
@@ -120,7 +120,10 @@ std::string LibraryCache::serializeManga(const Manga& manga) {
        << manga.chapterCount << "|"
        << manga.unreadCount << "|"
        << manga.downloadedCount << "|"
-       << manga.sourceName;
+       << manga.sourceName << "|"
+       << manga.inLibraryAt << "|"
+       << manga.lastReadAt << "|"
+       << manga.latestChapterUploadDate;
     return ss.str();
 }
 
@@ -149,6 +152,10 @@ bool LibraryCache::deserializeManga(const std::string& line, Manga& manga) {
         manga.downloadedCount = std::stoi(parts[10]);
         // sourceName added later; old caches have only 11 fields
         if (parts.size() > 11) manga.sourceName = parts[11];
+        // Sort-related timestamps added later; old caches have only 12 fields
+        if (parts.size() > 12) manga.inLibraryAt = std::stoll(parts[12]);
+        if (parts.size() > 13) manga.lastReadAt = std::stoll(parts[13]);
+        if (parts.size() > 14) manga.latestChapterUploadDate = std::stoll(parts[14]);
         return true;
     } catch (...) {
         return false;
@@ -651,6 +658,9 @@ std::string LibraryCache::serializeMangaDetails(const Manga& manga) {
     ss << "chapterCount=" << manga.chapterCount << "\n";
     ss << "lastChapterRead=" << manga.lastChapterRead << "\n";
     ss << "sourceName=" << escapeString(manga.sourceName) << "\n";
+    ss << "inLibraryAt=" << manga.inLibraryAt << "\n";
+    ss << "lastReadAt=" << manga.lastReadAt << "\n";
+    ss << "latestChapterUploadDate=" << manga.latestChapterUploadDate << "\n";
 
     // Serialize genres as comma-separated
     ss << "genre=";
@@ -692,6 +702,9 @@ bool LibraryCache::deserializeMangaDetails(const std::string& data, Manga& manga
             else if (key == "chapterCount") manga.chapterCount = std::stoi(value);
             else if (key == "lastChapterRead") manga.lastChapterRead = std::stoi(value);
             else if (key == "sourceName") manga.sourceName = unescapeString(value);
+            else if (key == "inLibraryAt") manga.inLibraryAt = std::stoll(value);
+            else if (key == "lastReadAt") manga.lastReadAt = std::stoll(value);
+            else if (key == "latestChapterUploadDate") manga.latestChapterUploadDate = std::stoll(value);
             else if (key == "genre") {
                 manga.genre.clear();
                 if (!value.empty()) {


### PR DESCRIPTION
Fixes group-by-source not showing all books (a hard-coded 500 limit), fixes JSON parsers truncating responses whose descriptions contain braces, and fixes library sort options when offline on cached data.

---
_Generated by [Claude Code](https://claude.ai/code)_