### PR TITLE
Fix oversized image pre-check triggering global OOM cooldown

### DIFF
--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -1113,7 +1113,9 @@ static std::vector<uint8_t> convertImageToTGA(const uint8_t* data, size_t dataSi
             if (rgbaBytes > 32 * 1024 * 1024) {
                 brls::Logger::warning("ImageLoader: Image too large to decode ({}x{} = {}MB RGBA), skipping",
                                       preW, preH, rgbaBytes / (1024 * 1024));
-                signalOOM("convertImageToTGA pre-check");
+                // Don't signalOOM here — this is a pre-check rejection, not an
+                // actual memory failure.  Triggering the global OOM cooldown
+                // would block all other (smaller) image loads for 60 frames.
                 return tgaData;
             }
         }


### PR DESCRIPTION
Fix oversized image pre-check triggering global OOM cooldown

The pre-check in convertImageToTGA() was calling signalOOM() when it
detected an image too large to decode (e.g. 3287x4096 thumbnail).
This triggered a 60-frame global cooldown that blocked ALL other image
loads — even small ones that would decode fine. The pre-check is just
rejecting one oversized image, not an actual memory failure, so it
should not suppress other loads.

---
_Generated by [Claude Code](https://claude.ai/code)_