### PR TITLE
Fix start/select buttons still triggering search during search results

### DIFF
--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -74,6 +74,7 @@ private:
     std::vector<Source> m_filteredSources;
     void filterSourcesByLanguage();
     void showGlobalSearchDialog();
+    void showSourceSearchDialog();
     void showFilterDialog();
     void showSearchHistoryDialog();
     void addToSearchHistory(const std::string& query);

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1434,7 +1434,10 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
             list->setAxis(brls::Axis::COLUMN);
             list->setPadding(10, 15, 10, 15);
 
-            for (const auto& pref : prefs) {
+            for (int prefIdx = 0; prefIdx < static_cast<int>(prefs.size()); prefIdx++) {
+                const auto& pref = prefs[prefIdx];
+                if (!pref.visible) continue;
+
                 auto* prefBox = new brls::Box();
                 prefBox->setAxis(brls::Axis::COLUMN);
                 prefBox->setMarginBottom(15);
@@ -1452,7 +1455,7 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
                     prefBox->addView(summaryLabel);
                 }
 
-                // Value display
+                // Value display (interactive)
                 auto* valueBox = new brls::Box();
                 valueBox->setAxis(brls::Axis::ROW);
                 valueBox->setFocusable(true);
@@ -1466,10 +1469,113 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
 
                 if (pref.type == SourcePreferenceType::CHECKBOX || pref.type == SourcePreferenceType::SWITCH) {
                     valueLabel->setText(pref.currentValue ? "Enabled" : "Disabled");
+
+                    // Toggle on click
+                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
+                        bool newValue = !pref.currentValue;
+                        SourcePreferenceChange change;
+                        change.position = prefIdx;
+                        if (pref.type == SourcePreferenceType::SWITCH) {
+                            change.switchState = newValue;
+                        } else {
+                            change.checkBoxState = newValue;
+                        }
+
+                        brls::async([this, source, change, newValue, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                            SuwayomiClient& client = SuwayomiClient::getInstance();
+                            bool success = client.updateSourcePreference(source.id, change);
+                            brls::sync([success, newValue, valueLabel, aliveWeak]() {
+                                auto alive = aliveWeak.lock();
+                                if (!alive || !*alive) return;
+                                if (success) {
+                                    valueLabel->setText(newValue ? "Enabled" : "Disabled");
+                                } else {
+                                    brls::Application::notify("Failed to update setting");
+                                }
+                            });
+                        });
+                        return true;
+                    });
                 } else if (pref.type == SourcePreferenceType::LIST) {
-                    valueLabel->setText(pref.selectedValue);
+                    // Show selected entry display name if available
+                    std::string displayValue = pref.selectedValue;
+                    for (size_t i = 0; i < pref.entryValues.size(); i++) {
+                        if (pref.entryValues[i] == pref.selectedValue && i < pref.entries.size()) {
+                            displayValue = pref.entries[i];
+                            break;
+                        }
+                    }
+                    valueLabel->setText(displayValue);
+
+                    // Show dropdown on click
+                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
+                        if (pref.entries.empty()) return true;
+
+                        // Find current selection index
+                        int currentIdx = 0;
+                        for (size_t i = 0; i < pref.entryValues.size(); i++) {
+                            if (pref.entryValues[i] == pref.selectedValue) {
+                                currentIdx = static_cast<int>(i);
+                                break;
+                            }
+                        }
+
+                        brls::Dropdown* dropdown = new brls::Dropdown(
+                            pref.title.empty() ? pref.key : pref.title, pref.entries,
+                            [this, source, prefIdx, pref, valueLabel](int selected) {
+                                if (selected < 0 || selected >= static_cast<int>(pref.entryValues.size())) return;
+
+                                std::string selectedVal = pref.entryValues[selected];
+                                std::string displayName = pref.entries[selected];
+
+                                SourcePreferenceChange change;
+                                change.position = prefIdx;
+                                change.listState = selectedVal;
+
+                                brls::async([this, source, change, displayName, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                                    SuwayomiClient& client = SuwayomiClient::getInstance();
+                                    bool success = client.updateSourcePreference(source.id, change);
+                                    brls::sync([success, displayName, valueLabel, aliveWeak]() {
+                                        auto alive = aliveWeak.lock();
+                                        if (!alive || !*alive) return;
+                                        if (success) {
+                                            valueLabel->setText(displayName);
+                                        } else {
+                                            brls::Application::notify("Failed to update setting");
+                                        }
+                                    });
+                                });
+                            }, currentIdx);
+                        brls::Application::pushActivity(new brls::Activity(dropdown));
+                        return true;
+                    });
                 } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {
-                    valueLabel->setText(pref.currentText);
+                    valueLabel->setText(pref.currentText.empty() ? "(empty)" : pref.currentText);
+
+                    // Open IME on click
+                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
+                        brls::Application::getImeManager()->openForText([this, source, prefIdx, pref, valueLabel](std::string text) {
+                            SourcePreferenceChange change;
+                            change.position = prefIdx;
+                            change.editTextState = text;
+
+                            brls::async([this, source, change, text, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                                SuwayomiClient& client = SuwayomiClient::getInstance();
+                                bool success = client.updateSourcePreference(source.id, change);
+                                brls::sync([success, text, valueLabel, aliveWeak]() {
+                                    auto alive = aliveWeak.lock();
+                                    if (!alive || !*alive) return;
+                                    if (success) {
+                                        valueLabel->setText(text.empty() ? "(empty)" : text);
+                                    } else {
+                                        brls::Application::notify("Failed to update setting");
+                                    }
+                                });
+                            });
+                        }, pref.dialogTitle.empty() ? pref.title : pref.dialogTitle,
+                           pref.dialogMessage, 256, pref.currentText);
+                        return true;
+                    });
                 } else {
                     valueLabel->setText(pref.key);
                 }
