### PR TITLE
Fix chapters not loading for non-library manga from sources tab

### DIFF
--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -608,6 +608,7 @@ private:
     bool fetchChaptersGraphQL(int mangaId, std::vector<Chapter>& chapters);
     bool fetchMangaGraphQL(int mangaId, Manga& manga);
     bool refreshMangaGraphQL(int mangaId);  // fetchManga mutation - tells server to fetch from source
+    bool refreshChaptersGraphQL(int mangaId);  // fetchChapters mutation - tells server to fetch chapters from source
     bool fetchServerInfoGraphQL(ServerInfo& info);
     bool addMangaToLibraryGraphQL(int mangaId);
     bool removeMangaFromLibraryGraphQL(int mangaId);

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -607,6 +607,7 @@ private:
     bool fetchCategoriesGraphQL(std::vector<Category>& categories);
     bool fetchChaptersGraphQL(int mangaId, std::vector<Chapter>& chapters);
     bool fetchMangaGraphQL(int mangaId, Manga& manga);
+    bool refreshMangaGraphQL(int mangaId);  // fetchManga mutation - tells server to fetch from source
     bool fetchServerInfoGraphQL(ServerInfo& info);
     bool addMangaToLibraryGraphQL(int mangaId);
     bool removeMangaFromLibraryGraphQL(int mangaId);

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1149,6 +1149,30 @@ bool SuwayomiClient::refreshMangaGraphQL(int mangaId) {
     return !response.empty() && response.find("\"id\"") != std::string::npos;
 }
 
