### PR TITLE
Configure server to serve only PNG/JPEG images on first connection

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -193,6 +193,9 @@ struct AppSettings {
     // Display Settings
     bool showUnreadBadge = true;
 
+    // Server image settings (applied once on first connection)
+    bool serverImageSettingsApplied = false;
+
     // Per-manga reader settings (keyed by manga ID)
     // If a manga has custom settings, they override the defaults above
     std::map<int, MangaReaderSettings> mangaReaderSettings;

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -575,6 +575,9 @@ public:
     // Returns the URL as-is if it's already a server URL or if proxy isn't available
     std::string buildProxiedImageUrl(const std::string& externalUrl) const;
 
+    // Apply server image settings (configure serveConversions to send only PNG/JPEG)
+    bool applyServerImageSettings();
+
     // Get update summary
     bool fetchUpdateSummary(int& pendingUpdates, int& runningJobs, bool& isUpdating);
 

--- a/include/utils/library_cache.hpp
+++ b/include/utils/library_cache.hpp
@@ -31,6 +31,11 @@ public:
     bool hasCategoryCache(int categoryId);
     void invalidateCategoryCache(int categoryId);
 
+    // All-library manga caching (flat list for NO_GROUPING / BY_SOURCE modes)
+    bool saveAllLibraryManga(const std::vector<Manga>& manga);
+    bool loadAllLibraryManga(std::vector<Manga>& manga);
+    bool hasAllLibraryCache();
+
     // Individual manga details caching (for detail view)
     bool saveMangaDetails(const Manga& manga);
     bool loadMangaDetails(int mangaId, Manga& manga);
@@ -79,6 +84,7 @@ private:
     std::string getMangaDetailsCacheDir();
     std::string getCategoryFilePath(int categoryId);
     std::string getCategoriesFilePath();
+    std::string getAllLibraryFilePath();
     std::string getMangaDetailsFilePath(int mangaId);
     bool ensureDirectoryExists(const std::string& path);
 

--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -259,6 +259,17 @@ void LoginActivity::onConnectPressed() {
                     settings.localServerUrl = serverUrl;
                 }
 
+                // Apply server image settings on first connection (convert to PNG/JPEG only)
+                if (!settings.serverImageSettingsApplied) {
+                    brls::Logger::info("First connection: applying server image settings...");
+                    if (client.applyServerImageSettings()) {
+                        settings.serverImageSettingsApplied = true;
+                        brls::Logger::info("Server image settings applied successfully");
+                    } else {
+                        brls::Logger::warning("Failed to apply server image settings, will retry next launch");
+                    }
+                }
+
                 Application::getInstance().saveSettings();
 
                 std::string modeName = getAuthModeName(authMode);

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -254,6 +254,18 @@ void Application::run() {
             brls::Logger::info("Connection restored successfully");
             m_isConnected = true;
 
+            // Apply server image settings on first run (convert to PNG/JPEG only)
+            if (!m_settings.serverImageSettingsApplied) {
+                brls::Logger::info("First run: applying server image settings...");
+                if (SuwayomiClient::getInstance().applyServerImageSettings()) {
+                    m_settings.serverImageSettingsApplied = true;
+                    saveSettings();
+                    brls::Logger::info("Server image settings applied successfully");
+                } else {
+                    brls::Logger::warning("Failed to apply server image settings, will retry next launch");
+                }
+            }
+
             // Sync offline reading progress to server in background
             DownloadsManager& dm = DownloadsManager::getInstance();
             if (!dm.getDownloads().empty()) {
@@ -603,6 +615,9 @@ bool Application::loadSettings() {
 
     // Load display settings
     m_settings.showUnreadBadge = extractBool("showUnreadBadge", true);
+
+    // Load server image settings flag
+    m_settings.serverImageSettingsApplied = extractBool("serverImageSettingsApplied", false);
 
     // Load library grid customization
     int displayModeInt = extractInt("libraryDisplayMode");
@@ -973,6 +988,9 @@ bool Application::saveSettings() {
 
     // Display settings
     json += "  \"showUnreadBadge\": " + std::string(m_settings.showUnreadBadge ? "true" : "false") + ",\n";
+
+    // Server image settings flag
+    json += "  \"serverImageSettingsApplied\": " + std::string(m_settings.serverImageSettingsApplied ? "true" : "false") + ",\n";
 
     // Library grid customization
     json += "  \"libraryDisplayMode\": " + std::to_string(static_cast<int>(m_settings.libraryDisplayMode)) + ",\n";

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2790,6 +2790,38 @@ std::string SuwayomiClient::getExtensionIconUrl(const std::string& apkName) {
 }
 
 // ============================================================================
+// Server Image Settings (serveConversions)
+// ============================================================================
+
+bool SuwayomiClient::applyServerImageSettings() {
+    // Configure serveConversions on the server so it converts non-PNG/JPEG
+    // formats (e.g. WebP, AVIF) to JPEG before serving to this client.
+    // The PS Vita handles JPEG/PNG natively and more efficiently.
+    const char* query = R"(
+        mutation SetSettings($input: SetSettingsInput!) {
+            setSettings(input: $input) {
+                settings {
+                    ip
+                }
+            }
+        }
+    )";
+
+    // Set serveConversions: convert default (all non-standard) to JPEG,
+    // but keep PNG and JPEG as-is (target "none" disables conversion).
+    std::string variables = R"({"input":{"settings":{"serveConversions":{"default":{"target":"image/jpeg","compressionLevel":0.9},"image/jpeg":{"target":"none"},"image/png":{"target":"none"}}}}})";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::error("Failed to apply server image settings (serveConversions)");
+        return false;
+    }
+
+    brls::Logger::info("Server image settings applied: serveConversions set to convert to JPEG/PNG only");
+    return true;
+}
+
+// ============================================================================
 // Extension Repository Management
 // ============================================================================
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2808,8 +2808,10 @@ bool SuwayomiClient::applyServerImageSettings() {
     )";
 
     // Set serveConversions: convert default (all non-standard) to JPEG,
-    // but keep PNG and JPEG as-is (target "none" disables conversion).
-    std::string variables = R"({"input":{"settings":{"serveConversions":{"default":{"target":"image/jpeg","compressionLevel":0.9},"image/jpeg":{"target":"none"},"image/png":{"target":"none"}}}}})";
+    // but keep PNG and JPEG as-is (target matching source mime skips conversion).
+    // serveConversions is a list of SettingsDownloadConversionTypeInput objects,
+    // each with a mimeType field (use "default" as fallback for unmatched types).
+    std::string variables = R"({"input":{"settings":{"serveConversions":[{"mimeType":"default","target":"image/jpeg","compressionLevel":0.9},{"mimeType":"image/jpeg","target":"image/jpeg"},{"mimeType":"image/png","target":"image/png"}]}}})";
 
     std::string response = executeGraphQL(query, variables);
     if (response.empty()) {

--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -75,6 +75,10 @@ std::string LibraryCache::getCategoriesFilePath() {
     return getCacheDir() + "/categories.txt";
 }
 
+std::string LibraryCache::getAllLibraryFilePath() {
+    return getCacheDir() + "/all_library.txt";
+}
+
 std::string LibraryCache::getCoverCachePath(int mangaId) {
     return getCoverCacheDir() + "/" + std::to_string(mangaId) + ".tga";
 }
@@ -420,6 +424,113 @@ void LibraryCache::invalidateCategoryCache(int categoryId) {
 #endif
 }
 
+bool LibraryCache::saveAllLibraryManga(const std::vector<Manga>& manga) {
+    if (!m_enabled) return false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    std::string path = getAllLibraryFilePath();
+
+#ifdef __vita__
+    SceUID fd = sceIoOpen(path.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+    if (fd < 0) {
+        brls::Logger::error("LibraryCache: Failed to open {} for writing", path);
+        return false;
+    }
+
+    for (const auto& m : manga) {
+        std::string line = serializeManga(m) + "\n";
+        sceIoWrite(fd, line.c_str(), line.size());
+    }
+
+    sceIoClose(fd);
+#else
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    for (const auto& m : manga) {
+        file << serializeManga(m) << "\n";
+    }
+
+    file.close();
+#endif
+
+    brls::Logger::debug("LibraryCache: Saved {} manga to all-library cache", manga.size());
+    return true;
+}
+
+bool LibraryCache::loadAllLibraryManga(std::vector<Manga>& manga) {
+    if (!m_enabled) return false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    std::string path = getAllLibraryFilePath();
+    manga.clear();
+
+#ifdef __vita__
+    SceUID fd = sceIoOpen(path.c_str(), SCE_O_RDONLY, 0);
+    if (fd < 0) {
+        return false;
+    }
+
+    SceOff size = sceIoLseek(fd, 0, SCE_SEEK_END);
+    sceIoLseek(fd, 0, SCE_SEEK_SET);
+
+    if (size <= 0 || size > 10 * 1024 * 1024) {
+        sceIoClose(fd);
+        return false;
+    }
+
+    std::vector<char> buffer(size + 1);
+    sceIoRead(fd, buffer.data(), size);
+    buffer[size] = '\0';
+    sceIoClose(fd);
+
+    std::istringstream stream(buffer.data());
+    std::string line;
+    while (std::getline(stream, line)) {
+        if (line.empty()) continue;
+        Manga m;
+        if (deserializeManga(line, m)) {
+            manga.push_back(m);
+        }
+    }
+#else
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty()) continue;
+        Manga m;
+        if (deserializeManga(line, m)) {
+            manga.push_back(m);
+        }
+    }
+
+    file.close();
+#endif
+
+    brls::Logger::debug("LibraryCache: Loaded {} manga from all-library cache", manga.size());
+    return !manga.empty();
+}
+
+bool LibraryCache::hasAllLibraryCache() {
+    std::string path = getAllLibraryFilePath();
+
+#ifdef __vita__
+    SceIoStat stat;
+    return sceIoGetstat(path.c_str(), &stat) >= 0;
+#else
+    struct stat st;
+    return stat(path.c_str(), &st) == 0;
+#endif
+}
+
 bool LibraryCache::saveCoverImage(int mangaId, const std::vector<uint8_t>& imageData) {
     if (!m_coverCacheEnabled || imageData.empty()) return false;
 
@@ -529,7 +640,8 @@ void LibraryCache::clearLibraryCache() {
     if (dfd >= 0) {
         SceIoDirent entry;
         while (sceIoDread(dfd, &entry) > 0) {
-            if (strstr(entry.d_name, "category_") != nullptr) {
+            if (strstr(entry.d_name, "category_") != nullptr ||
+                strcmp(entry.d_name, "all_library.txt") == 0) {
                 std::string path = dir + "/" + entry.d_name;
                 sceIoRemove(path.c_str());
             }
@@ -541,7 +653,8 @@ void LibraryCache::clearLibraryCache() {
     if (d) {
         struct dirent* entry;
         while ((entry = readdir(d)) != nullptr) {
-            if (strstr(entry->d_name, "category_") != nullptr) {
+            if (strstr(entry->d_name, "category_") != nullptr ||
+                strcmp(entry->d_name, "all_library.txt") == 0) {
                 std::string path = dir + "/" + entry->d_name;
                 remove(path.c_str());
             }

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -557,12 +557,17 @@ void LibrarySectionTab::loadCategories() {
         loadAllManga();
         // Fetch/load categories for potential mode switch later
         if (Application::getInstance().isConnected()) {
-            asyncRun([this, aliveWeak]() {
+            bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
+            asyncRun([this, aliveWeak, cacheEnabled]() {
                 SuwayomiClient& client = SuwayomiClient::getInstance();
                 std::vector<Category> categories;
                 if (client.fetchCategories(categories)) {
                     std::sort(categories.begin(), categories.end(),
                               [](const Category& a, const Category& b) { return a.order < b.order; });
+                    // Save categories to cache so offline mode switch works
+                    if (cacheEnabled) {
+                        LibraryCache::getInstance().saveCategories(categories);
+                    }
                     brls::sync([this, categories, aliveWeak]() {
                         auto alive = aliveWeak.lock();
                         if (!alive || !*alive) return;
@@ -596,12 +601,17 @@ void LibrarySectionTab::loadCategories() {
         loadBySource();
         // Fetch/load categories for potential mode switch later
         if (Application::getInstance().isConnected()) {
-            asyncRun([this, aliveWeak]() {
+            bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
+            asyncRun([this, aliveWeak, cacheEnabled]() {
                 SuwayomiClient& client = SuwayomiClient::getInstance();
                 std::vector<Category> categories;
                 if (client.fetchCategories(categories)) {
                     std::sort(categories.begin(), categories.end(),
                               [](const Category& a, const Category& b) { return a.order < b.order; });
+                    // Save categories to cache so offline mode switch works
+                    if (cacheEnabled) {
+                        LibraryCache::getInstance().saveCategories(categories);
+                    }
                     brls::sync([this, categories, aliveWeak]() {
                         auto alive = aliveWeak.lock();
                         if (!alive || !*alive) return;
@@ -2970,18 +2980,38 @@ void LibrarySectionTab::loadAllManga() {
         m_titleLabel->setText("All Manga");
     }
 
-    // When offline, aggregate cached category manga as fallback
+    // When offline, load from cache
     if (!Application::getInstance().isConnected()) {
         bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
         if (cacheEnabled) {
             LibraryCache& cache = LibraryCache::getInstance();
             std::vector<Manga> allCached;
+
+            // Try all-library cache first (populated when NO_GROUPING/BY_SOURCE fetches online)
+            if (cache.loadAllLibraryManga(allCached)) {
+                brls::Logger::info("LibrarySectionTab: Loaded {} manga from all-library cache (offline)",
+                                  allCached.size());
+                // Store categories for potential mode switch to BY_CATEGORY while offline
+                if (m_categories.empty()) {
+                    std::vector<Category> categories;
+                    if (cache.loadCategories(categories)) {
+                        std::sort(categories.begin(), categories.end(),
+                                  [](const Category& a, const Category& b) { return a.order < b.order; });
+                        m_categories = categories;
+                    }
+                }
+                m_fullMangaList = allCached;
+                m_mangaList = allCached;
+                sortMangaList();
+                m_loaded = true;
+                return;
+            }
+
+            // Fall back to aggregating per-category caches
             std::set<int> seenIds;
 
-            // Load cached categories and merge their manga
             std::vector<Category> categories;
             if (cache.loadCategories(categories)) {
-                // Store categories for potential mode switch to BY_CATEGORY while offline
                 if (m_categories.empty()) {
                     std::sort(categories.begin(), categories.end(),
                               [](const Category& a, const Category& b) { return a.order < b.order; });
@@ -3011,7 +3041,7 @@ void LibrarySectionTab::loadAllManga() {
             }
 
             if (!allCached.empty()) {
-                brls::Logger::info("LibrarySectionTab: Loaded {} manga from cache for all-manga view (offline)",
+                brls::Logger::info("LibrarySectionTab: Loaded {} manga from category caches for all-manga view (offline)",
                                   allCached.size());
                 m_fullMangaList = allCached;
                 m_mangaList = allCached;
@@ -3025,9 +3055,10 @@ void LibrarySectionTab::loadAllManga() {
         return;
     }
 
+    bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
     std::weak_ptr<bool> aliveWeak = m_alive;
 
-    asyncRun([this, aliveWeak]() {
+    asyncRun([this, aliveWeak, cacheEnabled]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         std::vector<Manga> allManga;
 
@@ -3040,6 +3071,11 @@ void LibrarySectionTab::loadAllManga() {
                 brls::Application::notify("Failed to load library - check connection");
             });
             return;
+        }
+
+        // Save to cache if enabled
+        if (cacheEnabled) {
+            LibraryCache::getInstance().saveAllLibraryManga(allManga);
         }
 
         brls::sync([this, allManga, aliveWeak]() {
@@ -3102,17 +3138,35 @@ void LibrarySectionTab::loadBySource() {
         }
     };
 
-    // When offline, aggregate cached category manga as fallback
+    // When offline, load from cache
     if (!Application::getInstance().isConnected()) {
         bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
         if (cacheEnabled) {
             LibraryCache& cache = LibraryCache::getInstance();
             std::vector<Manga> allCached;
+
+            // Try all-library cache first (populated when NO_GROUPING/BY_SOURCE fetches online)
+            if (cache.loadAllLibraryManga(allCached)) {
+                brls::Logger::info("LibrarySectionTab: Loaded {} manga from all-library cache for by-source view (offline)",
+                                  allCached.size());
+                // Store categories for potential mode switch to BY_CATEGORY while offline
+                if (m_categories.empty()) {
+                    std::vector<Category> categories;
+                    if (cache.loadCategories(categories)) {
+                        std::sort(categories.begin(), categories.end(),
+                                  [](const Category& a, const Category& b) { return a.order < b.order; });
+                        m_categories = categories;
+                    }
+                }
+                applySourceGrouping(allCached);
+                return;
+            }
+
+            // Fall back to aggregating per-category caches
             std::set<int> seenIds;
 
             std::vector<Category> categories;
             if (cache.loadCategories(categories)) {
-                // Store categories for potential mode switch to BY_CATEGORY while offline
                 if (m_categories.empty()) {
                     std::sort(categories.begin(), categories.end(),
                               [](const Category& a, const Category& b) { return a.order < b.order; });
@@ -3141,7 +3195,7 @@ void LibrarySectionTab::loadBySource() {
             }
 
             if (!allCached.empty()) {
-                brls::Logger::info("LibrarySectionTab: Loaded {} manga from cache for by-source view (offline)",
+                brls::Logger::info("LibrarySectionTab: Loaded {} manga from category caches for by-source view (offline)",
                                   allCached.size());
                 applySourceGrouping(allCached);
                 return;
@@ -3152,9 +3206,10 @@ void LibrarySectionTab::loadBySource() {
         return;
     }
 
+    bool cacheEnabled = Application::getInstance().getSettings().cacheLibraryData;
     std::weak_ptr<bool> aliveWeak = m_alive;
 
-    asyncRun([this, aliveWeak, applySourceGrouping]() {
+    asyncRun([this, aliveWeak, applySourceGrouping, cacheEnabled]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         std::vector<Manga> allManga;
 
@@ -3167,6 +3222,11 @@ void LibrarySectionTab::loadBySource() {
                 brls::Application::notify("Failed to load library - check connection");
             });
             return;
+        }
+
+        // Save to cache if enabled
+        if (cacheEnabled) {
+            LibraryCache::getInstance().saveAllLibraryManga(allManga);
         }
 
         brls::sync([this, allManga, aliveWeak, applySourceGrouping]() mutable {


### PR DESCRIPTION
Configures the server to serve only PNG/JPEG images on first connection (fixing the `serveConversions` mutation input type) and fixes library cache save/load for the BY_SOURCE and NO_GROUPING grouping modes.

---
_Generated by [Claude Code](https://claude.ai/code)_