@@ -1543,8 +1649,8 @@ void ExtensionsTab::showAddRepoDialog() {
         // Show loading notification
         brls::Application::notify("Adding extension repository...");
 
-        // Add repository in background thread
-        std::thread([this, text, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+        // Add repository in background
+        brls::async([this, text, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             SuwayomiClient& client = SuwayomiClient::getInstance();
             bool success = client.addExtensionRepo(text);
 
@@ -1559,7 +1665,7 @@ void ExtensionsTab::showAddRepoDialog() {
                     brls::Application::notify("Failed to add repository");
                 }
             });
-        }).detach();
+        });
     }, "Add Extension Repository",
        "", 256,
        "https://raw.githubusercontent.com/yuzono/manga-repo/repo/index.min.json", 0);

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -203,6 +203,7 @@ SearchTab::SearchTab() {
     m_popularBtn = new brls::Button();
     m_popularBtn->setText("Popular");
     m_popularBtn->setMarginRight(10);
+    m_popularBtn->setCornerRadius(6);
     m_popularBtn->setVisibility(brls::Visibility::GONE);
     m_popularBtn->registerClickAction([this](brls::View* view) {
         m_browseMode = BrowseMode::POPULAR;
@@ -222,6 +223,7 @@ SearchTab::SearchTab() {
     m_latestBtn = new brls::Button();
     m_latestBtn->setText("Latest");
     m_latestBtn->setMarginRight(10);
+    m_latestBtn->setCornerRadius(6);
     m_latestBtn->setVisibility(brls::Visibility::GONE);
     m_latestBtn->registerClickAction([this](brls::View* view) {
         m_browseMode = BrowseMode::LATEST;
@@ -1390,12 +1392,12 @@ void SearchTab::updateModeButtons() {
             }
         }
 
-        // Highlight the active mode button with accent color
-        NVGcolor accentColor = Application::getInstance().getAccentColor();
-        NVGcolor defaultColor = nvgRGBA(0, 0, 0, 0);  // transparent
+        // Highlight the active mode button using same colors as category buttons
+        NVGcolor activeColor = Application::getInstance().getActiveRowBackground();
+        NVGcolor inactiveColor = Application::getInstance().getInactiveRowBackground();
 
-        m_popularBtn->setBackgroundColor(m_browseMode == BrowseMode::POPULAR ? accentColor : defaultColor);
-        m_latestBtn->setBackgroundColor(m_browseMode == BrowseMode::LATEST ? accentColor : defaultColor);
+        m_popularBtn->setBackgroundColor(m_browseMode == BrowseMode::POPULAR ? activeColor : inactiveColor);
+        m_latestBtn->setBackgroundColor(m_browseMode == BrowseMode::LATEST ? activeColor : inactiveColor);
     }
 }
 

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -143,6 +143,8 @@ SearchTab::SearchTab() {
     // Register Start button to open global search dialog
     // Use brls::sync to defer IME opening to avoid crash during controller input handling
     this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
+        // Ignore when search/history buttons are disabled (e.g. during global search results)
+        if (m_browseMode == BrowseMode::SEARCH_RESULTS) return true;
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             auto a = aliveWeak.lock(); if (!a || !*a) return;
             showGlobalSearchDialog();
@@ -152,6 +154,8 @@ SearchTab::SearchTab() {
 
     // Register Select button to open search history
     this->registerAction("History", brls::ControllerButton::BUTTON_BACK, [this](brls::View* view) {
+        // Ignore when search/history buttons are disabled (e.g. during global search results)
+        if (m_browseMode == BrowseMode::SEARCH_RESULTS) return true;
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             auto a = aliveWeak.lock(); if (!a || !*a) return;
             showSearchHistoryDialog();

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -120,7 +120,11 @@ SearchTab::SearchTab() {
     m_globalSearchBtn->registerClickAction([this](brls::View* view) {
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             auto a = aliveWeak.lock(); if (!a || !*a) return;
-            showGlobalSearchDialog();
+            if (m_currentSourceId != 0 && (m_browseMode == BrowseMode::POPULAR || m_browseMode == BrowseMode::LATEST)) {
+                showSourceSearchDialog();
+            } else {
+                showGlobalSearchDialog();
+            }
         });
         return true;
     });
@@ -140,14 +144,18 @@ SearchTab::SearchTab() {
 
     this->addView(m_headerBox);
 
-    // Register Start button to open global search dialog
-    // Use brls::sync to defer IME opening to avoid crash during controller input handling
+    // Register Start button to open search dialog
+    // When browsing a source, search within that source; otherwise global search
     this->registerAction("Search", brls::ControllerButton::BUTTON_START, [this](brls::View* view) {
         // Ignore when search/history buttons are disabled (e.g. during global search results)
         if (m_browseMode == BrowseMode::SEARCH_RESULTS) return true;
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             auto a = aliveWeak.lock(); if (!a || !*a) return;
-            showGlobalSearchDialog();
+            if (m_currentSourceId != 0 && (m_browseMode == BrowseMode::POPULAR || m_browseMode == BrowseMode::LATEST)) {
+                showSourceSearchDialog();
+            } else {
+                showGlobalSearchDialog();
+            }
         });
         return true;
     });
@@ -506,6 +514,19 @@ void SearchTab::showGlobalSearchDialog() {
     }, "Global Search", "Search across all sources", 256, m_searchQuery);
 }
 
+void SearchTab::showSourceSearchDialog() {
+    m_loadGeneration++;  // Invalidate in-flight loads so they don't steal focus from IME
+    brls::Application::getImeManager()->openForText([this](std::string text) {
+        if (text.empty()) return;
+
+        m_searchQuery = text;
+        m_titleLabel->setText(m_currentSourceName + " - Search: " + text);
+        addToSearchHistory(text);
+        m_isGlobalSearch = false;
+        performSourceSearch(m_currentSourceId, text);
+    }, "Search " + m_currentSourceName, "Search within this source", 256, m_searchQuery);
+}
+
 void SearchTab::showSearchHistoryDialog() {
     m_loadGeneration++;  // Invalidate in-flight loads so they don't steal focus from dialog
     auto& settings = Application::getInstance().getSettings();
@@ -650,11 +671,28 @@ void SearchTab::showSources() {
         // Language header
         auto* langHeader = new brls::Label();
         std::string langName = lang.empty() ? "Unknown" : lang;
-        if (langName == "en") langName = "English";
-        else if (langName == "multi") langName = "Multi-language";
-        else if (langName == "ja") langName = "Japanese";
-        else if (langName == "ko") langName = "Korean";
-        else if (langName == "zh") langName = "Chinese";
+        // Comprehensive language code to display name mapping
+        static const std::map<std::string, std::string> languageNames = {
+            {"all", "All Languages"}, {"en", "English"}, {"ja", "Japanese"},
+            {"ko", "Korean"}, {"zh", "Chinese"}, {"zh-Hans", "Chinese (Simplified)"},
+            {"zh-Hant", "Chinese (Traditional)"}, {"es", "Spanish"},
+            {"es-419", "Spanish (Latin America)"}, {"pt", "Portuguese"},
+            {"pt-BR", "Portuguese (Brazil)"}, {"fr", "French"}, {"de", "German"},
+            {"it", "Italian"}, {"ru", "Russian"}, {"ar", "Arabic"},
+            {"id", "Indonesian"}, {"th", "Thai"}, {"vi", "Vietnamese"},
+            {"pl", "Polish"}, {"tr", "Turkish"}, {"nl", "Dutch"},
+            {"uk", "Ukrainian"}, {"cs", "Czech"}, {"ro", "Romanian"},
+            {"bg", "Bulgarian"}, {"hu", "Hungarian"}, {"el", "Greek"},
+            {"he", "Hebrew"}, {"fa", "Persian"}, {"hi", "Hindi"},
+            {"bn", "Bengali"}, {"ms", "Malay"}, {"fil", "Filipino"},
+            {"my", "Burmese"}, {"multi", "Multi-language"}
+        };
+        auto langIt = languageNames.find(lang);
+        if (langIt != languageNames.end()) {
+            langName = langIt->second;
+        } else if (!lang.empty()) {
+            langName[0] = std::toupper(langName[0]);
+        }
 
         langHeader->setText(langName + " (" + std::to_string(sources.size()) + ")");
         langHeader->setFontSize(18);
@@ -1003,8 +1041,12 @@ void SearchTab::performSearch(const std::string& query) {
                 brls::Logger::warning("SearchTab: Search failed for source '{}'", source.name);
             }
 
-            // Limit to prevent too many requests
-            if (totalResults >= 100) break;
+            // Limit to prevent too many requests on constrained hardware
+            if (totalResults >= 100) {
+                brls::Logger::info("SearchTab: Hit 100-result limit after {} of {} sources",
+                                   searchedSources, sourcesToSearch.size());
+                break;
+            }
         }
 
         brls::Logger::info("SearchTab: Found {} results from {} sources for '{}' ({} failed)",
@@ -1018,7 +1060,11 @@ void SearchTab::performSearch(const std::string& query) {
             }
         }
 
-        brls::sync([this, allResults, resultsBySource, failedSources, searchedSources, gen, aliveWeak]() {
+        int totalSourceCount = static_cast<int>(sourcesToSearch.size());
+        bool wasTruncated = (totalResults >= 100 && searchedSources < totalSourceCount);
+
+        brls::sync([this, allResults, resultsBySource, failedSources, searchedSources,
+                     totalSourceCount, wasTruncated, gen, aliveWeak]() {
             auto alive = aliveWeak.lock();
             if (!alive || !*alive) return;
             if (gen != m_loadGeneration) return;  // Stale callback, user navigated away
@@ -1040,7 +1086,11 @@ void SearchTab::performSearch(const std::string& query) {
                 brls::Application::giveFocus(m_backBtn);
             } else {
                 std::string resultText = std::to_string(allResults.size()) + " results from " +
-                                        std::to_string(resultsBySource.size()) + " sources";
+                                        std::to_string(resultsBySource.size()) + "/" +
+                                        std::to_string(totalSourceCount) + " sources";
+                if (wasTruncated) {
+                    resultText += " (limited)";
+                }
                 if (failedSources > 0) {
                     resultText += " (" + std::to_string(failedSources) + " failed)";
                 }
@@ -1324,8 +1374,6 @@ void SearchTab::loadNextPage() {
 }
 
 void SearchTab::updateModeButtons() {
-    // Highlight active mode button (in a real app, you'd change button style)
-    // For now, just ensure visibility is correct
     if (m_browseMode == BrowseMode::SOURCES) {
         m_popularBtn->setVisibility(brls::Visibility::GONE);
         m_latestBtn->setVisibility(brls::Visibility::GONE);
@@ -1341,6 +1389,13 @@ void SearchTab::updateModeButtons() {
                 break;
             }
         }
+
+        // Highlight the active mode button with accent color
+        NVGcolor accentColor = Application::getInstance().getAccentColor();
+        NVGcolor defaultColor = nvgRGBA(0, 0, 0, 0);  // transparent
+
+        m_popularBtn->setBackgroundColor(m_browseMode == BrowseMode::POPULAR ? accentColor : defaultColor);
+        m_latestBtn->setBackgroundColor(m_browseMode == BrowseMode::LATEST ? accentColor : defaultColor);
     }
 }
 


### PR DESCRIPTION
Stops the start/select buttons from re-triggering search while viewing results, improves Browse/Search and Extensions UX, and matches the source-browser mode-button colours to the category buttons.

---
_Generated by [Claude Code](https://claude.ai/code)_