### PR TITLE
Fix source-grouped update to only update that source's categories and add pull-to-refresh indicator

### DIFF
--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -488,6 +488,7 @@ public:
     bool fetchLibraryMangaByCategory(int categoryId, std::vector<Manga>& manga);
     bool triggerLibraryUpdate();
     bool triggerLibraryUpdate(int categoryId);
+    bool triggerLibraryUpdate(const std::vector<int>& categoryIds);
     bool fetchRecentUpdates(int page, std::vector<RecentUpdate>& updates);
 
     // Download Management

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -132,6 +132,9 @@ private:
     brls::Button* m_sortBtn = nullptr;
     brls::Image* m_sortIcon = nullptr;
 
+    // Pull-to-refresh indicator (shown during swipe-down gesture on category tabs)
+    brls::Label* m_pullIndicatorLabel = nullptr;
+
     // Main content grid
     RecyclingGrid* m_contentGrid = nullptr;
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3833,6 +3833,59 @@ bool SuwayomiClient::triggerLibraryUpdate(int categoryId) {
     return response.success && response.statusCode == 200;
 }
 
+bool SuwayomiClient::triggerLibraryUpdate(const std::vector<int>& categoryIds) {
+    if (categoryIds.empty()) {
+        return triggerLibraryUpdate();
+    }
+
+    // Single category: delegate to existing overload
+    if (categoryIds.size() == 1) {
+        return triggerLibraryUpdate(categoryIds[0]);
+    }
+
+    // Multiple categories: use GraphQL mutation with array
+    std::string idList = "[";
+    for (size_t i = 0; i < categoryIds.size(); i++) {
+        if (i > 0) idList += ",";
+        idList += std::to_string(categoryIds[i]);
+    }
+    idList += "]";
+
+    const char* query = R"(
+        mutation UpdateCategoryManga($categories: [Int!]!) {
+            updateCategoryManga(input: { categories: $categories }) {
+                updateStatus {
+                    isRunning
+                }
+            }
+        }
+    )";
+
+    std::string variables = "{\"categories\":" + idList + "}";
+    std::string response = executeGraphQL(query, variables);
+
+    if (!response.empty()) {
+        brls::Logger::info("GraphQL: Successfully triggered update for {} categories", categoryIds.size());
+        return true;
+    }
+
+    // REST fallback: trigger each category individually
+    brls::Logger::info("GraphQL failed for multi-category update, falling back to REST...");
+    bool anySuccess = false;
+    vitasuwayomi::HttpClient http = createHttpClient();
+    http.setDefaultHeader("Content-Type", "application/json");
+    std::string url = buildApiUrl("/update/fetch");
+
+    for (int catId : categoryIds) {
+        std::string body = "{\"categoryId\":" + std::to_string(catId) + "}";
+        vitasuwayomi::HttpResponse resp = http.post(url, body);
+        if (resp.success && resp.statusCode == 200) {
+            anySuccess = true;
+        }
+    }
+    return anySuccess;
+}
+
 bool SuwayomiClient::fetchRecentUpdates(int page, std::vector<RecentUpdate>& updates) {
     vitasuwayomi::HttpClient http = createHttpClient();
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -263,6 +263,7 @@ LibrarySectionTab::LibrarySectionTab() {
             static brls::Point pullStart;
             static bool validPull = false;
             static constexpr float PULL_THRESHOLD = 60.0f;
+            static constexpr float SHOW_THRESHOLD = 10.0f;
 
             if (status.state == brls::GestureState::START) {
                 pullStart = status.position;
@@ -274,17 +275,48 @@ LibrarySectionTab::LibrarySectionTab() {
                 if (dy > 0 && std::abs(dy) > std::abs(dx) * 1.5f) {
                     validPull = true;
                 }
+
+                // Show/update pull indicator
+                if (m_pullIndicatorLabel) {
+                    if (dy > SHOW_THRESHOLD && validPull) {
+                        m_pullIndicatorLabel->setVisibility(brls::Visibility::VISIBLE);
+                        if (dy > PULL_THRESHOLD) {
+                            m_pullIndicatorLabel->setText("Release to update");
+                            m_pullIndicatorLabel->setTextColor(nvgRGBA(0, 200, 170, 255));
+                        } else {
+                            m_pullIndicatorLabel->setText("Pull down to update");
+                            m_pullIndicatorLabel->setTextColor(nvgRGBA(150, 150, 150, 255));
+                        }
+                    } else {
+                        m_pullIndicatorLabel->setVisibility(brls::Visibility::GONE);
+                    }
+                }
             } else if (status.state == brls::GestureState::END) {
                 float dy = status.position.y - pullStart.y;
                 if (validPull && dy > PULL_THRESHOLD) {
                     triggerLibraryUpdate();
                 }
                 validPull = false;
+                // Hide indicator
+                if (m_pullIndicatorLabel) {
+                    m_pullIndicatorLabel->setVisibility(brls::Visibility::GONE);
+                }
             }
         },
         brls::PanAxis::VERTICAL));
 
     this->addView(topRow);
