### PR TITLE
Fix focus steal when loading new pages in browser tab

### DIFF
--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -1258,9 +1258,6 @@ void SearchTab::loadNextPage() {
                 m_hasNextPage = hasNextPage;
                 m_contentGrid->appendItems(manga);
                 m_resultsLabel->setText(std::to_string(m_mangaList.size()) + " manga");
-
-                // Focus on first newly loaded item so user can continue browsing
-                m_contentGrid->focusIndex(firstNewItemIndex);
                 m_isLoadingPage = false;
                 hideLoadingIndicator();
             });

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -277,20 +277,26 @@ void SourceBrowseTab::loadManga(int focusIndexAfterLoad) {
 
             m_isLoadingPage = false;
             if (success) {
-                // Append new manga to list
-                for (const auto& manga : newManga) {
-                    m_mangaList.push_back(manga);
-                }
                 m_hasNextPage = hasNext;
-                updateGrid();
-                updateLoadMoreButton();
 
-                // Focus on first newly loaded item (or first item for initial load)
-                if (focusIndexAfterLoad >= 0) {
-                    m_contentGrid->focusIndex(focusIndexAfterLoad);
-                } else if (!m_mangaList.empty()) {
-                    m_contentGrid->focusIndex(0);
+                if (focusIndexAfterLoad > 0) {
+                    // Subsequent page: append new items without rebuilding existing cells
+                    // This preserves the user's current focus position (no focus steal)
+                    for (const auto& manga : newManga) {
+                        m_mangaList.push_back(manga);
+                    }
+                    m_contentGrid->appendItems(newManga);
+                } else {
+                    // First page: full rebuild
+                    for (const auto& manga : newManga) {
+                        m_mangaList.push_back(manga);
+                    }
+                    updateGrid();
+                    if (!m_mangaList.empty()) {
+                        m_contentGrid->focusIndex(0);
+                    }
                 }
+                updateLoadMoreButton();
             } else {
                 brls::Application::notify("Failed to load manga");
                 // Reset load more button text on failure


### PR DESCRIPTION
Fixes focus being stolen when new pages load in the browser and search tabs.

---
_Generated by [Claude Code](https://claude.ai/code)_