### PR TITLE
Improve manga reader swipe: velocity flick, time-based animation, symmetric preload

### DIFF
--- a/include/activity/reader_activity.hpp
+++ b/include/activity/reader_activity.hpp
@@ -206,6 +206,12 @@ private:
     brls::Point m_touchStart;
     brls::Point m_touchCurrent;
 
+    // Swipe velocity tracking for flick-to-turn
+    std::chrono::steady_clock::time_point m_swipeStartTime;
+    brls::Point m_lastVelocityPos;
+    std::chrono::steady_clock::time_point m_lastVelocityTime;
+    float m_swipeVelocity = 0.0f;  // pixels/second at release
+
     // 3-page carousel swipe: positive side + current + negative side
     // "Positive" = revealed when swiping positive (right/down on screen)
     // "Negative" = revealed when swiping negative (left/up on screen)
@@ -232,6 +238,8 @@ private:
     bool m_completionTurnPage = false;    // whether to finalize page turn at end
     bool m_completionNavChapter = false;  // whether to navigate chapters after animation
     bool m_completionNavNext = false;     // true = next chapter, false = previous
+    std::chrono::steady_clock::time_point m_completionStartTime;  // For time-based easing
+    float m_completionStartOffset = 0.0f; // Offset when animation started
     void animateSwipeCompletion();        // per-frame step, called via brls::sync
     void finalizePageTurn();              // called when animation reaches target
 

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -193,6 +193,7 @@ struct AppSettings {
     bool autoDownloadChapters = false;
     bool deleteAfterRead = false;
     bool autoResumeDownloads = true;  // Auto-resume queued downloads on app restart
+    bool pageCacheEnabled = true;     // Cache decoded TGA pages to disk for instant loading
 
     // Source/Browse Settings
     std::set<std::string> enabledSourceLanguages;  // Empty = all languages, otherwise filter by these (e.g. "en", "multi")

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -232,10 +232,11 @@ private:
     // instead of the slower libwebp decoder.  No-op for non-WebP files.
     bool convertWebPToJpeg(const std::string& filePath);
 
-    // Pre-convert a downloaded page to TGA and save to page cache so the
+    // Pre-convert a downloaded page to TGA in the downloads folder so the
     // reader can load it instantly without any decode step.
+    // Updates filePath to the new .tga path on success.
     void preConvertToPageCache(int mangaId, int chapterIndex, int pageIndex,
-                               const std::string& filePath);
+                               std::string& filePath);
 
     // Internal save without locking (caller must hold m_mutex)
     void saveStateUnlocked();

--- a/include/app/downloads_manager.hpp
+++ b/include/app/downloads_manager.hpp
@@ -232,6 +232,11 @@ private:
     // instead of the slower libwebp decoder.  No-op for non-WebP files.
     bool convertWebPToJpeg(const std::string& filePath);
 
+    // Pre-convert a downloaded page to TGA and save to page cache so the
+    // reader can load it instantly without any decode step.
+    void preConvertToPageCache(int mangaId, int chapterIndex, int pageIndex,
+                               const std::string& filePath);
+
     // Internal save without locking (caller must hold m_mutex)
     void saveStateUnlocked();
 

--- a/include/utils/library_cache.hpp
+++ b/include/utils/library_cache.hpp
@@ -48,6 +48,13 @@ public:
     bool hasCoverCache(int mangaId);
     std::string getCoverCachePath(int mangaId);
 
+    // Reader page image caching (decoded TGA data cached to disk)
+    bool savePageImage(int mangaId, int chapterId, int pageIndex, const std::vector<uint8_t>& imageData);
+    bool loadPageImage(int mangaId, int chapterId, int pageIndex, std::vector<uint8_t>& imageData);
+    bool hasPageCache(int mangaId, int chapterId, int pageIndex);
+    void clearPageCache();  // Clear all cached pages
+    void clearPageCache(int mangaId);  // Clear pages for a specific manga
+
     // Reading history caching
     bool saveHistory(const std::vector<ReadingHistoryItem>& history);
     bool loadHistory(std::vector<ReadingHistoryItem>& history);
@@ -87,6 +94,8 @@ private:
     std::string getAllLibraryFilePath();
     std::string getMangaDetailsFilePath(int mangaId);
     bool ensureDirectoryExists(const std::string& path);
+    std::string getPageCacheDir();
+    std::string getPageCachePath(int mangaId, int chapterId, int pageIndex);
 
     // Serialize/deserialize manga (basic - for category lists)
     std::string serializeManga(const Manga& manga);
@@ -116,6 +125,7 @@ private:
     bool m_initialized = false;
     std::mutex m_mutex;       // Protects metadata operations (categories, manga lists, details)
     std::mutex m_coverMutex;  // Separate mutex for cover image I/O (allows parallel reads by worker threads)