+
+    // Pull-to-refresh indicator label (hidden by default, shown during swipe-down gesture)
+    m_pullIndicatorLabel = new brls::Label();
+    m_pullIndicatorLabel->setText("Pull down to update");
+    m_pullIndicatorLabel->setFontSize(16);
+    m_pullIndicatorLabel->setTextColor(nvgRGBA(150, 150, 150, 255));
+    m_pullIndicatorLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
+    m_pullIndicatorLabel->setMarginTop(2);
+    m_pullIndicatorLabel->setMarginBottom(4);
+    m_pullIndicatorLabel->setVisibility(brls::Visibility::GONE);
+    this->addView(m_pullIndicatorLabel);
 
     // Content grid
     m_contentGrid = new RecyclingGrid();
@@ -1386,11 +1418,36 @@ void LibrarySectionTab::triggerLibraryUpdate() {
     int categoryId = m_currentCategoryId;
     int generation = ++m_updatePollGeneration;
 
-    asyncRun([categoryId, aliveWeak, generation, this]() {
+    // For BY_SOURCE mode: collect category IDs from the current source's manga
+    // so we only update categories that contain this source's books
+    std::vector<int> sourceCategoryIds;
+    if (m_groupMode == LibraryGroupMode::BY_SOURCE && !m_currentSourceName.empty()) {
+        auto it = m_mangaBySource.find(m_currentSourceName);
+        if (it != m_mangaBySource.end()) {
+            std::set<int> uniqueCatIds;
+            for (const auto& manga : it->second) {
+                if (manga.categoryIds.empty()) {
+                    uniqueCatIds.insert(0);  // Default category
+                } else {
+                    for (int catId : manga.categoryIds) {
+                        uniqueCatIds.insert(catId);
+                    }
+                }
+            }
+            sourceCategoryIds.assign(uniqueCatIds.begin(), uniqueCatIds.end());
+            brls::Logger::info("LibrarySectionTab: BY_SOURCE update for '{}' - {} categories",
+                              m_currentSourceName, sourceCategoryIds.size());
+        }
+    }
+
+    asyncRun([categoryId, sourceCategoryIds, aliveWeak, generation, this]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
 
         bool success = false;
-        if (categoryId == 0) {
+        if (!sourceCategoryIds.empty()) {
+            // BY_SOURCE mode: update only the categories containing this source's manga
+            success = client.triggerLibraryUpdate(sourceCategoryIds);
+        } else if (categoryId == 0) {
             success = client.triggerLibraryUpdate();
         } else {
             success = client.triggerLibraryUpdate(categoryId);


### PR DESCRIPTION
Fix source-grouped update to only update that source's categories and add pull-to-refresh indicator

When grouped by source, the update button now collects category IDs from
the selected source's manga and only triggers updates for those specific
categories instead of updating the entire library. Also adds a visual
pull-to-refresh indicator label on the category tabs row that shows
"Pull down to update" / "Release to update" during swipe-down gestures,
disappearing when scrolling back up or releasing.

---
_Generated by [Claude Code](https://claude.ai/code)_