+bool SuwayomiClient::refreshChaptersGraphQL(int mangaId) {
+    const char* query = R"(
+        mutation FetchChapters($id: Int!) {
+            fetchChapters(input: { id: $id }) {
+                chapters {
+                    id
+                }
+            }
+        }
+    )";
+
+    std::string variables = "{\"id\":" + std::to_string(mangaId) + "}";
+    brls::Logger::info("GraphQL: Fetching chapters from source for manga {} (fetchChapters mutation)", mangaId);
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::warning("GraphQL: fetchChapters mutation returned empty response for manga {}", mangaId);
+        return false;
+    }
+    // Check for successful response
+    bool success = response.find("\"fetchChapters\"") != std::string::npos;
+    brls::Logger::info("GraphQL: fetchChapters mutation for manga {} {}", mangaId, success ? "succeeded" : "failed");
+    return success;
+}
+
 bool SuwayomiClient::addMangaToLibraryGraphQL(int mangaId) {
     const char* query = R"(
         mutation AddToLibrary($id: Int!) {
@@ -1980,14 +2004,17 @@ bool SuwayomiClient::fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, st
     }
 
     // If 0 chapters returned, the server may not have fetched them from the source yet.
-    // Use the fetchManga mutation to tell the server to initialize/refresh the manga,
+    // Use fetchChapters mutation to tell the server to fetch chapter list from source,
     // then re-query chapters.
     if (chapters.empty() && manga.id > 0) {
-        brls::Logger::info("GraphQL combined: 0 chapters for manga {} - triggering fetchManga mutation to fetch from source", mangaId);
-        if (refreshMangaGraphQL(mangaId)) {
+        brls::Logger::info("GraphQL combined: 0 chapters for manga {} - triggering fetchChapters mutation to fetch from source", mangaId);
+        // First ensure manga is initialized
+        refreshMangaGraphQL(mangaId);
+        // Then fetch chapters from source
+        if (refreshChaptersGraphQL(mangaId)) {
             // Re-fetch chapters now that the server has scraped them
             fetchChaptersGraphQL(mangaId, chapters);
-            brls::Logger::info("GraphQL combined: After fetchManga mutation, got {} chapters", chapters.size());
+            brls::Logger::info("GraphQL combined: After fetchChapters mutation, got {} chapters", chapters.size());
         }
     }
 
@@ -3325,12 +3352,13 @@ bool SuwayomiClient::fetchChapters(int mangaId, std::vector<Chapter>& chapters) 
     // Try GraphQL first (primary API)
     if (fetchChaptersGraphQL(mangaId, chapters)) {
         // If 0 chapters, the server may not have fetched from source yet.
-        // Trigger fetchManga mutation to initialize, then re-query.
+        // Trigger fetchChapters mutation to fetch chapter list from source, then re-query.
         if (chapters.empty()) {
-            brls::Logger::info("fetchChapters: 0 chapters for manga {} - triggering fetchManga mutation", mangaId);
-            if (refreshMangaGraphQL(mangaId)) {
+            brls::Logger::info("fetchChapters: 0 chapters for manga {} - triggering fetchChapters mutation", mangaId);
+            refreshMangaGraphQL(mangaId);  // Ensure manga is initialized first
+            if (refreshChaptersGraphQL(mangaId)) {
                 fetchChaptersGraphQL(mangaId, chapters);
-                brls::Logger::info("fetchChapters: After fetchManga mutation, got {} chapters", chapters.size());
+                brls::Logger::info("fetchChapters: After fetchChapters mutation, got {} chapters", chapters.size());
             }
         }
         return true;

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1131,6 +1131,24 @@ bool SuwayomiClient::fetchMangaGraphQL(int mangaId, Manga& manga) {
     return true;
 }
 
+bool SuwayomiClient::refreshMangaGraphQL(int mangaId) {
+    const char* query = R"(
+        mutation RefreshManga($id: Int!) {
+            fetchManga(input: { id: $id }) {
+                manga {
+                    id
+                    initialized
+                }
+            }
+        }
+    )";
+
+    std::string variables = "{\"id\":" + std::to_string(mangaId) + "}";
+    brls::Logger::info("GraphQL: Refreshing manga {} from source (fetchManga mutation)", mangaId);
+    std::string response = executeGraphQL(query, variables);
+    return !response.empty() && response.find("\"id\"") != std::string::npos;
+}
+
 bool SuwayomiClient::addMangaToLibraryGraphQL(int mangaId) {
     const char* query = R"(
         mutation AddToLibrary($id: Int!) {
@@ -1959,6 +1977,18 @@ bool SuwayomiClient::fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, st
             chapters.push_back(ch);
         }
         brls::Logger::debug("GraphQL combined: Fetched {} chapters for manga {}", chapters.size(), mangaId);
+    }
+
+    // If 0 chapters returned, the server may not have fetched them from the source yet.
+    // Use the fetchManga mutation to tell the server to initialize/refresh the manga,
+    // then re-query chapters.
+    if (chapters.empty() && manga.id > 0) {
+        brls::Logger::info("GraphQL combined: 0 chapters for manga {} - triggering fetchManga mutation to fetch from source", mangaId);
+        if (refreshMangaGraphQL(mangaId)) {
+            // Re-fetch chapters now that the server has scraped them
+            fetchChaptersGraphQL(mangaId, chapters);
+            brls::Logger::info("GraphQL combined: After fetchManga mutation, got {} chapters", chapters.size());
+        }
     }
 
     return manga.id > 0;
@@ -3294,6 +3324,15 @@ std::string SuwayomiClient::getMangaThumbnailUrl(int mangaId) {
 bool SuwayomiClient::fetchChapters(int mangaId, std::vector<Chapter>& chapters) {
     // Try GraphQL first (primary API)
     if (fetchChaptersGraphQL(mangaId, chapters)) {
+        // If 0 chapters, the server may not have fetched from source yet.
+        // Trigger fetchManga mutation to initialize, then re-query.
+        if (chapters.empty()) {
+            brls::Logger::info("fetchChapters: 0 chapters for manga {} - triggering fetchManga mutation", mangaId);
+            if (refreshMangaGraphQL(mangaId)) {
+                fetchChaptersGraphQL(mangaId, chapters);
+                brls::Logger::info("fetchChapters: After fetchManga mutation, got {} chapters", chapters.size());
+            }
+        }
         return true;
     }
 

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1151,8 +1151,8 @@ bool SuwayomiClient::refreshMangaGraphQL(int mangaId) {
 
 bool SuwayomiClient::refreshChaptersGraphQL(int mangaId) {
     const char* query = R"(
-        mutation FetchChapters($id: Int!) {
-            fetchChapters(input: { id: $id }) {
+        mutation FetchChapters($mangaId: Int!) {
+            fetchChapters(input: { mangaId: $mangaId }) {
                 chapters {
                     id
                 }
@@ -1160,7 +1160,7 @@ bool SuwayomiClient::refreshChaptersGraphQL(int mangaId) {
         }
     )";
 
-    std::string variables = "{\"id\":" + std::to_string(mangaId) + "}";
+    std::string variables = "{\"mangaId\":" + std::to_string(mangaId) + "}";
     brls::Logger::info("GraphQL: Fetching chapters from source for manga {} (fetchChapters mutation)", mangaId);
     std::string response = executeGraphQL(query, variables);
     if (response.empty()) {


### PR DESCRIPTION
Fixes chapters not loading for non-library manga from the sources tab by using the `fetchChapters` mutation (with the correct input field name) instead of `fetchManga`.

---
_Generated by [Claude Code](https://claude.ai/code)_