+    std::mutex m_pageMutex;   // Separate mutex for page image I/O
 };
 
 } // namespace vitasuwayomi

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1329,6 +1329,13 @@ void ReaderActivity::loadPages() {
                 loadedFromLocal = true;
                 *sharedLoadedFromLocal = true;
 
+                // Eagerly preload the first few local pages on the worker threads
+                // so decode starts immediately, before the UI callback fires.
+                // This significantly reduces perceived first-page load time.
+                for (size_t pi = 0; pi < std::min(rawPages.size(), static_cast<size_t>(3)); pi++) {
+                    ImageLoader::preloadFullSize(rawPages[pi].imageUrl);
+                }
+
                 // Use DownloadsManager metadata for chapter navigation instead of
                 // blocking on network requests. This makes downloaded chapters load
                 // instantly without waiting for server round-trips.

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -3226,7 +3226,7 @@ void ReaderActivity::updateSwipePreview(float offset) {
 
     // Debug: log slide positions once when swipe first starts or direction changes
     static int s_lastLoggedOffset = -99999;
-    int roundedOffset = static_cast<int>(offset / 50) * 50;  // log every ~50px
+    int roundedOffset = static_cast<int>(offset / 150) * 150;  // log every ~150px
     if (roundedOffset != s_lastLoggedOffset) {
         s_lastLoggedOffset = roundedOffset;
         brls::Logger::info("SWIPE offset={:.0f} rot={} vert={} extent={:.0f} | "

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -487,6 +487,11 @@ void ReaderActivity::onContentAvailable() {
                     m_swipeToChapter = false;
                     m_previewIsTransition = false;
                     m_swipingToNext = true;
+                    // Velocity tracking for flick-to-turn
+                    m_swipeStartTime = std::chrono::steady_clock::now();
+                    m_lastVelocityPos = status.position;
+                    m_lastVelocityTime = m_swipeStartTime;
+                    m_swipeVelocity = 0.0f;
                     brls::Logger::info("PAN START rot={} vert={} invert={} page={}/{}",
                         static_cast<int>(m_settings.rotation), useVerticalSwipe,
                         invertDirection, m_currentPage, static_cast<int>(m_pages.size()));
@@ -566,6 +571,18 @@ void ReaderActivity::onContentAvailable() {
 
                         // Update visual positions - all 3 pages slide together
                         updateSwipePreview(scaledDelta);
+
+                        // Track velocity: use last ~50ms of movement for release speed
+                        auto now = std::chrono::steady_clock::now();
+                        auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastVelocityTime).count();
+                        if (dt > 30) {
+                            float lastDelta = useVerticalSwipe ?
+                                (m_touchCurrent.y - m_lastVelocityPos.y) :
+                                (m_touchCurrent.x - m_lastVelocityPos.x);
+                            m_swipeVelocity = (dt > 0) ? (std::abs(lastDelta) * 1000.0f / dt) : 0.0f;
+                            m_lastVelocityPos = m_touchCurrent;
+                            m_lastVelocityTime = now;
+                        }
                     }
                 } else if (status.state == brls::GestureState::END) {
                     // Don't turn the page if we were just pinch-zooming
@@ -598,17 +615,26 @@ void ReaderActivity::onContentAvailable() {
                         // Complete swipe animation - use raw delta for threshold
                         float absSwipe = std::abs(rawDelta);
 
+                        // Allow page turn via either distance OR velocity (flick gesture).
+                        // A fast flick (>600 px/s) that moved at least 30px should turn
+                        // the page even if it didn't reach the full 80px threshold.
+                        const float FLICK_VELOCITY_THRESHOLD = 600.0f;  // px/sec
+                        const float FLICK_MIN_DISTANCE = 30.0f;        // minimum travel for flick
+                        bool isFlick = m_swipeVelocity >= FLICK_VELOCITY_THRESHOLD &&
+                                       absSwipe >= FLICK_MIN_DISTANCE;
+                        bool distanceMet = absSwipe >= PAGE_TURN_THRESHOLD;
+
                         bool hasValidPreview = m_previewPageIndex >= 0 &&
                             m_previewPageIndex < static_cast<int>(m_pages.size());
-                        if (absSwipe >= PAGE_TURN_THRESHOLD && (hasValidPreview || m_swipeToChapter)) {
-                            // Swipe was long enough - turn the page
+                        if ((distanceMet || isFlick) && (hasValidPreview || m_swipeToChapter)) {
+                            // Swipe was long enough or fast enough - turn the page
                             completeSwipeAnimation(true);
-                        } else if (absSwipe >= PAGE_TURN_THRESHOLD) {
+                        } else if (distanceMet || isFlick) {
                             // No valid preview in that direction — on a transition page
                             // this triggers chapter navigation, otherwise just snap back
                             completeSwipeAnimation(isTransitionPage(m_currentPage));
                         } else {
-                            // Swipe too short - snap back
+                            // Swipe too short and too slow - snap back
                             completeSwipeAnimation(false);
                         }
                     } else {
@@ -752,6 +778,11 @@ void ReaderActivity::onContentAvailable() {
                     m_swipeToChapter = false;
                     m_previewIsTransition = false;
                     m_swipingToNext = true;  // reset to avoid stale direction
+                    // Velocity tracking for flick-to-turn
+                    m_swipeStartTime = std::chrono::steady_clock::now();
+                    m_lastVelocityPos = status.position;
+                    m_lastVelocityTime = m_swipeStartTime;
+                    m_swipeVelocity = 0.0f;
                     brls::Logger::info("TSWIPE START: page={}/{} url={}",
                         m_currentPage, static_cast<int>(m_pages.size()),
                         m_currentPage < static_cast<int>(m_pages.size()) ? m_pages[m_currentPage].imageUrl : "?");
@@ -832,6 +863,18 @@ void ReaderActivity::onContentAvailable() {
                         }
 
                         updateSwipePreview(scaledDelta);
+
+                        // Track velocity for flick detection
+                        auto now = std::chrono::steady_clock::now();
+                        auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastVelocityTime).count();
+                        if (dt > 30) {
+                            float lastDelta = useVerticalSwipe ?
+                                (m_touchCurrent.y - m_lastVelocityPos.y) :
+                                (m_touchCurrent.x - m_lastVelocityPos.x);
+                            m_swipeVelocity = (dt > 0) ? (std::abs(lastDelta) * 1000.0f / dt) : 0.0f;
+                            m_lastVelocityPos = m_touchCurrent;
+                            m_lastVelocityTime = now;
+                        }
                     }
                 } else if (status.state == brls::GestureState::END) {
                     if (m_pages.empty()) {
@@ -853,11 +896,19 @@ void ReaderActivity::onContentAvailable() {
                         resetSwipeState();
                     } else if (m_isSwipeAnimating) {
                         float absSwipe = std::abs(rawDelta);
+
+                        // Velocity-based flick detection (same as pageImage handler)
+                        const float FLICK_VELOCITY_THRESHOLD = 600.0f;
+                        const float FLICK_MIN_DISTANCE = 30.0f;
+                        bool isFlick = m_swipeVelocity >= FLICK_VELOCITY_THRESHOLD &&
+                                       absSwipe >= FLICK_MIN_DISTANCE;
+                        bool distanceMet = absSwipe >= PAGE_TURN_THRESHOLD;
+
                         bool hasValidPreview = m_previewPageIndex >= 0 &&
                             m_previewPageIndex < static_cast<int>(m_pages.size());
-                        if (absSwipe >= PAGE_TURN_THRESHOLD && (hasValidPreview || m_swipeToChapter)) {
+                        if ((distanceMet || isFlick) && (hasValidPreview || m_swipeToChapter)) {
                             completeSwipeAnimation(true);
-                        } else if (absSwipe >= PAGE_TURN_THRESHOLD) {
+                        } else if (distanceMet || isFlick) {
                             // No preview page in that direction — on a transition page
                             // this triggers chapter navigation, otherwise just snap back
                             completeSwipeAnimation(true);
@@ -1583,19 +1634,19 @@ void ReaderActivity::loadPage(int index) {
 }
 
 void ReaderActivity::preloadAdjacentPages() {
-    // Preload next 2 pages for smoother swiping/reading.
-    // Reduced from 3 to 2 to lower peak memory usage — each page can be
-    // 2+ MB (animated WebP) and the Vita's RAM is very limited.
+    // Preload 2 pages ahead and 2 pages behind for smoother swiping in
+    // both directions. This prevents blank frames when swiping backward
+    // through previously-read pages. The Vita's 20MB LRU cache evicts
+    // the oldest entries, so this won't exceed memory limits.
     for (int i = 1; i <= 2; i++) {
         int nextIdx = m_currentPage + i;
         if (nextIdx < static_cast<int>(m_pages.size()) && !isTransitionPage(nextIdx)) {
             ImageLoader::preloadFullSize(m_pages[nextIdx].imageUrl);
         }
-    }
-
-    // Preload previous page (for going back)
-    if (m_currentPage > 0 && !isTransitionPage(m_currentPage - 1)) {
-        ImageLoader::preloadFullSize(m_pages[m_currentPage - 1].imageUrl);
+        int prevIdx = m_currentPage - i;
+        if (prevIdx >= 0 && !isTransitionPage(prevIdx)) {
+            ImageLoader::preloadFullSize(m_pages[prevIdx].imageUrl);
+        }
     }
 }
 
@@ -3491,6 +3542,14 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
         turnPage, m_swipeToChapter, m_previewIsTransition,
         m_previewPageIndex, m_swipingToNext, m_currentPage);
 
+    // Helper: start the completion animation with time-based easing
+    auto startAnimation = [this]() {
+        m_completionStartTime = std::chrono::steady_clock::now();
+        m_completionStartOffset = m_completionOffset;
+        m_completionAnimating = true;
+        animateSwipeCompletion();
+    };
+
     // Determine target offset for slide animation
     // Use actual view dimensions, not physical screen dimensions
     bool useVerticalSwipe = (m_settings.rotation == ImageRotation::ROTATE_90 ||
@@ -3508,8 +3567,7 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
         m_completionTurnPage = false;
         m_completionNavChapter = true;
         m_completionNavNext = m_swipingToNext;
-        m_completionAnimating = true;
-        animateSwipeCompletion();
+        startAnimation();
         return;
     }
 
@@ -3521,8 +3579,7 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
         m_completionTarget = target;
         m_completionTurnPage = true;
         m_completionNavChapter = false;
-        m_completionAnimating = true;
-        animateSwipeCompletion();
+        startAnimation();
         return;
     }
 
@@ -3550,8 +3607,7 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
             m_completionTurnPage = false;
             m_completionNavChapter = true;
             m_completionNavNext = navNext;
-            m_completionAnimating = true;
-            animateSwipeCompletion();
+            startAnimation();
             return;
         }
     }
@@ -3561,17 +3617,30 @@ void ReaderActivity::completeSwipeAnimation(bool turnPage) {
     m_completionTarget = 0.0f;
     m_completionTurnPage = false;
     m_completionNavChapter = false;
-    m_completionAnimating = true;
-    animateSwipeCompletion();
+    startAnimation();
 }
 
 void ReaderActivity::animateSwipeCompletion() {
     if (!m_completionAnimating) return;
     if (m_alive && !*m_alive) { m_completionAnimating = false; return; }
 
-    float diff = m_completionTarget - m_completionOffset;
-    if (std::abs(diff) < 3.0f) {
-        // Close enough to target — finalize
+    // Time-based ease-out animation (frame-rate independent).
+    // Uses a fixed duration so the animation feels the same at 30fps and 60fps.
+    constexpr float ANIM_DURATION_MS = 180.0f;  // Total animation time
+    auto now = std::chrono::steady_clock::now();
+    float elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        now - m_completionStartTime).count() / 1000.0f;
+    float t = std::min(1.0f, elapsed / ANIM_DURATION_MS);
+
+    // Ease-out cubic: starts fast, decelerates smoothly
+    float eased = 1.0f - (1.0f - t) * (1.0f - t) * (1.0f - t);
+
+    m_completionOffset = m_completionStartOffset +
+        (m_completionTarget - m_completionStartOffset) * eased;
+    updateSwipePreview(m_completionOffset);
+
+    if (t >= 1.0f) {
+        // Animation complete — finalize
         m_completionAnimating = false;
         if (m_completionNavChapter) {
             // Chapter navigation after slide animation
@@ -3590,10 +3659,6 @@ void ReaderActivity::animateSwipeCompletion() {
         }
         return;
     }
-
-    // Ease toward target (~30% of remaining distance per frame)
-    m_completionOffset += diff * 0.3f;
-    updateSwipePreview(m_completionOffset);
 
     // Schedule next frame
     std::weak_ptr<bool> aliveWeak = m_alive;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1396,6 +1396,7 @@ bool Application::loadSettings() {
     m_settings.autoDownloadChapters = extractBool("autoDownloadChapters", false);
     m_settings.deleteAfterRead = extractBool("deleteAfterRead", false);
     m_settings.autoResumeDownloads = extractBool("autoResumeDownloads", true);
+    m_settings.pageCacheEnabled = extractBool("pageCacheEnabled", true);
 
     // Load browse/source settings
     m_settings.showNsfwSources = extractBool("showNsfwSources", false);
@@ -1801,6 +1802,7 @@ bool Application::saveSettings() {
     json += "  \"autoDownloadChapters\": " + std::string(m_settings.autoDownloadChapters ? "true" : "false") + ",\n";
     json += "  \"deleteAfterRead\": " + std::string(m_settings.deleteAfterRead ? "true" : "false") + ",\n";
     json += "  \"autoResumeDownloads\": " + std::string(m_settings.autoResumeDownloads ? "true" : "false") + ",\n";
+    json += "  \"pageCacheEnabled\": " + std::string(m_settings.pageCacheEnabled ? "true" : "false") + ",\n";
 
     // Browse/Source settings
     json += "  \"showNsfwSources\": " + std::string(m_settings.showNsfwSources ? "true" : "false") + ",\n";

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -8,6 +8,7 @@
 #include "app/suwayomi_client.hpp"
 #include "utils/http_client.hpp"
 #include "utils/image_loader.hpp"
+#include "utils/library_cache.hpp"
 
 #include <borealis.hpp>
 #include <sstream>
@@ -1917,6 +1918,13 @@ bool DownloadsManager::downloadPage(int mangaId, int chapterIndex, int pageIndex
 
         // Process image quality if needed (resize/recompress)
         processImageQuality(localPath);
+
+        // Pre-convert to TGA and save to page cache so the reader loads
+        // downloaded pages instantly without any decode step at read time.
+        if (Application::getInstance().getSettings().pageCacheEnabled) {
+            preConvertToPageCache(mangaId, chapterIndex, pageIndex, localPath);
+        }
+
         brls::Logger::debug("DownloadsManager: Page {} downloaded successfully", pageIndex);
         return true;
     }
@@ -2087,6 +2095,90 @@ bool DownloadsManager::convertWebPToJpeg(const std::string& filePath) {
         brls::Logger::error("DownloadsManager: Failed to write JPEG for WebP conversion: {}", filePath);
     }
     return result != 0;
+}
+
+void DownloadsManager::preConvertToPageCache(int mangaId, int chapterIndex, int pageIndex,
+                                              const std::string& filePath) {
+    // Load the downloaded JPEG image
+    int w, h, channels;
+    unsigned char* rgba = stbi_load(filePath.c_str(), &w, &h, &channels, 4);
+    if (!rgba) {
+        brls::Logger::warning("DownloadsManager: Could not load image for TGA pre-conversion: {}", filePath);
+        return;
+    }
+
+    // Downscale to Vita display size (same as reader pipeline uses)
+    const int MAX_TEXTURE_SIZE = 1280;
+    int targetW = w;
+    int targetH = h;
+    if (w > MAX_TEXTURE_SIZE || h > MAX_TEXTURE_SIZE) {
+        float scale = (float)MAX_TEXTURE_SIZE / std::max(w, h);
+        targetW = std::max(1, (int)(w * scale));
+        targetH = std::max(1, (int)(h * scale));
+    }
+
+    // Build TGA: 18-byte header + BGRA pixel data
+    size_t pixelCount = (size_t)targetW * targetH;
+    std::vector<uint8_t> tgaData(18 + pixelCount * 4);
+
+    // TGA header
+    memset(tgaData.data(), 0, 18);
+    tgaData[2] = 2;  // Uncompressed true-color
+    tgaData[12] = targetW & 0xFF;
+    tgaData[13] = (targetW >> 8) & 0xFF;
+    tgaData[14] = targetH & 0xFF;
+    tgaData[15] = (targetH >> 8) & 0xFF;
+    tgaData[16] = 32;    // 32 bits per pixel
+    tgaData[17] = 0x28;  // Top-left origin + 8 alpha bits
+
+    uint8_t* dst = tgaData.data() + 18;
+
+    if (targetW != w || targetH != h) {
+        // Bilinear downscale + RGBA→BGRA swizzle
+        float xRatio = (float)w / targetW;
+        float yRatio = (float)h / targetH;
+        for (int y = 0; y < targetH; y++) {
+            float srcY = y * yRatio;
+            int sy0 = (int)srcY;
+            int sy1 = std::min(sy0 + 1, h - 1);
+            float fy = srcY - sy0;
+            for (int x = 0; x < targetW; x++) {
+                float srcX = x * xRatio;
+                int sx0 = (int)srcX;
+                int sx1 = std::min(sx0 + 1, w - 1);
+                float fx = srcX - sx0;
+
+                const uint8_t* p00 = rgba + (sy0 * w + sx0) * 4;
+                const uint8_t* p10 = rgba + (sy0 * w + sx1) * 4;
+                const uint8_t* p01 = rgba + (sy1 * w + sx0) * 4;
+                const uint8_t* p11 = rgba + (sy1 * w + sx1) * 4;
+
+                for (int c = 0; c < 4; c++) {
+                    float v = p00[c] * (1 - fx) * (1 - fy) + p10[c] * fx * (1 - fy) +
+                              p01[c] * (1 - fx) * fy + p11[c] * fx * fy;
+                    // RGBA→BGRA: swap R and B channels
+                    int dstC = (c == 0) ? 2 : (c == 2) ? 0 : c;
+                    dst[(y * targetW + x) * 4 + dstC] = (uint8_t)(v + 0.5f);
+                }
+            }
+        }
+    } else {
+        // No resize needed, just RGBA→BGRA swizzle
+        for (size_t i = 0; i < pixelCount; i++) {
+            dst[i * 4 + 0] = rgba[i * 4 + 2];  // B
+            dst[i * 4 + 1] = rgba[i * 4 + 1];  // G
+            dst[i * 4 + 2] = rgba[i * 4 + 0];  // R
+            dst[i * 4 + 3] = rgba[i * 4 + 3];  // A
+        }
+    }
+
+    stbi_image_free(rgba);
+
+    // Save to page cache
+    if (LibraryCache::getInstance().savePageImage(mangaId, chapterIndex, pageIndex, tgaData)) {
+        brls::Logger::info("DownloadsManager: Pre-converted page {} to TGA cache ({}x{}, {} bytes)",
+                          pageIndex, targetW, targetH, tgaData.size());
+    }
 }
 
 std::string DownloadsManager::createMangaDir(int mangaId, const std::string& title) {

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -8,7 +8,6 @@
 #include "app/suwayomi_client.hpp"
 #include "utils/http_client.hpp"
 #include "utils/image_loader.hpp"
-#include "utils/library_cache.hpp"
 
 #include <borealis.hpp>
 #include <sstream>
@@ -1919,11 +1918,10 @@ bool DownloadsManager::downloadPage(int mangaId, int chapterIndex, int pageIndex
         // Process image quality if needed (resize/recompress)
         processImageQuality(localPath);
 
-        // Pre-convert to TGA and save to page cache so the reader loads
+        // Pre-convert to TGA in the downloads folder so the reader loads
         // downloaded pages instantly without any decode step at read time.
-        if (Application::getInstance().getSettings().pageCacheEnabled) {
-            preConvertToPageCache(mangaId, chapterIndex, pageIndex, localPath);
-        }
+        // Replaces the JPEG with a GPU-ready TGA file and updates localPath.
+        preConvertToPageCache(mangaId, chapterIndex, pageIndex, localPath);
 
         brls::Logger::debug("DownloadsManager: Page {} downloaded successfully", pageIndex);
         return true;
@@ -2098,7 +2096,7 @@ bool DownloadsManager::convertWebPToJpeg(const std::string& filePath) {
 }
 
 void DownloadsManager::preConvertToPageCache(int mangaId, int chapterIndex, int pageIndex,
-                                              const std::string& filePath) {
+                                              std::string& filePath) {
     // Load the downloaded JPEG image
     int w, h, channels;
     unsigned char* rgba = stbi_load(filePath.c_str(), &w, &h, &channels, 4);
@@ -2174,10 +2172,41 @@ void DownloadsManager::preConvertToPageCache(int mangaId, int chapterIndex, int 
 
     stbi_image_free(rgba);
 
-    // Save to page cache
-    if (LibraryCache::getInstance().savePageImage(mangaId, chapterIndex, pageIndex, tgaData)) {
-        brls::Logger::info("DownloadsManager: Pre-converted page {} to TGA cache ({}x{}, {} bytes)",
-                          pageIndex, targetW, targetH, tgaData.size());
+    // Write TGA to downloads folder, replacing the JPEG.
+    // The reader detects TGA by header and does a zero-decode pass-through.
+    std::string tgaPath = filePath;
+    size_t dotPos = tgaPath.rfind('.');
+    if (dotPos != std::string::npos) {
+        tgaPath = tgaPath.substr(0, dotPos) + ".tga";
+    } else {
+        tgaPath += ".tga";
+    }
+
+    bool writeOk = false;
+#ifdef __vita__
+    SceUID fd = sceIoOpen(tgaPath.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+    if (fd >= 0) {
+        SceSSize written = sceIoWrite(fd, tgaData.data(), tgaData.size());
+        sceIoClose(fd);
+        writeOk = (written == (SceSSize)tgaData.size());
+    }
+#else
+    std::ofstream out(tgaPath, std::ios::binary);
+    if (out.is_open()) {
+        out.write(reinterpret_cast<const char*>(tgaData.data()), tgaData.size());
+        writeOk = out.good();
+        out.close();
+    }
+#endif
+
+    if (writeOk) {
+        // Delete the original JPEG now that TGA is saved
+        deleteFile(filePath);
+        filePath = tgaPath;  // Update so the download state records the .tga path
+        brls::Logger::info("DownloadsManager: Pre-converted page {} to TGA ({}x{}, {} bytes): {}",
+                          pageIndex, targetW, targetH, tgaData.size(), tgaPath);
+    } else {
+        brls::Logger::error("DownloadsManager: Failed to write TGA for page {}: {}", pageIndex, tgaPath);
     }
 }
 

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -147,32 +147,67 @@ static bool isUnderMemoryPressure() {
 // Returns true if all three values were extracted
 static bool extractPageUrlIds(const std::string& url, int& mangaId, int& chapterIdx, int& pageIdx) {
     mangaId = chapterIdx = pageIdx = -1;
+
+    // Try HTTP-style URL first: /manga/X/chapter/Y/page/Z
     size_t mPos = url.find("/manga/");
-    if (mPos == std::string::npos) return false;
-    mPos += 7;
-    size_t mEnd = url.find('/', mPos);
-    if (mEnd == std::string::npos) return false;
+    if (mPos != std::string::npos) {
+        mPos += 7;
+        size_t mEnd = url.find('/', mPos);
+        if (mEnd == std::string::npos) return false;
 
-    size_t cPos = url.find("/chapter/", mEnd);
-    if (cPos == std::string::npos) return false;
-    cPos += 9;
-    size_t cEnd = url.find('/', cPos);
-    if (cEnd == std::string::npos) return false;
+        size_t cPos = url.find("/chapter/", mEnd);
+        if (cPos == std::string::npos) return false;
+        cPos += 9;
+        size_t cEnd = url.find('/', cPos);
+        if (cEnd == std::string::npos) return false;
 
-    size_t pPos = url.find("/page/", cEnd);
-    if (pPos == std::string::npos) return false;
-    pPos += 6;
-    size_t pEnd = url.find('/', pPos);
-    if (pEnd == std::string::npos) pEnd = url.length();
+        size_t pPos = url.find("/page/", cEnd);
+        if (pPos == std::string::npos) return false;
+        pPos += 6;
+        size_t pEnd = url.find('/', pPos);
+        if (pEnd == std::string::npos) pEnd = url.length();
 
-    try {
-        mangaId = std::stoi(url.substr(mPos, mEnd - mPos));
-        chapterIdx = std::stoi(url.substr(cPos, cEnd - cPos));
-        pageIdx = std::stoi(url.substr(pPos, pEnd - pPos));
-        return true;
-    } catch (...) {
-        return false;
+        try {
+            mangaId = std::stoi(url.substr(mPos, mEnd - mPos));
+            chapterIdx = std::stoi(url.substr(cPos, cEnd - cPos));
+            pageIdx = std::stoi(url.substr(pPos, pEnd - pPos));
+            return true;
+        } catch (...) {
+            return false;
+        }
     }
+
+    // Try local download path: .../manga_X/chapter_Y/page_Z.ext
+    size_t lmPos = url.find("manga_");
+    if (lmPos != std::string::npos) {
+        lmPos += 6;
+        size_t lmEnd = url.find('/', lmPos);
+        if (lmEnd == std::string::npos) return false;
+
+        size_t lcPos = url.find("chapter_", lmEnd);
+        if (lcPos == std::string::npos) return false;
+        lcPos += 8;
+        size_t lcEnd = url.find('/', lcPos);
+        if (lcEnd == std::string::npos) return false;
+
+        size_t lpPos = url.find("page_", lcEnd);
+        if (lpPos == std::string::npos) return false;
+        lpPos += 5;
+        // Page index ends at '.' (extension) or end of string
+        size_t lpEnd = url.find('.', lpPos);
+        if (lpEnd == std::string::npos) lpEnd = url.length();
+
+        try {
+            mangaId = std::stoi(url.substr(lmPos, lmEnd - lmPos));
+            chapterIdx = std::stoi(url.substr(lcPos, lcEnd - lcPos));
+            pageIdx = std::stoi(url.substr(lpPos, lpEnd - lpPos));
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    return false;
 }
 
 // Helper to extract manga ID from thumbnail URL

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -2667,7 +2667,8 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
     // Check page disk cache before downloading (avoids network + expensive decode)
     int pageMangaId = -1, pageChapterIdx = -1, pagePageIdx = -1;
     bool hasPageIds = extractPageUrlIds(url, pageMangaId, pageChapterIdx, pagePageIdx);
-    if (hasPageIds && totalSegments <= 1) {
+    bool pageCacheOn = Application::getInstance().getSettings().pageCacheEnabled;
+    if (pageCacheOn && hasPageIds && totalSegments <= 1) {
         std::vector<uint8_t> diskData;
         if (LibraryCache::getInstance().loadPageImage(pageMangaId, pageChapterIdx, pagePageIdx, diskData)) {
             auto ioEndTime = std::chrono::steady_clock::now();
@@ -3206,7 +3207,7 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
         cachePut(cacheKey, imageData);
 
         // Save to page disk cache for instant loading next time
-        if (hasPageIds && totalSegments <= 1 && !imageData.empty()) {
+        if (pageCacheOn && hasPageIds && totalSegments <= 1 && !imageData.empty()) {
             LibraryCache::getInstance().savePageImage(pageMangaId, pageChapterIdx, pagePageIdx, imageData);
         }
 

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -142,6 +142,39 @@ static bool isUnderMemoryPressure() {
     return false;
 }
 
+// Helper to extract manga ID, chapter index, and page index from a reader page URL
+// URLs look like: http://server/api/v1/manga/622/chapter/75/page/0
+// Returns true if all three values were extracted
+static bool extractPageUrlIds(const std::string& url, int& mangaId, int& chapterIdx, int& pageIdx) {
+    mangaId = chapterIdx = pageIdx = -1;
+    size_t mPos = url.find("/manga/");
+    if (mPos == std::string::npos) return false;
+    mPos += 7;
+    size_t mEnd = url.find('/', mPos);
+    if (mEnd == std::string::npos) return false;
+
+    size_t cPos = url.find("/chapter/", mEnd);
+    if (cPos == std::string::npos) return false;
+    cPos += 9;
+    size_t cEnd = url.find('/', cPos);
+    if (cEnd == std::string::npos) return false;
+
+    size_t pPos = url.find("/page/", cEnd);
+    if (pPos == std::string::npos) return false;
+    pPos += 6;
+    size_t pEnd = url.find('/', pPos);
+    if (pEnd == std::string::npos) pEnd = url.length();
+
+    try {
+        mangaId = std::stoi(url.substr(mPos, mEnd - mPos));
+        chapterIdx = std::stoi(url.substr(cPos, cEnd - cPos));
+        pageIdx = std::stoi(url.substr(pPos, pEnd - pPos));
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 // Helper to extract manga ID from thumbnail URL
 // URLs look like: http://server/api/v1/manga/123/thumbnail or /api/v1/manga/123/thumbnail
 static int extractMangaIdFromUrl(const std::string& url) {
@@ -2596,6 +2629,28 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
 
     auto loadStartTime = std::chrono::steady_clock::now();
 
+    // Check page disk cache before downloading (avoids network + expensive decode)
+    int pageMangaId = -1, pageChapterIdx = -1, pagePageIdx = -1;
+    bool hasPageIds = extractPageUrlIds(url, pageMangaId, pageChapterIdx, pagePageIdx);
+    if (hasPageIds && totalSegments <= 1) {
+        std::vector<uint8_t> diskData;
+        if (LibraryCache::getInstance().loadPageImage(pageMangaId, pageChapterIdx, pagePageIdx, diskData)) {
+            auto ioEndTime = std::chrono::steady_clock::now();
+            auto ioMs = std::chrono::duration_cast<std::chrono::milliseconds>(ioEndTime - loadStartTime).count();
+            brls::Logger::info("ImageLoader: [TIMING] Disk cache hit {}ms for {} ({} bytes)",
+                              ioMs, url, diskData.size());
+
+            // Put in LRU memory cache too
+            std::string cacheKey = url + "_full";
+            cachePut(cacheKey, diskData);
+
+            if (target || callback) {
+                queueRotatableTextureUpdate(diskData, target, callback, alive);
+            }
+            return;
+        }
+    }
+
     std::string imageBody;
     bool loadSuccess = false;
 
@@ -2786,8 +2841,12 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
             return;
         }
 
-        // Convert images to TGA with size limit for Vita GPU (max texture 2048x2048)
-        const int MAX_TEXTURE_SIZE = 2048;
+        // Convert images to TGA with size limit optimized for Vita display.
+        // The Vita renders at 1280x726 internally, so anything larger than 1280
+        // on the longest dimension is wasted resolution. Using 1280 instead of 2048
+        // reduces decode time and memory significantly:
+        // e.g. 1125x1600 → 900x1280 (saves ~40% pixels, ~40% faster decode)
+        const int MAX_TEXTURE_SIZE = 1280;
 
         // Serialize decodes across all worker threads to prevent concurrent
         // multi-MB decode buffers from exhausting the Vita's memory.
@@ -2874,7 +2933,10 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
                                       static_cast<int>(imageBody.size()), &origW, &origH, &c);
             }
 
-            if (origW > 0 && origH > MAX_TEXTURE_SIZE) {
+            if (origW > 0 && origH > MAX_TEXTURE_SIZE * 2) {
+                // Only auto-split if image is MUCH taller than max (webtoon-style).
+                // For normal manga pages slightly taller than max, proportional
+                // scaling into a single texture is faster than multi-segment decode.
                 int autoSegments = (origH + MAX_TEXTURE_SIZE - 1) / MAX_TEXTURE_SIZE;
 
                 // VRAM budget: cap total texture memory per image to prevent GPU exhaustion.
@@ -3107,6 +3169,11 @@ void ImageLoader::executeRotatableLoad(const RotatableLoadRequest& request) {
             cacheKey += "_seg" + std::to_string(segment);
         }
         cachePut(cacheKey, imageData);
+
+        // Save to page disk cache for instant loading next time
+        if (hasPageIds && totalSegments <= 1 && !imageData.empty()) {
+            LibraryCache::getInstance().savePageImage(pageMangaId, pageChapterIdx, pagePageIdx, imageData);
+        }
 
         {
             auto decodeEndTime = std::chrono::steady_clock::now();

--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -50,6 +50,11 @@ bool LibraryCache::init() {
         return false;
     }
 
+    if (!ensureDirectoryExists(getPageCacheDir())) {
+        brls::Logger::error("LibraryCache: Failed to create page cache directory");
+        return false;
+    }
+
     m_initialized = true;
     brls::Logger::info("LibraryCache: Initialized at {}", getCacheDir());
     return true;
@@ -641,9 +646,170 @@ bool LibraryCache::hasCoverCache(int mangaId) {
 #endif
 }
 
+// --- Reader page image caching ---
+
+std::string LibraryCache::getPageCacheDir() {
+    return getCacheDir() + "/pages";
+}
+
+std::string LibraryCache::getPageCachePath(int mangaId, int chapterId, int pageIndex) {
+    return getPageCacheDir() + "/" + std::to_string(mangaId) + "_" +
+           std::to_string(chapterId) + "_" + std::to_string(pageIndex) + ".tga";
+}
+
+bool LibraryCache::savePageImage(int mangaId, int chapterId, int pageIndex, const std::vector<uint8_t>& imageData) {
+    if (imageData.empty()) return false;
+
+    std::lock_guard<std::mutex> lock(m_pageMutex);
+
+    // Ensure page cache directory exists
+    ensureDirectoryExists(getPageCacheDir());
+
+    std::string path = getPageCachePath(mangaId, chapterId, pageIndex);
+
+#ifdef __vita__
+    SceUID fd = sceIoOpen(path.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
+    if (fd < 0) return false;
+    sceIoWrite(fd, imageData.data(), imageData.size());
+    sceIoClose(fd);
+#else
+    std::ofstream file(path, std::ios::binary);
+    if (!file.is_open()) return false;
+    file.write(reinterpret_cast<const char*>(imageData.data()), imageData.size());
+    file.close();
+#endif
+
+    return true;
+}
+
+bool LibraryCache::loadPageImage(int mangaId, int chapterId, int pageIndex, std::vector<uint8_t>& imageData) {
+    std::lock_guard<std::mutex> lock(m_pageMutex);
+
+    std::string path = getPageCachePath(mangaId, chapterId, pageIndex);
+    imageData.clear();
+
+#ifdef __vita__
+    SceUID fd = sceIoOpen(path.c_str(), SCE_O_RDONLY, 0);
+    if (fd < 0) return false;
+
+    SceOff size = sceIoLseek(fd, 0, SCE_SEEK_END);
+    sceIoLseek(fd, 0, SCE_SEEK_SET);
+
+    if (size <= 18 || size > 16 * 1024 * 1024) {  // TGA must be > 18 bytes, max 16MB
+        sceIoClose(fd);
+        return false;
+    }
+
+    imageData.resize(size);
+    sceIoRead(fd, imageData.data(), size);
+    sceIoClose(fd);
+#else
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) return false;
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    if (size <= 18 || size > 16 * 1024 * 1024) return false;
+
+    imageData.resize(size);
+    file.read(reinterpret_cast<char*>(imageData.data()), size);
+    file.close();
+#endif
+
+    // Validate TGA header
+    if (imageData.size() > 18 &&
+        imageData[0] == 0 && imageData[1] == 0 &&
+        imageData[2] == 2 && imageData[16] == 32) {
+        return true;
+    }
+
+    // Invalid data, discard
+    imageData.clear();
+    return false;
+}
+
+bool LibraryCache::hasPageCache(int mangaId, int chapterId, int pageIndex) {
+    std::string path = getPageCachePath(mangaId, chapterId, pageIndex);
+
+#ifdef __vita__
+    SceIoStat stat;
+    return sceIoGetstat(path.c_str(), &stat) >= 0;
+#else
+    struct stat st;
+    return stat(path.c_str(), &st) == 0;
+#endif
+}
+
+void LibraryCache::clearPageCache() {
+    std::lock_guard<std::mutex> lock(m_pageMutex);
+    std::string dir = getPageCacheDir();
+
+#ifdef __vita__
+    SceUID dfd = sceIoDopen(dir.c_str());
+    if (dfd >= 0) {
+        SceIoDirent entry;
+        while (sceIoDread(dfd, &entry) > 0) {
+            if (strstr(entry.d_name, ".tga") != nullptr) {
+                std::string path = dir + "/" + entry.d_name;
+                sceIoRemove(path.c_str());
+            }
+        }
+        sceIoDclose(dfd);
+    }
+#else
+    DIR* d = opendir(dir.c_str());
+    if (d) {
+        struct dirent* dentry;
+        while ((dentry = readdir(d)) != nullptr) {
+            if (strstr(dentry->d_name, ".tga") != nullptr) {
+                std::string path = dir + "/" + dentry->d_name;
+                remove(path.c_str());
+            }
+        }
+        closedir(d);
+    }
+#endif
+
+    brls::Logger::info("LibraryCache: Page cache cleared");
+}
+
+void LibraryCache::clearPageCache(int mangaId) {
+    std::lock_guard<std::mutex> lock(m_pageMutex);
+    std::string dir = getPageCacheDir();
+    std::string prefix = std::to_string(mangaId) + "_";
+
+#ifdef __vita__
+    SceUID dfd = sceIoDopen(dir.c_str());
+    if (dfd >= 0) {
+        SceIoDirent entry;
+        while (sceIoDread(dfd, &entry) > 0) {
+            if (strncmp(entry.d_name, prefix.c_str(), prefix.size()) == 0) {
+                std::string path = dir + "/" + entry.d_name;
+                sceIoRemove(path.c_str());
+            }
+        }
+        sceIoDclose(dfd);
+    }
+#else
+    DIR* d = opendir(dir.c_str());
+    if (d) {
+        struct dirent* dentry;
+        while ((dentry = readdir(d)) != nullptr) {
+            if (strncmp(dentry->d_name, prefix.c_str(), prefix.size()) == 0) {
+                std::string path = dir + "/" + dentry->d_name;
+                remove(path.c_str());
+            }
+        }
+        closedir(d);
+    }
+#endif
+}
+
 void LibraryCache::clearAllCache() {
     clearLibraryCache();
     clearCoverCache();
+    clearPageCache();
 }
 
 void LibraryCache::clearLibraryCache() {

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -196,14 +196,6 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
     bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
 
     if (hasSlide) {
-        // Debug: log draw coords and slide offsets (throttled to avoid spam)
-        static int s_drawLogCounter = 0;
-        if ((s_drawLogCounter++ % 180) == 0) {  // ~every 3 seconds at 60fps
-            brls::Logger::info("DRAW slideX={:.0f} slideY={:.0f} x={:.0f} y={:.0f} "
-                "w={:.0f} h={:.0f} rot={:.0f} img={}x{}",
-                m_slideX, m_slideY, x, y, width, height,
-                m_rotationDegrees, m_imageWidth, m_imageHeight);
-        }
 
         // During swipe: clip in the SWIPE direction only to prevent pages
         // from overlapping each other. The cross-axis is left unclipped

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1154,9 +1154,9 @@ void SettingsTab::createDownloadsSection() {
     });
     m_contentBox->addView(autoResumeToggle);
 
-    // Page cache toggle
+    // Page cache toggle (caches decoded pages to disk for faster re-loading)
     auto* pageCacheToggle = new brls::BooleanCell();
-    pageCacheToggle->init("Page Cache", settings.pageCacheEnabled, [&settings](bool value) {
+    pageCacheToggle->init("Cache Read Pages", settings.pageCacheEnabled, [&settings](bool value) {
         settings.pageCacheEnabled = value;
         Application::getInstance().saveSettings();
         if (!value) {

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1154,6 +1154,19 @@ void SettingsTab::createDownloadsSection() {
     });
     m_contentBox->addView(autoResumeToggle);
 
+    // Page cache toggle
+    auto* pageCacheToggle = new brls::BooleanCell();
+    pageCacheToggle->init("Page Cache", settings.pageCacheEnabled, [&settings](bool value) {
+        settings.pageCacheEnabled = value;
+        Application::getInstance().saveSettings();
+        if (!value) {
+            // Clear existing page cache when disabled
+            LibraryCache::getInstance().clearPageCache();
+            brls::Application::notify("Page cache cleared");
+        }
+    });
+    m_contentBox->addView(pageCacheToggle);
+
     // Sync progress now button
     auto* syncNowCell = new brls::DetailCell();
     syncNowCell->setText("Sync Progress Now");


### PR DESCRIPTION
Improves reader swipe (velocity flick, time-based animation, symmetric preload) and speeds up page loading with a disk cache, reduced decode overhead, and pre-converting downloaded pages to TGA in the downloads folder with a page-cache toggle.

---
_Generated by [Claude Code](https://claude.ai/code)_