### PR TITLE
Hide UI elements during source-specific search results

### DIFF
--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -100,6 +100,7 @@ private:
     int m_currentPage = 1;
     bool m_hasNextPage = false;
     bool m_isGlobalSearch = false;  // Track if current search is global or source-specific
+    BrowseMode m_previousBrowseMode = BrowseMode::POPULAR;  // Mode before source-specific search
     int m_loadGeneration = 0;       // Incremented on navigation; stale async callbacks check this
 
     // Navigation helper

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -841,11 +841,6 @@ void SearchTab::showSourceBrowser(const Source& source) {
     }
     m_contentGrid->setVisibility(brls::Visibility::VISIBLE);
 
-    // Set up navigation from mode buttons up to header buttons
-    m_popularBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
-    m_latestBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
-    m_backBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_globalSearchBtn);
-
     // RIGHT on Back button wraps to header history button
     m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
 

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -842,8 +842,18 @@ void SearchTab::showSourceBrowser(const Source& source) {
     m_contentGrid->setVisibility(brls::Visibility::VISIBLE);
 
     // Set up navigation from header buttons down to mode buttons (source list is now hidden)
-    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_backBtn);
-    m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_backBtn);
+    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_popularBtn);
+    m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_popularBtn);
+
+    // Set up navigation from mode buttons up to header buttons
+    m_popularBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
+    m_latestBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
+    m_backBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_globalSearchBtn);
+
+    // RIGHT on Back button wraps to header history button
+    m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
+    // LEFT on Popular button wraps to header search button
+    m_popularBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_globalSearchBtn);
 
     // Load popular manga by default
     m_browseMode = BrowseMode::POPULAR;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -1109,6 +1109,8 @@ void SearchTab::performSourceSearch(int64_t sourceId, const std::string& query) 
     brls::Logger::debug("SearchTab: Searching '{}' in source {}", query, sourceId);
     m_resultsLabel->setText("Searching...");
     showLoadingIndicator("Searching");
+    // Remember which mode (Popular/Latest) the user was in before searching
+    m_previousBrowseMode = m_browseMode;
     m_browseMode = BrowseMode::SEARCH_RESULTS;
     m_currentPage = 1;
 
@@ -1429,11 +1431,11 @@ void SearchTab::handleBackNavigation() {
             showSources();
             m_isNavigatingBack = false;
         } else {
-            // Source-specific search: go back to source's main page (Popular)
+            // Source-specific search: go back to the mode the user was in before searching
             // Find the current source and show its browser again
             for (const auto& source : m_sources) {
                 if (source.id == m_currentSourceId) {
-                    m_browseMode = BrowseMode::POPULAR;
+                    m_browseMode = m_previousBrowseMode;
                     m_titleLabel->setText(source.name);
                     m_searchLabel->setVisibility(brls::Visibility::GONE);
 
@@ -1448,7 +1450,7 @@ void SearchTab::handleBackNavigation() {
                     m_globalSearchBtn->setFocusable(true);
 
                     // CRITICAL: Move focus before clearing search result views
-                    brls::Application::giveFocus(m_popularBtn);
+                    brls::Application::giveFocus(m_browseMode == BrowseMode::LATEST ? m_latestBtn : m_popularBtn);
 
                     // Hide search results, show content grid
                     if (m_searchResultsScrollView) {
@@ -1460,8 +1462,13 @@ void SearchTab::handleBackNavigation() {
                     }
                     m_contentGrid->setVisibility(brls::Visibility::VISIBLE);
 
-                    // Load popular manga
-                    loadPopularManga(m_currentSourceId);
+                    // Reload the mode the user was previously browsing
+                    updateModeButtons();
+                    if (m_browseMode == BrowseMode::LATEST) {
+                        loadLatestManga(m_currentSourceId);
+                    } else {
+                        loadPopularManga(m_currentSourceId);
+                    }
                     m_isNavigatingBack = false;  // Allow back navigation again
                     return;
                 }

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -843,6 +843,9 @@ void SearchTab::showSourceBrowser(const Source& source) {
 
     // RIGHT on Back button wraps to header history button
     m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
+    // LEFT on History/Search buttons goes back to Back button
+    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
+    m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
 
     // Load popular manga by default
     m_browseMode = BrowseMode::POPULAR;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -841,10 +841,6 @@ void SearchTab::showSourceBrowser(const Source& source) {
     }
     m_contentGrid->setVisibility(brls::Visibility::VISIBLE);
 
-    // Set up navigation from header buttons down to mode buttons (source list is now hidden)
-    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_popularBtn);
-    m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, m_popularBtn);
-
     // Set up navigation from mode buttons up to header buttons
     m_popularBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
     m_latestBtn->setCustomNavigationRoute(brls::FocusDirection::UP, m_historyBtn);
@@ -852,8 +848,6 @@ void SearchTab::showSourceBrowser(const Source& source) {
 
     // RIGHT on Back button wraps to header history button
     m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
-    // LEFT on Popular button wraps to header search button
-    m_popularBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_globalSearchBtn);
 
     // Load popular manga by default
     m_browseMode = BrowseMode::POPULAR;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -845,7 +845,6 @@ void SearchTab::showSourceBrowser(const Source& source) {
     m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
     // LEFT on History/Search buttons goes back to Back button
     m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
-    m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
 
     // Load popular manga by default
     m_browseMode = BrowseMode::POPULAR;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -1111,6 +1111,16 @@ void SearchTab::performSourceSearch(int64_t sourceId, const std::string& query) 
     showLoadingIndicator("Searching");
     m_browseMode = BrowseMode::SEARCH_RESULTS;
     m_currentPage = 1;
+
+    // Hide Popular/Latest buttons during source-specific search
+    m_popularBtn->setVisibility(brls::Visibility::GONE);
+    m_latestBtn->setVisibility(brls::Visibility::GONE);
+
+    // Hide search and search history buttons
+    m_buttonContainer->setVisibility(brls::Visibility::GONE);
+    m_historyBtn->setFocusable(false);
+    m_globalSearchBtn->setFocusable(false);
+
     int gen = ++m_loadGeneration;
 
     asyncRun([this, sourceId, query, gen, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
@@ -1431,6 +1441,11 @@ void SearchTab::handleBackNavigation() {
                     m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
                     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
                     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
+
+                    // Restore search/history buttons
+                    m_buttonContainer->setVisibility(brls::Visibility::VISIBLE);
+                    m_historyBtn->setFocusable(true);
+                    m_globalSearchBtn->setFocusable(true);
 
                     // CRITICAL: Move focus before clearing search result views
                     brls::Application::giveFocus(m_popularBtn);


### PR DESCRIPTION
Hides UI elements during source-specific search results, restores the previous browse mode when navigating back, and tunes D-pad navigation for the source browse mode buttons.

---
_Generated by [Claude Code](https://claude.ai/code)_