### PR TITLE
Add source tag support for filtering in Browse tab

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -199,6 +199,10 @@ struct AppSettings {
     std::set<std::string> enabledSourceLanguages;  // Empty = all languages, otherwise filter by these (e.g. "en", "multi")
     bool showNsfwSources = false;
 
+    // Source Tags (user-assigned labels for filtering)
+    std::map<std::string, std::set<std::string>> sourceTags;  // sourceId -> set of tag names
+    std::set<std::string> selectedSourceTagFilters;            // Currently active tag filters (empty = show all)
+
     // Network Settings
     std::string localServerUrl;        // Local network URL (e.g., http://192.168.1.100:4567)
     std::string remoteServerUrl;       // Remote/external URL (e.g., https://myserver.com:4567)

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -268,13 +268,48 @@ enum class FilterType {
     GROUP
 };
 
+// Tristate values (matches Suwayomi GraphQL TriState enum)
+enum class TriState {
+    IGNORE = 0,
+    INCLUDE = 1,
+    EXCLUDE = 2
+};
+
+// Sort selection for SortFilter
+struct SortSelection {
+    int index = 0;
+    bool ascending = true;
+};
+
 // Source filter for search
 struct SourceFilter {
     FilterType type = FilterType::TEXT;
     std::string name;
-    std::string state;
-    std::vector<std::string> options;      // For SELECT type
-    std::vector<SourceFilter> filters;     // For GROUP type
+    int position = 0;  // Position in the filter list (for FilterChange)
+
+    // TextFilter state
+    std::string textState;
+    std::string textDefault;
+
+    // CheckBoxFilter state
+    bool checkBoxState = false;
+    bool checkBoxDefault = false;
+
+    // TriStateFilter state (for genre AND/OR include/exclude)
+    TriState triState = TriState::IGNORE;
+
+    // SelectFilter state
+    std::vector<std::string> selectOptions;
+    int selectState = 0;
+    int selectDefault = 0;
+
+    // SortFilter state
+    std::vector<std::string> sortOptions;
+    SortSelection sortState;
+    SortSelection sortDefault;
+
+    // GroupFilter children
+    std::vector<SourceFilter> filters;
 };
 
 // Track search result (from tracker search)
@@ -442,6 +477,9 @@ public:
     bool fetchLatestManga(int64_t sourceId, int page, std::vector<Manga>& manga, bool& hasNextPage);
     bool searchManga(int64_t sourceId, const std::string& query, int page,
                      std::vector<Manga>& manga, bool& hasNextPage);
+    bool searchMangaWithFilters(int64_t sourceId, const std::string& query, int page,
+                                const std::vector<SourceFilter>& filters,
+                                std::vector<Manga>& manga, bool& hasNextPage);
     bool quickSearchManga(int64_t sourceId, const std::string& query, std::vector<Manga>& manga);
 
     // Manga Operations
@@ -603,6 +641,11 @@ private:
     bool fetchPopularMangaGraphQL(int64_t sourceId, int page, std::vector<Manga>& manga, bool& hasNextPage);
     bool fetchLatestMangaGraphQL(int64_t sourceId, int page, std::vector<Manga>& manga, bool& hasNextPage);
     bool searchMangaGraphQL(int64_t sourceId, const std::string& query, int page, std::vector<Manga>& manga, bool& hasNextPage);
+    bool searchMangaWithFiltersGraphQL(int64_t sourceId, const std::string& query, int page,
+                                        const std::vector<SourceFilter>& filters,
+                                        std::vector<Manga>& manga, bool& hasNextPage);
+    bool fetchSourceFiltersGraphQL(int64_t sourceId, std::vector<SourceFilter>& filters);
+    std::string buildFilterChangesJson(const std::vector<SourceFilter>& filters);
     bool fetchLibraryMangaGraphQL(std::vector<Manga>& manga);
     bool fetchCategoriesGraphQL(std::vector<Category>& categories);
     bool fetchChaptersGraphQL(int mangaId, std::vector<Chapter>& chapters);

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -77,6 +77,12 @@ private:
     void showSourceSearchDialog();
     void showFilterDialog();
     void showSearchHistoryDialog();
+    void showTagFilterDialog();
+    void showTagManageDialog(const Source& source);
+    void collectAllTags(std::set<std::string>& allTags);
+
+    // Tag filter button (source list view)
+    brls::Button* m_tagFilterBtn = nullptr;
     void addToSearchHistory(const std::string& query);
     void clearSearchHistory();
 

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -63,7 +63,6 @@ private:
     brls::Box* m_modeBox = nullptr;
     brls::Button* m_popularBtn = nullptr;
     brls::Button* m_latestBtn = nullptr;
-    brls::Button* m_filterBtn = nullptr;
     brls::Button* m_backBtn = nullptr;
 
     // Source list (scrollable)
@@ -84,8 +83,9 @@ private:
     void showTagManageDialog(const Source& source);
     void collectAllTags(std::set<std::string>& allTags);
 
-    // Tag filter button (source list view)
+    // Tag/filter button (header) - context-aware: tag filter on source list, source filter when browsing
     brls::Button* m_tagFilterBtn = nullptr;
+    brls::Image* m_tagFilterIcon = nullptr;  // Icon swapped based on context
     void addToSearchHistory(const std::string& query);
     void clearSearchHistory();
 

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -76,6 +76,9 @@ private:
     void showGlobalSearchDialog();
     void showSourceSearchDialog();
     void showFilterDialog();
+    void loadSourceFilters();
+    void applyFilters();
+    void resetFilters();
     void showSearchHistoryDialog();
     void showTagFilterDialog();
     void showTagManageDialog(const Source& source);
@@ -97,6 +100,11 @@ private:
     std::map<std::string, std::vector<Manga>> m_resultsBySource;
     void populateSearchResultsBySource();
     brls::View* createSourceRow(const std::string& sourceName, const std::vector<Manga>& manga);
+
+    // Source filter state
+    std::vector<SourceFilter> m_sourceFilters;
+    bool m_filtersLoaded = false;
+    bool m_filtersActive = false;  // True when user has applied filters
 
     // State
     BrowseMode m_browseMode = BrowseMode::SOURCES;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1424,6 +1424,77 @@ bool Application::loadSettings() {
     }
     brls::Logger::info("loadSettings: enabledSourceLanguages count = {}", m_settings.enabledSourceLanguages.size());
 
+    // Load source tags (sourceTags: { "sourceId": ["tag1", "tag2"], ... })
+    m_settings.sourceTags.clear();
+    size_t sourceTagsPos = content.find("\"sourceTags\"");
+    if (sourceTagsPos != std::string::npos) {
+        size_t objStart = content.find('{', sourceTagsPos + 12);
+        if (objStart != std::string::npos) {
+            // Find matching closing brace (handle nested arrays)
+            int depth = 1;
+            size_t objEnd = objStart + 1;
+            while (objEnd < content.size() && depth > 0) {
+                if (content[objEnd] == '{') depth++;
+                else if (content[objEnd] == '}') depth--;
+                objEnd++;
+            }
+            std::string tagsObj = content.substr(objStart + 1, objEnd - objStart - 2);
+
+            // Parse each "sourceId": ["tag1", "tag2"] entry
+            size_t searchPos = 0;
+            while (searchPos < tagsObj.size()) {
+                size_t keyStart = tagsObj.find('"', searchPos);
+                if (keyStart == std::string::npos) break;
+                size_t keyEnd = tagsObj.find('"', keyStart + 1);
+                if (keyEnd == std::string::npos) break;
+                std::string sourceId = tagsObj.substr(keyStart + 1, keyEnd - keyStart - 1);
+
+                size_t arrStart = tagsObj.find('[', keyEnd);
+                if (arrStart == std::string::npos) break;
+                size_t arrEnd = tagsObj.find(']', arrStart);
+                if (arrEnd == std::string::npos) break;
+
+                std::string arrStr = tagsObj.substr(arrStart + 1, arrEnd - arrStart - 1);
+                std::set<std::string> tags;
+                size_t tPos = 0;
+                while (tPos < arrStr.size()) {
+                    size_t tStart = arrStr.find('"', tPos);
+                    if (tStart == std::string::npos) break;
+                    size_t tEnd = arrStr.find('"', tStart + 1);
+                    if (tEnd == std::string::npos) break;
+                    std::string tag = arrStr.substr(tStart + 1, tEnd - tStart - 1);
+                    if (!tag.empty()) tags.insert(tag);
+                    tPos = tEnd + 1;
+                }
+                if (!tags.empty()) {
+                    m_settings.sourceTags[sourceId] = tags;
+                }
+                searchPos = arrEnd + 1;
+            }
+        }
+    }
+
+    // Load selected source tag filters
+    m_settings.selectedSourceTagFilters.clear();
+    size_t tagFilterPos = content.find("\"selectedSourceTagFilters\"");
+    if (tagFilterPos != std::string::npos) {
+        size_t arrStart = content.find('[', tagFilterPos);
+        size_t arrEnd = content.find(']', arrStart);
+        if (arrStart != std::string::npos && arrEnd != std::string::npos) {
+            std::string arrStr = content.substr(arrStart + 1, arrEnd - arrStart - 1);
+            size_t tPos = 0;
+            while (tPos < arrStr.size()) {
+                size_t tStart = arrStr.find('"', tPos);
+                if (tStart == std::string::npos) break;
+                size_t tEnd = arrStr.find('"', tStart + 1);
+                if (tEnd == std::string::npos) break;
+                std::string tag = arrStr.substr(tStart + 1, tEnd - tStart - 1);
+                if (!tag.empty()) m_settings.selectedSourceTagFilters.insert(tag);
+                tPos = tEnd + 1;
+            }
+        }
+    }
+
     // Load network settings
     m_settings.localServerUrl = extractString("localServerUrl");
     m_settings.remoteServerUrl = extractString("remoteServerUrl");
@@ -1813,6 +1884,38 @@ bool Application::saveSettings() {
             if (!first) json += ", ";
             first = false;
             json += "\"" + lang + "\"";
+        }
+    }
+    json += "],\n";
+
+    // Source tags
+    json += "  \"sourceTags\": {";
+    {
+        bool firstSource = true;
+        for (const auto& [sourceId, tags] : m_settings.sourceTags) {
+            if (tags.empty()) continue;
+            if (!firstSource) json += ", ";
+            firstSource = false;
+            json += "\"" + sourceId + "\": [";
+            bool firstTag = true;
+            for (const auto& tag : tags) {
+                if (!firstTag) json += ", ";
+                firstTag = false;
+                json += "\"" + tag + "\"";
+            }
+            json += "]";
+        }
+    }
+    json += "},\n";
+
+    // Selected source tag filters
+    json += "  \"selectedSourceTagFilters\": [";
+    {
+        bool first = true;
+        for (const auto& tag : m_settings.selectedSourceTagFilters) {
+            if (!first) json += ", ";
+            first = false;
+            json += "\"" + tag + "\"";
         }
     }
     json += "],\n";

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3382,9 +3382,9 @@ bool SuwayomiClient::fetchSourceFiltersGraphQL(int64_t sourceId, std::vector<Sou
 }
 
 std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilter>& filters) {
-    // Build JSON array of FilterChange objects
-    // Each FilterChange has: position, and the relevant state field
-    std::string json = "[";
+    // Build GraphQL literal array of FilterChange input objects (unquoted keys, unquoted enums)
+    // Used inline in GraphQL query strings, NOT as JSON variables
+    std::string gql = "[";
     bool first = true;
 
     for (const auto& filter : filters) {
@@ -3395,56 +3395,56 @@ std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilte
                 break;
             case FilterType::TEXT:
                 if (filter.textState != filter.textDefault) {
-                    if (!first) json += ",";
-                    json += "{\"position\":" + std::to_string(filter.position) +
-                            ",\"textState\":\"";
+                    if (!first) gql += ", ";
+                    gql += "{position: " + std::to_string(filter.position) +
+                            ", textState: \"";
                     // Escape the text
                     for (char c : filter.textState) {
-                        if (c == '"') json += "\\\"";
-                        else if (c == '\\') json += "\\\\";
-                        else json += c;
+                        if (c == '"') gql += "\\\"";
+                        else if (c == '\\') gql += "\\\\";
+                        else gql += c;
                     }
-                    json += "\"}";
+                    gql += "\"}";
                     first = false;
                 }
                 break;
             case FilterType::CHECKBOX:
                 if (filter.checkBoxState != filter.checkBoxDefault) {
-                    if (!first) json += ",";
-                    json += "{\"position\":" + std::to_string(filter.position) +
-                            ",\"checkBoxState\":" + (filter.checkBoxState ? "true" : "false") + "}";
+                    if (!first) gql += ", ";
+                    gql += "{position: " + std::to_string(filter.position) +
+                            ", checkBoxState: " + (filter.checkBoxState ? "true" : "false") + "}";
                     first = false;
                 }
                 break;
             case FilterType::TRISTATE:
                 if (filter.triState != TriState::IGNORE) {
-                    if (!first) json += ",";
+                    if (!first) gql += ", ";
                     std::string triStr;
                     switch (filter.triState) {
                         case TriState::IGNORE: triStr = "IGNORE"; break;
                         case TriState::INCLUDE: triStr = "INCLUDE"; break;
                         case TriState::EXCLUDE: triStr = "EXCLUDE"; break;
                     }
-                    json += "{\"position\":" + std::to_string(filter.position) +
-                            ",\"triState\":\"" + triStr + "\"}";
+                    gql += "{position: " + std::to_string(filter.position) +
+                            ", triState: " + triStr + "}";
                     first = false;
                 }
                 break;
             case FilterType::SELECT:
                 if (filter.selectState != filter.selectDefault) {
-                    if (!first) json += ",";
-                    json += "{\"position\":" + std::to_string(filter.position) +
-                            ",\"selectState\":" + std::to_string(filter.selectState) + "}";
+                    if (!first) gql += ", ";
+                    gql += "{position: " + std::to_string(filter.position) +
+                            ", selectState: " + std::to_string(filter.selectState) + "}";
                     first = false;
                 }
                 break;
             case FilterType::SORT: {
                 if (filter.sortState.index != filter.sortDefault.index ||
                     filter.sortState.ascending != filter.sortDefault.ascending) {
-                    if (!first) json += ",";
-                    json += "{\"position\":" + std::to_string(filter.position) +
-                            ",\"sortState\":{\"index\":" + std::to_string(filter.sortState.index) +
-                            ",\"ascending\":" + (filter.sortState.ascending ? "true" : "false") + "}}";
+                    if (!first) gql += ", ";
+                    gql += "{position: " + std::to_string(filter.position) +
+                            ", sortState: {index: " + std::to_string(filter.sortState.index) +
+                            ", ascending: " + (filter.sortState.ascending ? "true" : "false") + "}}";
                     first = false;
                 }
                 break;
@@ -3453,7 +3453,7 @@ std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilte
                 // For groups, build nested filter changes for modified children
                 for (const auto& child : filter.filters) {
                     bool childChanged = false;
-                    std::string childJson;
+                    std::string childGql;
 
                     switch (child.type) {
                         case FilterType::TRISTATE:
@@ -3465,29 +3465,29 @@ std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilte
                                     case TriState::INCLUDE: ts = "INCLUDE"; break;
                                     case TriState::EXCLUDE: ts = "EXCLUDE"; break;
                                 }
-                                childJson = "{\"position\":" + std::to_string(child.position) +
-                                            ",\"triState\":\"" + ts + "\"}";
+                                childGql = "{position: " + std::to_string(child.position) +
+                                            ", triState: " + ts + "}";
                             }
                             break;
                         case FilterType::CHECKBOX:
                             if (child.checkBoxState != child.checkBoxDefault) {
                                 childChanged = true;
-                                childJson = "{\"position\":" + std::to_string(child.position) +
-                                            ",\"checkBoxState\":" + (child.checkBoxState ? "true" : "false") + "}";
+                                childGql = "{position: " + std::to_string(child.position) +
+                                            ", checkBoxState: " + (child.checkBoxState ? "true" : "false") + "}";
                             }
                             break;
                         case FilterType::TEXT:
                             if (child.textState != child.textDefault) {
                                 childChanged = true;
-                                childJson = "{\"position\":" + std::to_string(child.position) +
-                                            ",\"textState\":\"" + child.textState + "\"}";
+                                childGql = "{position: " + std::to_string(child.position) +
+                                            ", textState: \"" + child.textState + "\"}";
                             }
                             break;
                         case FilterType::SELECT:
                             if (child.selectState != child.selectDefault) {
                                 childChanged = true;
-                                childJson = "{\"position\":" + std::to_string(child.position) +
-                                            ",\"selectState\":" + std::to_string(child.selectState) + "}";
+                                childGql = "{position: " + std::to_string(child.position) +
+                                            ", selectState: " + std::to_string(child.selectState) + "}";
                             }
                             break;
                         default:
@@ -3495,9 +3495,9 @@ std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilte
                     }
 
                     if (childChanged) {
-                        if (!first) json += ",";
-                        json += "{\"position\":" + std::to_string(filter.position) +
-                                ",\"groupChange\":" + childJson + "}";
+                        if (!first) gql += ", ";
+                        gql += "{position: " + std::to_string(filter.position) +
+                                ", groupChange: " + childGql + "}";
                         first = false;
                     }
                 }
@@ -3506,8 +3506,8 @@ std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilte
         }
     }
 
-    json += "]";
-    return json;
+    gql += "]";
+    return gql;
 }
 
 bool SuwayomiClient::searchMangaWithFilters(int64_t sourceId, const std::string& query, int page,

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3123,8 +3123,13 @@ bool SuwayomiClient::fetchSource(int64_t sourceId, Source& source) {
 }
 
 bool SuwayomiClient::fetchSourceFilters(int64_t sourceId, std::vector<SourceFilter>& filters) {
-    vitasuwayomi::HttpClient http = createHttpClient();
+    // Try GraphQL first
+    if (fetchSourceFiltersGraphQL(sourceId, filters)) {
+        return true;
+    }
 
+    // REST fallback - get filters from REST API
+    vitasuwayomi::HttpClient http = createHttpClient();
     std::string url = buildApiUrl("/source/" + std::to_string(sourceId) + "/filters");
     vitasuwayomi::HttpResponse response = http.get(url);
 
@@ -3132,14 +3137,452 @@ bool SuwayomiClient::fetchSourceFilters(int64_t sourceId, std::vector<SourceFilt
         return false;
     }
 
-    // TODO: Parse filters (complex structure)
     filters.clear();
+    // REST returns a JSON array of filter objects
+    std::vector<std::string> items = splitJsonArray(response.body);
+    int pos = 0;
+    for (const auto& item : items) {
+        SourceFilter filter;
+        filter.position = pos++;
+        std::string typeName = extractJsonValue(item, "type");
+
+        if (typeName == "Header" || typeName == "HeaderFilter") {
+            filter.type = FilterType::HEADER;
+            filter.name = extractJsonValue(item, "name");
+        } else if (typeName == "Separator" || typeName == "SeparatorFilter") {
+            filter.type = FilterType::SEPARATOR;
+            filter.name = extractJsonValue(item, "name");
+        } else if (typeName == "Text" || typeName == "TextFilter") {
+            filter.type = FilterType::TEXT;
+            filter.name = extractJsonValue(item, "name");
+            filter.textDefault = extractJsonValue(item, "state");
+            filter.textState = filter.textDefault;
+        } else if (typeName == "CheckBox" || typeName == "CheckBoxFilter") {
+            filter.type = FilterType::CHECKBOX;
+            filter.name = extractJsonValue(item, "name");
+            filter.checkBoxDefault = extractJsonBool(item, "state");
+            filter.checkBoxState = filter.checkBoxDefault;
+        } else if (typeName == "TriState" || typeName == "TriStateFilter") {
+            filter.type = FilterType::TRISTATE;
+            filter.name = extractJsonValue(item, "name");
+            int st = extractJsonInt(item, "state");
+            filter.triState = static_cast<TriState>(st);
+        } else if (typeName == "Select" || typeName == "SelectFilter") {
+            filter.type = FilterType::SELECT;
+            filter.name = extractJsonValue(item, "name");
+            filter.selectOptions = extractJsonStringArray(item, "displayValues");
+            if (filter.selectOptions.empty()) {
+                filter.selectOptions = extractJsonStringArray(item, "values");
+            }
+            filter.selectDefault = extractJsonInt(item, "state");
+            filter.selectState = filter.selectDefault;
+        } else if (typeName == "Sort" || typeName == "SortFilter") {
+            filter.type = FilterType::SORT;
+            filter.name = extractJsonValue(item, "name");
+            filter.sortOptions = extractJsonStringArray(item, "displayValues");
+            if (filter.sortOptions.empty()) {
+                filter.sortOptions = extractJsonStringArray(item, "values");
+            }
+            // Parse sort state
+            std::string stateObj = extractJsonObject(item, "state");
+            if (!stateObj.empty()) {
+                filter.sortState.index = extractJsonInt(stateObj, "index");
+                filter.sortState.ascending = extractJsonBool(stateObj, "ascending");
+            }
+            filter.sortDefault = filter.sortState;
+        } else if (typeName == "Group" || typeName == "GroupFilter") {
+            filter.type = FilterType::GROUP;
+            filter.name = extractJsonValue(item, "name");
+            // Parse nested filters
+            std::string filtersJson = extractJsonArray(item, "state");
+            if (filtersJson.empty()) {
+                filtersJson = extractJsonArray(item, "filters");
+            }
+            std::vector<std::string> subItems = splitJsonArray(filtersJson);
+            int subPos = 0;
+            for (const auto& subItem : subItems) {
+                SourceFilter subFilter;
+                subFilter.position = subPos++;
+                std::string subType = extractJsonValue(subItem, "type");
+                subFilter.name = extractJsonValue(subItem, "name");
+
+                if (subType == "TriState" || subType == "TriStateFilter") {
+                    subFilter.type = FilterType::TRISTATE;
+                    int subSt = extractJsonInt(subItem, "state");
+                    subFilter.triState = static_cast<TriState>(subSt);
+                } else if (subType == "CheckBox" || subType == "CheckBoxFilter") {
+                    subFilter.type = FilterType::CHECKBOX;
+                    subFilter.checkBoxState = extractJsonBool(subItem, "state");
+                    subFilter.checkBoxDefault = subFilter.checkBoxState;
+                } else if (subType == "Text" || subType == "TextFilter") {
+                    subFilter.type = FilterType::TEXT;
+                    subFilter.textState = extractJsonValue(subItem, "state");
+                    subFilter.textDefault = subFilter.textState;
+                } else if (subType == "Select" || subType == "SelectFilter") {
+                    subFilter.type = FilterType::SELECT;
+                    subFilter.selectOptions = extractJsonStringArray(subItem, "displayValues");
+                    if (subFilter.selectOptions.empty()) {
+                        subFilter.selectOptions = extractJsonStringArray(subItem, "values");
+                    }
+                    subFilter.selectState = extractJsonInt(subItem, "state");
+                    subFilter.selectDefault = subFilter.selectState;
+                }
+                filter.filters.push_back(subFilter);
+            }
+        }
+
+        filters.push_back(filter);
+    }
+
+    brls::Logger::info("Fetched {} source filters via REST", filters.size());
+    return true;
+}
+
+bool SuwayomiClient::fetchSourceFiltersGraphQL(int64_t sourceId, std::vector<SourceFilter>& filters) {
+    const char* query = R"(
+        query GetSourceFilters($sourceId: LongString!) {
+            source(id: $sourceId) {
+                filters {
+                    ... on HeaderFilter { __typename name }
+                    ... on SeparatorFilter { __typename name }
+                    ... on TextFilter { __typename name default }
+                    ... on CheckBoxFilter { __typename name default }
+                    ... on TriStateFilter { __typename name default }
+                    ... on SelectFilter { __typename name default values displayValues }
+                    ... on SortFilter { __typename name default { index ascending } values }
+                    ... on GroupFilter {
+                        __typename name
+                        filters {
+                            ... on HeaderFilter { __typename name }
+                            ... on SeparatorFilter { __typename name }
+                            ... on TextFilter { __typename name default }
+                            ... on CheckBoxFilter { __typename name default }
+                            ... on TriStateFilter { __typename name default }
+                            ... on SelectFilter { __typename name default values displayValues }
+                            ... on SortFilter { __typename name default { index ascending } values }
+                        }
+                    }
+                }
+            }
+        }
+    )";
+
+    std::string variables = "{\"sourceId\":\"" + std::to_string(sourceId) + "\"}";
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) return false;
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) return false;
+
+    std::string sourceObj = extractJsonObject(data, "source");
+    if (sourceObj.empty()) return false;
+
+    std::string filtersJson = extractJsonArray(sourceObj, "filters");
+    if (filtersJson.empty()) {
+        filters.clear();
+        return true;  // Source has no filters
+    }
+
+    filters.clear();
+    std::vector<std::string> items = splitJsonArray(filtersJson);
+    int pos = 0;
+
+    for (const auto& item : items) {
+        SourceFilter filter;
+        filter.position = pos++;
+        std::string typeName = extractJsonValue(item, "__typename");
+
+        if (typeName == "HeaderFilter") {
+            filter.type = FilterType::HEADER;
+            filter.name = extractJsonValue(item, "name");
+        } else if (typeName == "SeparatorFilter") {
+            filter.type = FilterType::SEPARATOR;
+            filter.name = extractJsonValue(item, "name");
+        } else if (typeName == "TextFilter") {
+            filter.type = FilterType::TEXT;
+            filter.name = extractJsonValue(item, "name");
+            filter.textDefault = extractJsonValue(item, "default");
+            filter.textState = filter.textDefault;
+        } else if (typeName == "CheckBoxFilter") {
+            filter.type = FilterType::CHECKBOX;
+            filter.name = extractJsonValue(item, "name");
+            filter.checkBoxDefault = extractJsonBool(item, "default");
+            filter.checkBoxState = filter.checkBoxDefault;
+        } else if (typeName == "TriStateFilter") {
+            filter.type = FilterType::TRISTATE;
+            filter.name = extractJsonValue(item, "name");
+            // Default is usually 0 (IGNORE)
+            int def = extractJsonInt(item, "default");
+            filter.triState = static_cast<TriState>(def);
+        } else if (typeName == "SelectFilter") {
+            filter.type = FilterType::SELECT;
+            filter.name = extractJsonValue(item, "name");
+            filter.selectOptions = extractJsonStringArray(item, "displayValues");
+            if (filter.selectOptions.empty()) {
+                filter.selectOptions = extractJsonStringArray(item, "values");
+            }
+            filter.selectDefault = extractJsonInt(item, "default");
+            filter.selectState = filter.selectDefault;
+        } else if (typeName == "SortFilter") {
+            filter.type = FilterType::SORT;
+            filter.name = extractJsonValue(item, "name");
+            filter.sortOptions = extractJsonStringArray(item, "values");
+            // Parse default sort selection
+            std::string defObj = extractJsonObject(item, "default");
+            if (!defObj.empty()) {
+                filter.sortDefault.index = extractJsonInt(defObj, "index");
+                filter.sortDefault.ascending = extractJsonBool(defObj, "ascending");
+            }
+            filter.sortState = filter.sortDefault;
+        } else if (typeName == "GroupFilter") {
+            filter.type = FilterType::GROUP;
+            filter.name = extractJsonValue(item, "name");
+            std::string subFiltersJson = extractJsonArray(item, "filters");
+            std::vector<std::string> subItems = splitJsonArray(subFiltersJson);
+            int subPos = 0;
+            for (const auto& subItem : subItems) {
+                SourceFilter subFilter;
+                subFilter.position = subPos++;
+                std::string subType = extractJsonValue(subItem, "__typename");
+                subFilter.name = extractJsonValue(subItem, "name");
+
+                if (subType == "TriStateFilter") {
+                    subFilter.type = FilterType::TRISTATE;
+                    int subDef = extractJsonInt(subItem, "default");
+                    subFilter.triState = static_cast<TriState>(subDef);
+                } else if (subType == "CheckBoxFilter") {
+                    subFilter.type = FilterType::CHECKBOX;
+                    subFilter.checkBoxDefault = extractJsonBool(subItem, "default");
+                    subFilter.checkBoxState = subFilter.checkBoxDefault;
+                } else if (subType == "TextFilter") {
+                    subFilter.type = FilterType::TEXT;
+                    subFilter.textDefault = extractJsonValue(subItem, "default");
+                    subFilter.textState = subFilter.textDefault;
+                } else if (subType == "SelectFilter") {
+                    subFilter.type = FilterType::SELECT;
+                    subFilter.selectOptions = extractJsonStringArray(subItem, "displayValues");
+                    if (subFilter.selectOptions.empty()) {
+                        subFilter.selectOptions = extractJsonStringArray(subItem, "values");
+                    }
+                    subFilter.selectDefault = extractJsonInt(subItem, "default");
+                    subFilter.selectState = subFilter.selectDefault;
+                } else if (subType == "HeaderFilter") {
+                    subFilter.type = FilterType::HEADER;
+                } else if (subType == "SeparatorFilter") {
+                    subFilter.type = FilterType::SEPARATOR;
+                }
+                filter.filters.push_back(subFilter);
+            }
+        }
+        filters.push_back(filter);
+    }
+
+    brls::Logger::info("GraphQL: Fetched {} source filters", filters.size());
+    return true;
+}
+
+std::string SuwayomiClient::buildFilterChangesJson(const std::vector<SourceFilter>& filters) {
+    // Build JSON array of FilterChange objects
+    // Each FilterChange has: position, and the relevant state field
+    std::string json = "[";
+    bool first = true;
+
+    for (const auto& filter : filters) {
+        switch (filter.type) {
+            case FilterType::HEADER:
+            case FilterType::SEPARATOR:
+                // No state to send for these
+                break;
+            case FilterType::TEXT:
+                if (filter.textState != filter.textDefault) {
+                    if (!first) json += ",";
+                    json += "{\"position\":" + std::to_string(filter.position) +
+                            ",\"textState\":\"";
+                    // Escape the text
+                    for (char c : filter.textState) {
+                        if (c == '"') json += "\\\"";
+                        else if (c == '\\') json += "\\\\";
+                        else json += c;
+                    }
+                    json += "\"}";
+                    first = false;
+                }
+                break;
+            case FilterType::CHECKBOX:
+                if (filter.checkBoxState != filter.checkBoxDefault) {
+                    if (!first) json += ",";
+                    json += "{\"position\":" + std::to_string(filter.position) +
+                            ",\"checkBoxState\":" + (filter.checkBoxState ? "true" : "false") + "}";
+                    first = false;
+                }
+                break;
+            case FilterType::TRISTATE:
+                if (filter.triState != TriState::IGNORE) {
+                    if (!first) json += ",";
+                    std::string triStr;
+                    switch (filter.triState) {
+                        case TriState::IGNORE: triStr = "IGNORE"; break;
+                        case TriState::INCLUDE: triStr = "INCLUDE"; break;
+                        case TriState::EXCLUDE: triStr = "EXCLUDE"; break;
+                    }
+                    json += "{\"position\":" + std::to_string(filter.position) +
+                            ",\"triState\":\"" + triStr + "\"}";
+                    first = false;
+                }
+                break;
+            case FilterType::SELECT:
+                if (filter.selectState != filter.selectDefault) {
+                    if (!first) json += ",";
+                    json += "{\"position\":" + std::to_string(filter.position) +
+                            ",\"selectState\":" + std::to_string(filter.selectState) + "}";
+                    first = false;
+                }
+                break;
+            case FilterType::SORT: {
+                if (filter.sortState.index != filter.sortDefault.index ||
+                    filter.sortState.ascending != filter.sortDefault.ascending) {
+                    if (!first) json += ",";
+                    json += "{\"position\":" + std::to_string(filter.position) +
+                            ",\"sortState\":{\"index\":" + std::to_string(filter.sortState.index) +
+                            ",\"ascending\":" + (filter.sortState.ascending ? "true" : "false") + "}}";
+                    first = false;
+                }
+                break;
+            }
+            case FilterType::GROUP: {
+                // For groups, build nested filter changes for modified children
+                for (const auto& child : filter.filters) {
+                    bool childChanged = false;
+                    std::string childJson;
+
+                    switch (child.type) {
+                        case FilterType::TRISTATE:
+                            if (child.triState != TriState::IGNORE) {
+                                childChanged = true;
+                                std::string ts;
+                                switch (child.triState) {
+                                    case TriState::IGNORE: ts = "IGNORE"; break;
+                                    case TriState::INCLUDE: ts = "INCLUDE"; break;
+                                    case TriState::EXCLUDE: ts = "EXCLUDE"; break;
+                                }
+                                childJson = "{\"position\":" + std::to_string(child.position) +
+                                            ",\"triState\":\"" + ts + "\"}";
+                            }
+                            break;
+                        case FilterType::CHECKBOX:
+                            if (child.checkBoxState != child.checkBoxDefault) {
+                                childChanged = true;
+                                childJson = "{\"position\":" + std::to_string(child.position) +
+                                            ",\"checkBoxState\":" + (child.checkBoxState ? "true" : "false") + "}";
+                            }
+                            break;
+                        case FilterType::TEXT:
+                            if (child.textState != child.textDefault) {
+                                childChanged = true;
+                                childJson = "{\"position\":" + std::to_string(child.position) +
+                                            ",\"textState\":\"" + child.textState + "\"}";
+                            }
+                            break;
+                        case FilterType::SELECT:
+                            if (child.selectState != child.selectDefault) {
+                                childChanged = true;
+                                childJson = "{\"position\":" + std::to_string(child.position) +
+                                            ",\"selectState\":" + std::to_string(child.selectState) + "}";
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+
+                    if (childChanged) {
+                        if (!first) json += ",";
+                        json += "{\"position\":" + std::to_string(filter.position) +
+                                ",\"groupChange\":" + childJson + "}";
+                        first = false;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    json += "]";
+    return json;
+}
+
+bool SuwayomiClient::searchMangaWithFilters(int64_t sourceId, const std::string& query, int page,
+                                             const std::vector<SourceFilter>& filters,
+                                             std::vector<Manga>& manga, bool& hasNextPage) {
+    return searchMangaWithFiltersGraphQL(sourceId, query, page, filters, manga, hasNextPage);
+}
+
+bool SuwayomiClient::searchMangaWithFiltersGraphQL(int64_t sourceId, const std::string& query, int page,
+                                                     const std::vector<SourceFilter>& filters,
+                                                     std::vector<Manga>& manga, bool& hasNextPage) {
+    // Build the filter changes JSON
+    std::string filterChangesJson = buildFilterChangesJson(filters);
+
+    // Build query dynamically since filters are inline
+    std::string gqlQuery = R"(
+        mutation SearchWithFilters($sourceId: LongString!, $page: Int!) {
+            fetchSourceManga(input: {
+                source: $sourceId,
+                type: SEARCH,
+                page: $page,
+                query: ")" + ([&]() {
+                    std::string escaped;
+                    for (char c : query) {
+                        if (c == '"') escaped += "\\\"";
+                        else if (c == '\\') escaped += "\\\\";
+                        else if (c == '\n') escaped += "\\n";
+                        else escaped += c;
+                    }
+                    return escaped;
+                })() + R"(",
+                filters: )" + filterChangesJson + R"(
+            }) {
+                mangas {
+                    id
+                    title
+                    thumbnailUrl
+                    author
+                    artist
+                    description
+                    inLibrary
+                }
+                hasNextPage
+            }
+        }
+    )";
+
+    std::string variables = "{\"sourceId\":\"" + std::to_string(sourceId) + "\",\"page\":" + std::to_string(page) + "}";
+
+    std::string response = executeGraphQL(gqlQuery, variables);
+    if (response.empty()) return false;
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) return false;
+
+    std::string fetchResult = extractJsonObject(data, "fetchSourceManga");
+    if (fetchResult.empty()) return false;
+
+    hasNextPage = extractJsonBool(fetchResult, "hasNextPage");
+
+    std::string mangasJson = extractJsonArray(fetchResult, "mangas");
+    manga.clear();
+    std::vector<std::string> items = splitJsonArray(mangasJson);
+    for (const auto& item : items) {
+        manga.push_back(parseMangaFromGraphQL(item));
+    }
+
+    brls::Logger::debug("GraphQL: Fetched {} manga with filters (hasNext: {})", manga.size(), hasNextPage);
     return true;
 }
 
 bool SuwayomiClient::setSourceFilters(int64_t sourceId, const std::vector<SourceFilter>& filters) {
-    // TODO: Implement filter setting
-    return false;
+    // Filters are sent directly with fetchSourceManga, not set separately
+    // This method is kept for API compatibility
+    return true;
 }
 
 // ============================================================================

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -204,6 +204,18 @@ SearchTab::SearchTab() {
         return true;
     });
 
+    // Register Y button to open source filters when browsing a source
+    this->registerAction("Filter", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
+        if (m_currentSourceId != 0 && (m_browseMode == BrowseMode::POPULAR || m_browseMode == BrowseMode::LATEST)) {
+            brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                auto a = aliveWeak.lock(); if (!a || !*a) return;
+                showFilterDialog();
+            });
+            return true;
+        }
+        return false;  // Let default handling occur (tag management on source list)
+    });
+
     // Register Circle button (B) to go back in search/browse modes
     this->registerAction("Back", brls::ControllerButton::BUTTON_B, [this](brls::View* view) {
         // Only handle if we're not on the sources list
@@ -900,9 +912,17 @@ void SearchTab::showSourceBrowser(const Source& source) {
     // Show source-specific buttons
     m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    // Filter button hidden until source filters are implemented
+    // Show filter button - will be shown once filters are loaded
     m_filterBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
+
+    // Reset filter state for new source
+    m_sourceFilters.clear();
+    m_filtersLoaded = false;
+    m_filtersActive = false;
+    if (m_filterBtn) {
+        m_filterBtn->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+    }
 
     // CRITICAL: Move focus away from source list BEFORE clearing views.
     // The currently focused view may be a source row that clearViews() will delete.
@@ -938,21 +958,435 @@ void SearchTab::showSourceBrowser(const Source& source) {
     }
     m_contentGrid->setVisibility(brls::Visibility::VISIBLE);
 
-    // RIGHT on Back button wraps to header history button
-    m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_historyBtn);
-    // LEFT on History/Search buttons goes back to Back button
-    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
+    // Navigation chain: [< Back] → [Tag] → [History] → [Search]
+    // RIGHT on Back button goes to Tag button
+    m_backBtn->setCustomNavigationRoute(brls::FocusDirection::RIGHT, m_tagFilterBtn);
+    // LEFT on Tag button goes to Back button
+    m_tagFilterBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_backBtn);
+    // LEFT on History button goes to Tag button
+    m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::LEFT, m_tagFilterBtn);
 
     // Load popular manga by default
     m_browseMode = BrowseMode::POPULAR;
     loadPopularManga(source.id);
     updateModeButtons();
+
+    // Load source filters in background
+    loadSourceFilters();
+}
+
+void SearchTab::loadSourceFilters() {
+    if (m_filtersLoaded || m_currentSourceId == 0) return;
+
+    asyncRun([this, sourceId = m_currentSourceId, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<SourceFilter> filters;
+
+        if (client.fetchSourceFilters(sourceId, filters)) {
+            brls::sync([this, filters, sourceId, aliveWeak]() {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+                if (m_currentSourceId != sourceId) return;  // User navigated away
+                m_sourceFilters = filters;
+                m_filtersLoaded = true;
+
+                // Show the filter button if source has actionable filters
+                bool hasFilters = false;
+                for (const auto& f : filters) {
+                    if (f.type != FilterType::HEADER && f.type != FilterType::SEPARATOR) {
+                        hasFilters = true;
+                        break;
+                    }
+                }
+                if (hasFilters && m_filterBtn) {
+                    m_filterBtn->setVisibility(brls::Visibility::VISIBLE);
+                }
+                brls::Logger::info("Loaded {} filters for source", filters.size());
+            });
+        } else {
+            brls::Logger::warning("Failed to load source filters");
+        }
+    });
+}
+
+void SearchTab::resetFilters() {
+    for (auto& filter : m_sourceFilters) {
+        switch (filter.type) {
+            case FilterType::TEXT:
+                filter.textState = filter.textDefault;
+                break;
+            case FilterType::CHECKBOX:
+                filter.checkBoxState = filter.checkBoxDefault;
+                break;
+            case FilterType::TRISTATE:
+                filter.triState = TriState::IGNORE;
+                break;
+            case FilterType::SELECT:
+                filter.selectState = filter.selectDefault;
+                break;
+            case FilterType::SORT:
+                filter.sortState = filter.sortDefault;
+                break;
+            case FilterType::GROUP:
+                for (auto& child : filter.filters) {
+                    switch (child.type) {
+                        case FilterType::TRISTATE:
+                            child.triState = TriState::IGNORE;
+                            break;
+                        case FilterType::CHECKBOX:
+                            child.checkBoxState = child.checkBoxDefault;
+                            break;
+                        case FilterType::TEXT:
+                            child.textState = child.textDefault;
+                            break;
+                        case FilterType::SELECT:
+                            child.selectState = child.selectDefault;
+                            break;
+                        default: break;
+                    }
+                }
+                break;
+            default: break;
+        }
+    }
+    m_filtersActive = false;
+}
+
+void SearchTab::applyFilters() {
+    if (m_currentSourceId == 0) return;
+
+    m_filtersActive = true;
+    m_currentPage = 1;
+    m_mangaList.clear();
+    m_browseMode = BrowseMode::POPULAR;  // Treat filter search as browsing
+    showLoadingIndicator("Applying filters");
+    m_resultsLabel->setText("Searching with filters...");
+    updateModeButtons();
+
+    // Update filter button to show it's active
+    if (m_filterBtn) {
+        m_filterBtn->setBackgroundColor(Application::getInstance().getActiveRowBackground());
+    }
+
+    int gen = ++m_loadGeneration;
+
+    asyncRun([this, gen, aliveWeak = std::weak_ptr<bool>(m_alive),
+              sourceId = m_currentSourceId, filters = m_sourceFilters]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Manga> manga;
+        bool hasNextPage = false;
+
+        if (client.searchMangaWithFilters(sourceId, "", 1, filters, manga, hasNextPage)) {
+            brls::sync([this, manga, hasNextPage, gen, aliveWeak]() {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+                if (gen != m_loadGeneration) return;
+                hideLoadingIndicator();
+                m_mangaList = manga;
+                m_hasNextPage = hasNextPage;
+                m_contentGrid->setDataSource(m_mangaList);
+                m_resultsLabel->setText(std::to_string(manga.size()) + " results (filtered)");
+
+                if (!manga.empty()) {
+                    m_contentGrid->focusIndex(0);
+                }
+            });
+        } else {
+            brls::sync([this, gen, aliveWeak]() {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+                if (gen != m_loadGeneration) return;
+                hideLoadingIndicator();
+                m_resultsLabel->setText("Filter search failed");
+                brls::Application::giveFocus(m_filterBtn);
+            });
+        }
+    });
 }
 
 void SearchTab::showFilterDialog() {
-    // Source filter dialog not yet implemented
-    // Would show configurable filters like genres, status, etc.
-    brls::Application::notify("Source filters coming soon");
+    if (m_sourceFilters.empty()) {
+        if (!m_filtersLoaded) {
+            brls::Application::notify("Loading filters...");
+            loadSourceFilters();
+        } else {
+            brls::Application::notify("This source has no filters");
+        }
+        return;
+    }
+
+    m_loadGeneration++;  // Invalidate in-flight loads
+
+    // Build the filter options list
+    std::vector<std::string> options;
+    // Track which filter index each option maps to
+    std::vector<std::pair<int, int>> filterIndices;  // (filter_index, sub_index) where sub_index=-1 for top-level
+
+    for (size_t i = 0; i < m_sourceFilters.size(); i++) {
+        const auto& filter = m_sourceFilters[i];
+
+        switch (filter.type) {
+            case FilterType::HEADER:
+                options.push_back("--- " + filter.name + " ---");
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+
+            case FilterType::SEPARATOR:
+                options.push_back("----------");
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+
+            case FilterType::TEXT:
+                options.push_back(filter.name + ": " +
+                    (filter.textState.empty() ? "(empty)" : filter.textState));
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+
+            case FilterType::CHECKBOX:
+                options.push_back((filter.checkBoxState ? "[x] " : "[  ] ") + filter.name);
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+
+            case FilterType::TRISTATE: {
+                std::string prefix;
+                switch (filter.triState) {
+                    case TriState::IGNORE:  prefix = "[  ] "; break;
+                    case TriState::INCLUDE: prefix = "[+] "; break;
+                    case TriState::EXCLUDE: prefix = "[-] "; break;
+                }
+                options.push_back(prefix + filter.name);
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+            }
+
+            case FilterType::SELECT:
+                if (!filter.selectOptions.empty() && filter.selectState >= 0 &&
+                    filter.selectState < static_cast<int>(filter.selectOptions.size())) {
+                    options.push_back(filter.name + ": " + filter.selectOptions[filter.selectState]);
+                } else {
+                    options.push_back(filter.name + ": (select)");
+                }
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+
+            case FilterType::SORT: {
+                std::string sortLabel = filter.name + ": ";
+                if (!filter.sortOptions.empty() && filter.sortState.index >= 0 &&
+                    filter.sortState.index < static_cast<int>(filter.sortOptions.size())) {
+                    sortLabel += filter.sortOptions[filter.sortState.index];
+                    sortLabel += (filter.sortState.ascending ? " (Asc)" : " (Desc)");
+                } else {
+                    sortLabel += "(default)";
+                }
+                options.push_back(sortLabel);
+                filterIndices.push_back({static_cast<int>(i), -1});
+                break;
+            }
+
+            case FilterType::GROUP:
+                // Show group header
+                options.push_back("=== " + filter.name + " ===");
+                filterIndices.push_back({static_cast<int>(i), -1});
+
+                // Show group children
+                for (size_t j = 0; j < filter.filters.size(); j++) {
+                    const auto& child = filter.filters[j];
+                    switch (child.type) {
+                        case FilterType::TRISTATE: {
+                            std::string prefix;
+                            switch (child.triState) {
+                                case TriState::IGNORE:  prefix = "  [  ] "; break;
+                                case TriState::INCLUDE: prefix = "  [+] "; break;
+                                case TriState::EXCLUDE: prefix = "  [-] "; break;
+                            }
+                            options.push_back(prefix + child.name);
+                            break;
+                        }
+                        case FilterType::CHECKBOX:
+                            options.push_back(std::string("  ") + (child.checkBoxState ? "[x] " : "[  ] ") + child.name);
+                            break;
+                        case FilterType::TEXT:
+                            options.push_back("  " + child.name + ": " +
+                                (child.textState.empty() ? "(empty)" : child.textState));
+                            break;
+                        case FilterType::SELECT:
+                            if (!child.selectOptions.empty() && child.selectState >= 0 &&
+                                child.selectState < static_cast<int>(child.selectOptions.size())) {
+                                options.push_back("  " + child.name + ": " + child.selectOptions[child.selectState]);
+                            } else {
+                                options.push_back("  " + child.name);
+                            }
+                            break;
+                        default:
+                            options.push_back("  " + child.name);
+                            break;
+                    }
+                    filterIndices.push_back({static_cast<int>(i), static_cast<int>(j)});
+                }
+                break;
+        }
+    }
+
+    // Add action buttons at the bottom
+    options.push_back(">> Apply Filters <<");
+    filterIndices.push_back({-1, 0});  // Apply
+    options.push_back(">> Reset Filters <<");
+    filterIndices.push_back({-1, 1});  // Reset
+
+    brls::Dropdown* dropdown = new brls::Dropdown(
+        "Source Filters", options,
+        [this, filterIndices](int selected) {
+            if (selected < 0 || selected >= static_cast<int>(filterIndices.size())) return;
+
+            brls::sync([this, selected, filterIndices]() {
+                auto [filterIdx, subIdx] = filterIndices[selected];
+
+                // Action buttons
+                if (filterIdx == -1) {
+                    if (subIdx == 0) {
+                        // Apply
+                        applyFilters();
+                    } else {
+                        // Reset
+                        resetFilters();
+                        if (m_filterBtn) {
+                            m_filterBtn->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+                        }
+                        brls::Application::notify("Filters reset");
+                        // Reload popular manga
+                        loadPopularManga(m_currentSourceId);
+                    }
+                    return;
+                }
+
+                if (filterIdx < 0 || filterIdx >= static_cast<int>(m_sourceFilters.size())) return;
+                auto& filter = m_sourceFilters[filterIdx];
+
+                // Handle group child
+                if (subIdx >= 0 && filter.type == FilterType::GROUP) {
+                    if (subIdx >= static_cast<int>(filter.filters.size())) return;
+                    auto& child = filter.filters[subIdx];
+
+                    switch (child.type) {
+                        case FilterType::TRISTATE:
+                            // Cycle: IGNORE -> INCLUDE -> EXCLUDE -> IGNORE
+                            switch (child.triState) {
+                                case TriState::IGNORE:  child.triState = TriState::INCLUDE; break;
+                                case TriState::INCLUDE: child.triState = TriState::EXCLUDE; break;
+                                case TriState::EXCLUDE: child.triState = TriState::IGNORE; break;
+                            }
+                            // Re-show dialog to reflect change
+                            showFilterDialog();
+                            break;
+                        case FilterType::CHECKBOX:
+                            child.checkBoxState = !child.checkBoxState;
+                            showFilterDialog();
+                            break;
+                        case FilterType::TEXT:
+                            brls::Application::getImeManager()->openForText(
+                                [this, filterIdx, subIdx](std::string text) {
+                                    if (filterIdx < static_cast<int>(m_sourceFilters.size()) &&
+                                        subIdx < static_cast<int>(m_sourceFilters[filterIdx].filters.size())) {
+                                        m_sourceFilters[filterIdx].filters[subIdx].textState = text;
+                                    }
+                                    showFilterDialog();
+                                }, child.name, "", 256, child.textState);
+                            break;
+                        case FilterType::SELECT: {
+                            // Show sub-dropdown for select options
+                            brls::Dropdown* selectDrop = new brls::Dropdown(
+                                child.name, child.selectOptions,
+                                [this, filterIdx, subIdx](int sel) {
+                                    if (sel >= 0 && filterIdx < static_cast<int>(m_sourceFilters.size()) &&
+                                        subIdx < static_cast<int>(m_sourceFilters[filterIdx].filters.size())) {
+                                        m_sourceFilters[filterIdx].filters[subIdx].selectState = sel;
+                                    }
+                                    brls::sync([this]() { showFilterDialog(); });
+                                }, child.selectState);
+                            brls::Application::pushActivity(new brls::Activity(selectDrop));
+                            break;
+                        }
+                        default: break;
+                    }
+                    return;
+                }
+
+                // Handle top-level filters
+                switch (filter.type) {
+                    case FilterType::HEADER:
+                    case FilterType::SEPARATOR:
+                        // No action for headers/separators
+                        showFilterDialog();
+                        break;
+
+                    case FilterType::TEXT:
+                        brls::Application::getImeManager()->openForText(
+                            [this, filterIdx](std::string text) {
+                                if (filterIdx < static_cast<int>(m_sourceFilters.size())) {
+                                    m_sourceFilters[filterIdx].textState = text;
+                                }
+                                showFilterDialog();
+                            }, filter.name, "", 256, filter.textState);
+                        break;
+
+                    case FilterType::CHECKBOX:
+                        filter.checkBoxState = !filter.checkBoxState;
+                        showFilterDialog();
+                        break;
+
+                    case FilterType::TRISTATE:
+                        // Cycle: IGNORE -> INCLUDE -> EXCLUDE -> IGNORE
+                        switch (filter.triState) {
+                            case TriState::IGNORE:  filter.triState = TriState::INCLUDE; break;
+                            case TriState::INCLUDE: filter.triState = TriState::EXCLUDE; break;
+                            case TriState::EXCLUDE: filter.triState = TriState::IGNORE; break;
+                        }
+                        showFilterDialog();
+                        break;
+
+                    case FilterType::SELECT: {
+                        // Show sub-dropdown for select options
+                        brls::Dropdown* selectDrop = new brls::Dropdown(
+                            filter.name, filter.selectOptions,
+                            [this, filterIdx](int sel) {
+                                if (sel >= 0 && filterIdx < static_cast<int>(m_sourceFilters.size())) {
+                                    m_sourceFilters[filterIdx].selectState = sel;
+                                }
+                                brls::sync([this]() { showFilterDialog(); });
+                            }, filter.selectState);
+                        brls::Application::pushActivity(new brls::Activity(selectDrop));
+                        break;
+                    }
+
+                    case FilterType::SORT: {
+                        // Show sort options with ascending/descending
+                        std::vector<std::string> sortOpts;
+                        for (const auto& opt : filter.sortOptions) {
+                            sortOpts.push_back(opt + " (Ascending)");
+                            sortOpts.push_back(opt + " (Descending)");
+                        }
+                        int currentSortIdx = filter.sortState.index * 2 + (filter.sortState.ascending ? 0 : 1);
+                        brls::Dropdown* sortDrop = new brls::Dropdown(
+                            filter.name, sortOpts,
+                            [this, filterIdx](int sel) {
+                                if (sel >= 0 && filterIdx < static_cast<int>(m_sourceFilters.size())) {
+                                    m_sourceFilters[filterIdx].sortState.index = sel / 2;
+                                    m_sourceFilters[filterIdx].sortState.ascending = (sel % 2 == 0);
+                                }
+                                brls::sync([this]() { showFilterDialog(); });
+                            }, currentSortIdx);
+                        brls::Application::pushActivity(new brls::Activity(sortDrop));
+                        break;
+                    }
+
+                    case FilterType::GROUP:
+                        // Group header - just re-show dialog
+                        showFilterDialog();
+                        break;
+                }
+            });
+        }, 0);
+    brls::Application::pushActivity(new brls::Activity(dropdown));
 }
 
 void SearchTab::collectAllTags(std::set<std::string>& allTags) {
@@ -1571,15 +2005,19 @@ void SearchTab::loadNextPage() {
     auto sourceId = m_currentSourceId;
     auto page = m_currentPage;
     auto query = m_searchQuery;
+    auto filtersActive = m_filtersActive;
+    auto filters = m_sourceFilters;
 
     asyncRun([this, firstNewItemIndex, gen, aliveWeak = std::weak_ptr<bool>(m_alive),
-              browseMode, sourceId, page, query]() {
+              browseMode, sourceId, page, query, filtersActive, filters]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         std::vector<Manga> manga;
         bool hasNextPage = false;
 
         bool success = false;
-        if (browseMode == BrowseMode::POPULAR) {
+        if (filtersActive) {
+            success = client.searchMangaWithFilters(sourceId, "", page, filters, manga, hasNextPage);
+        } else if (browseMode == BrowseMode::POPULAR) {
             success = client.fetchPopularManga(sourceId, page, manga, hasNextPage);
         } else if (browseMode == BrowseMode::LATEST) {
             success = client.fetchLatestManga(sourceId, page, manga, hasNextPage);
@@ -1618,10 +2056,16 @@ void SearchTab::updateModeButtons() {
     if (m_browseMode == BrowseMode::SOURCES) {
         m_popularBtn->setVisibility(brls::Visibility::GONE);
         m_latestBtn->setVisibility(brls::Visibility::GONE);
+        m_filterBtn->setVisibility(brls::Visibility::GONE);
         m_backBtn->setVisibility(brls::Visibility::GONE);
     } else {
         m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
         m_backBtn->setVisibility(brls::Visibility::VISIBLE);
+
+        // Show filter button if source has filters loaded
+        if (m_filtersLoaded && !m_sourceFilters.empty()) {
+            m_filterBtn->setVisibility(brls::Visibility::VISIBLE);
+        }
 
         // Show latest button if source supports it
         for (const auto& source : m_sources) {
@@ -1669,6 +2113,7 @@ void SearchTab::handleBackNavigation() {
                     // Update buttons for source browsing mode
                     m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
                     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+                    m_filterBtn->setVisibility(m_filtersLoaded && !m_sourceFilters.empty() ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
                     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
 
                     // Restore search/history buttons
@@ -1706,6 +2151,9 @@ void SearchTab::handleBackNavigation() {
         }
     } else {
         // For POPULAR/LATEST modes: go back to sources list
+        m_sourceFilters.clear();
+        m_filtersLoaded = false;
+        m_filtersActive = false;
         showSources();
         m_isNavigatingBack = false;
     }

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -51,17 +51,21 @@ SearchTab::SearchTab() {
     m_tagFilterBtn->setJustifyContent(brls::JustifyContent::CENTER);
     m_tagFilterBtn->setAlignItems(brls::AlignItems::CENTER);
 
-    auto* tagIcon = new brls::Image();
-    tagIcon->setWidth(24);
-    tagIcon->setHeight(24);
-    tagIcon->setScalingType(brls::ImageScalingType::FIT);
-    tagIcon->setImageFromFile("app0:resources/icons/tag.png");
-    m_tagFilterBtn->addView(tagIcon);
+    m_tagFilterIcon = new brls::Image();
+    m_tagFilterIcon->setWidth(24);
+    m_tagFilterIcon->setHeight(24);
+    m_tagFilterIcon->setScalingType(brls::ImageScalingType::FIT);
+    m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
+    m_tagFilterBtn->addView(m_tagFilterIcon);
 
     m_tagFilterBtn->registerClickAction([this](brls::View* view) {
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
             auto a = aliveWeak.lock(); if (!a || !*a) return;
-            showTagFilterDialog();
+            if (m_browseMode != BrowseMode::SOURCES && m_currentSourceId != 0) {
+                showFilterDialog();
+            } else {
+                showTagFilterDialog();
+            }
         });
         return true;
     });
@@ -283,35 +287,6 @@ SearchTab::SearchTab() {
         return true;
     }, true);
     m_modeBox->addView(m_latestBtn);
-
-    // Filter button with tag icon
-    m_filterBtn = new brls::Button();
-    m_filterBtn->setWidth(44);
-    m_filterBtn->setHeight(40);
-    m_filterBtn->setCornerRadius(8);
-    m_filterBtn->setMarginRight(10);
-    m_filterBtn->setVisibility(brls::Visibility::GONE);
-    m_filterBtn->setJustifyContent(brls::JustifyContent::CENTER);
-    m_filterBtn->setAlignItems(brls::AlignItems::CENTER);
-
-    auto* filterIcon = new brls::Image();
-    filterIcon->setWidth(20);
-    filterIcon->setHeight(20);
-    filterIcon->setScalingType(brls::ImageScalingType::FIT);
-    filterIcon->setImageFromFile("app0:resources/icons/tag.png");
-    m_filterBtn->addView(filterIcon);
-
-    m_filterBtn->registerClickAction([this](brls::View* view) {
-        showFilterDialog();
-        return true;
-    });
-    m_filterBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_filterBtn));
-    // B button on Filter goes back
-    m_filterBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
-        brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() { auto a = aliveWeak.lock(); if (!a || !*a) return; handleBackNavigation(); });
-        return true;
-    }, true);
-    m_modeBox->addView(m_filterBtn);
 
     // Back button
     m_backBtn = new brls::Button();
@@ -689,8 +664,10 @@ void SearchTab::showSources() {
     // Hide source-specific buttons
     m_popularBtn->setVisibility(brls::Visibility::GONE);
     m_latestBtn->setVisibility(brls::Visibility::GONE);
-    m_filterBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->setVisibility(brls::Visibility::GONE);
+    // Restore tag icon on header button and reset background
+    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
+    m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
     // Restore search/history buttons when returning to source list
     m_buttonContainer->setVisibility(brls::Visibility::VISIBLE);
     m_historyBtn->setFocusable(true);
@@ -912,17 +889,15 @@ void SearchTab::showSourceBrowser(const Source& source) {
     // Show source-specific buttons
     m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    // Show filter button - will be shown once filters are loaded
-    m_filterBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
 
     // Reset filter state for new source
     m_sourceFilters.clear();
     m_filtersLoaded = false;
     m_filtersActive = false;
-    if (m_filterBtn) {
-        m_filterBtn->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-    }
+    // Switch header tag button to filter icon for source browsing
+    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/filter-menu-outline.png");
+    m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
 
     // CRITICAL: Move focus away from source list BEFORE clearing views.
     // The currently focused view may be a source row that clearViews() will delete.
@@ -989,18 +964,6 @@ void SearchTab::loadSourceFilters() {
                 if (m_currentSourceId != sourceId) return;  // User navigated away
                 m_sourceFilters = filters;
                 m_filtersLoaded = true;
-
-                // Show the filter button if source has actionable filters
-                bool hasFilters = false;
-                for (const auto& f : filters) {
-                    if (f.type != FilterType::HEADER && f.type != FilterType::SEPARATOR) {
-                        hasFilters = true;
-                        break;
-                    }
-                }
-                if (hasFilters && m_filterBtn) {
-                    m_filterBtn->setVisibility(brls::Visibility::VISIBLE);
-                }
                 brls::Logger::info("Loaded {} filters for source", filters.size());
             });
         } else {
@@ -1063,10 +1026,8 @@ void SearchTab::applyFilters() {
     m_resultsLabel->setText("Searching with filters...");
     updateModeButtons();
 
-    // Update filter button to show it's active
-    if (m_filterBtn) {
-        m_filterBtn->setBackgroundColor(Application::getInstance().getActiveRowBackground());
-    }
+    // Update header tag/filter button to show filters are active
+    m_tagFilterBtn->setBackgroundColor(Application::getInstance().getActiveRowBackground());
 
     int gen = ++m_loadGeneration;
 
@@ -1098,7 +1059,7 @@ void SearchTab::applyFilters() {
                 if (gen != m_loadGeneration) return;
                 hideLoadingIndicator();
                 m_resultsLabel->setText("Filter search failed");
-                brls::Application::giveFocus(m_filterBtn);
+                brls::Application::giveFocus(m_tagFilterBtn);
             });
         }
     });
@@ -1249,9 +1210,7 @@ void SearchTab::showFilterDialog() {
                     } else {
                         // Reset
                         resetFilters();
-                        if (m_filterBtn) {
-                            m_filterBtn->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-                        }
+                        m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
                         brls::Application::notify("Filters reset");
                         // Reload popular manga
                         loadPopularManga(m_currentSourceId);
@@ -1636,7 +1595,6 @@ void SearchTab::performSearch(const std::string& query) {
     m_browseMode = BrowseMode::SEARCH_RESULTS;
     m_popularBtn->setVisibility(brls::Visibility::GONE);
     m_latestBtn->setVisibility(brls::Visibility::GONE);
-    m_filterBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
     // Hide search/history buttons during global search
     m_buttonContainer->setVisibility(brls::Visibility::GONE);
@@ -2056,16 +2014,10 @@ void SearchTab::updateModeButtons() {
     if (m_browseMode == BrowseMode::SOURCES) {
         m_popularBtn->setVisibility(brls::Visibility::GONE);
         m_latestBtn->setVisibility(brls::Visibility::GONE);
-        m_filterBtn->setVisibility(brls::Visibility::GONE);
         m_backBtn->setVisibility(brls::Visibility::GONE);
     } else {
         m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
         m_backBtn->setVisibility(brls::Visibility::VISIBLE);
-
-        // Show filter button if source has filters loaded
-        if (m_filtersLoaded && !m_sourceFilters.empty()) {
-            m_filterBtn->setVisibility(brls::Visibility::VISIBLE);
-        }
 
         // Show latest button if source supports it
         for (const auto& source : m_sources) {
@@ -2113,8 +2065,9 @@ void SearchTab::handleBackNavigation() {
                     // Update buttons for source browsing mode
                     m_popularBtn->setVisibility(brls::Visibility::VISIBLE);
                     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-                    m_filterBtn->setVisibility(m_filtersLoaded && !m_sourceFilters.empty() ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
                     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
+                    // Restore filter icon on header button
+                    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/filter-menu-outline.png");
 
                     // Restore search/history buttons
                     m_buttonContainer->setVisibility(brls::Visibility::VISIBLE);

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -42,6 +42,39 @@ SearchTab::SearchTab() {
     m_buttonContainer->setAxis(brls::Axis::ROW);
     m_buttonContainer->setAlignItems(brls::AlignItems::FLEX_END);
 
+    // Tag filter button (only shown on source list)
+    m_tagFilterBtn = new brls::Button();
+    m_tagFilterBtn->setWidth(44);
+    m_tagFilterBtn->setHeight(44);
+    m_tagFilterBtn->setCornerRadius(8);
+    m_tagFilterBtn->setMarginRight(10);
+    m_tagFilterBtn->setJustifyContent(brls::JustifyContent::CENTER);
+    m_tagFilterBtn->setAlignItems(brls::AlignItems::CENTER);
+
+    auto* tagIcon = new brls::Image();
+    tagIcon->setWidth(24);
+    tagIcon->setHeight(24);
+    tagIcon->setScalingType(brls::ImageScalingType::FIT);
+    tagIcon->setImageFromFile("app0:resources/icons/tag.png");
+    m_tagFilterBtn->addView(tagIcon);
+
+    m_tagFilterBtn->registerClickAction([this](brls::View* view) {
+        brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+            auto a = aliveWeak.lock(); if (!a || !*a) return;
+            showTagFilterDialog();
+        });
+        return true;
+    });
+    m_tagFilterBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_tagFilterBtn));
+    m_tagFilterBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        if (m_browseMode != BrowseMode::SOURCES) {
+            brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() { auto a = aliveWeak.lock(); if (!a || !*a) return; handleBackNavigation(); });
+            return true;
+        }
+        return false;
+    }, true);
+    m_buttonContainer->addView(m_tagFilterBtn);
+
     // Search history button with Select icon above
     auto* historyContainer = new brls::Box();
     historyContainer->setAxis(brls::Axis::COLUMN);
@@ -498,6 +531,27 @@ void SearchTab::filterSourcesByLanguage() {
             }
         }
 
+        // Filter by selected tags
+        if (!settings.selectedSourceTagFilters.empty()) {
+            std::string srcId = std::to_string(source.id);
+            auto tagIt = settings.sourceTags.find(srcId);
+            if (tagIt == settings.sourceTags.end() || tagIt->second.empty()) {
+                // Source has no tags, skip if tag filters are active
+                continue;
+            }
+            // Check if source has at least one of the selected filter tags
+            bool hasMatchingTag = false;
+            for (const auto& filterTag : settings.selectedSourceTagFilters) {
+                if (tagIt->second.count(filterTag) > 0) {
+                    hasMatchingTag = true;
+                    break;
+                }
+            }
+            if (!hasMatchingTag) {
+                continue;
+            }
+        }
+
         m_filteredSources.push_back(source);
     }
 
@@ -607,9 +661,18 @@ void SearchTab::showSources() {
     m_titleLabel->setText("Browse");
     m_searchLabel->setVisibility(brls::Visibility::GONE);
 
-    // Filter sources by language setting
+    // Filter sources by language and tags
     filterSourcesByLanguage();
-    m_resultsLabel->setText(std::to_string(m_filteredSources.size()) + " sources");
+    {
+        const auto& settings = Application::getInstance().getSettings();
+        std::string resultText = std::to_string(m_filteredSources.size()) + " sources";
+        if (!settings.selectedSourceTagFilters.empty()) {
+            resultText += " (filtered by " + std::to_string(settings.selectedSourceTagFilters.size()) + " tag";
+            if (settings.selectedSourceTagFilters.size() > 1) resultText += "s";
+            resultText += ")";
+        }
+        m_resultsLabel->setText(resultText);
+    }
 
     // Hide source-specific buttons
     m_popularBtn->setVisibility(brls::Visibility::GONE);
@@ -732,12 +795,35 @@ void SearchTab::showSources() {
             }
             sourceRow->addView(sourceIcon);
 
-            // Source name
+            // Source name and tags container
+            auto* nameTagBox = new brls::Box();
+            nameTagBox->setAxis(brls::Axis::COLUMN);
+            nameTagBox->setGrow(1.0f);
+
             auto* nameLabel = new brls::Label();
             nameLabel->setText(source.name);
             nameLabel->setFontSize(16);
-            nameLabel->setGrow(1.0f);
-            sourceRow->addView(nameLabel);
+            nameTagBox->addView(nameLabel);
+
+            // Show tags for this source
+            {
+                const auto& settings = Application::getInstance().getSettings();
+                std::string srcId = std::to_string(source.id);
+                auto tagIt = settings.sourceTags.find(srcId);
+                if (tagIt != settings.sourceTags.end() && !tagIt->second.empty()) {
+                    auto* tagLabel = new brls::Label();
+                    std::string tagStr;
+                    for (const auto& t : tagIt->second) {
+                        if (!tagStr.empty()) tagStr += ", ";
+                        tagStr += t;
+                    }
+                    tagLabel->setText(tagStr);
+                    tagLabel->setFontSize(12);
+                    tagLabel->setTextColor(nvgRGBA(150, 150, 150, 255));
+                    nameTagBox->addView(tagLabel);
+                }
+            }
+            sourceRow->addView(nameTagBox);
 
             // Click to browse source
             Source sourceCopy = source;
@@ -746,6 +832,15 @@ void SearchTab::showSources() {
                 return true;
             });
             sourceRow->addGestureRecognizer(new brls::TapGestureRecognizer(sourceRow));
+
+            // Y button to manage tags on this source
+            sourceRow->registerAction("Tags", brls::ControllerButton::BUTTON_Y, [this, sourceCopy](brls::View*) {
+                brls::sync([this, sourceCopy, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                    auto a = aliveWeak.lock(); if (!a || !*a) return;
+                    showTagManageDialog(sourceCopy);
+                });
+                return true;
+            }, false);  // visible action
 
             // Register B button on source row to go back (exit tab in SOURCES mode)
             // This ensures B button works when focus is on source rows
@@ -776,10 +871,12 @@ void SearchTab::showSources() {
 
     // Set up navigation from header buttons down to first source row
     if (firstSourceRow) {
+        m_tagFilterBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, firstSourceRow);
         m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, firstSourceRow);
         m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, firstSourceRow);
     } else {
         // No source rows - clear navigation routes to prevent crash
+        m_tagFilterBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, nullptr);
         m_historyBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, nullptr);
         m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, nullptr);
     }
@@ -856,6 +953,135 @@ void SearchTab::showFilterDialog() {
     // Source filter dialog not yet implemented
     // Would show configurable filters like genres, status, etc.
     brls::Application::notify("Source filters coming soon");
+}
+
+void SearchTab::collectAllTags(std::set<std::string>& allTags) {
+    const auto& settings = Application::getInstance().getSettings();
+    for (const auto& [sourceId, tags] : settings.sourceTags) {
+        for (const auto& tag : tags) {
+            allTags.insert(tag);
+        }
+    }
+}
+
+void SearchTab::showTagFilterDialog() {
+    std::set<std::string> allTags;
+    collectAllTags(allTags);
+
+    if (allTags.empty()) {
+        brls::Application::notify("No tags yet - long press a source to add tags");
+        return;
+    }
+
+    auto& settings = Application::getInstance().getSettings();
+
+    // Build options: each tag with a check mark if active
+    std::vector<std::string> options;
+    std::vector<std::string> tagList;
+    for (const auto& tag : allTags) {
+        bool active = settings.selectedSourceTagFilters.count(tag) > 0;
+        options.push_back((active ? "[x] " : "[  ] ") + tag);
+        tagList.push_back(tag);
+    }
+    options.push_back("Clear All Filters");
+
+    brls::Dropdown* dropdown = new brls::Dropdown(
+        "Filter by Tag", options,
+        [this, tagList](int selected) {
+            if (selected < 0) return;
+
+            brls::sync([this, selected, tagList]() {
+                auto& settings = Application::getInstance().getSettings();
+
+                if (selected == static_cast<int>(tagList.size())) {
+                    // Clear all filters
+                    settings.selectedSourceTagFilters.clear();
+                    Application::getInstance().saveSettings();
+                    showSources();
+                    brls::Application::notify("Tag filters cleared");
+                } else if (selected < static_cast<int>(tagList.size())) {
+                    // Toggle the selected tag filter
+                    const std::string& tag = tagList[selected];
+                    if (settings.selectedSourceTagFilters.count(tag) > 0) {
+                        settings.selectedSourceTagFilters.erase(tag);
+                    } else {
+                        settings.selectedSourceTagFilters.insert(tag);
+                    }
+                    Application::getInstance().saveSettings();
+                    showSources();
+                }
+            });
+        }, 0);
+    brls::Application::pushActivity(new brls::Activity(dropdown));
+}
+
+void SearchTab::showTagManageDialog(const Source& source) {
+    auto& settings = Application::getInstance().getSettings();
+    std::string sourceIdStr = std::to_string(source.id);
+
+    // Get current tags for this source
+    std::set<std::string> currentTags;
+    auto it = settings.sourceTags.find(sourceIdStr);
+    if (it != settings.sourceTags.end()) {
+        currentTags = it->second;
+    }
+
+    // Collect all existing tags across all sources
+    std::set<std::string> allTags;
+    collectAllTags(allTags);
+
+    // Build options: existing tags with check marks + "Add new tag" + "Done"
+    std::vector<std::string> options;
+    std::vector<std::string> tagList;
+    for (const auto& tag : allTags) {
+        bool has = currentTags.count(tag) > 0;
+        options.push_back((has ? "[x] " : "[  ] ") + tag);
+        tagList.push_back(tag);
+    }
+    options.push_back("+ Add New Tag");
+    options.push_back("Done");
+
+    brls::Dropdown* dropdown = new brls::Dropdown(
+        "Tags: " + source.name, options,
+        [this, sourceIdStr, tagList, source](int selected) {
+            if (selected < 0) return;
+
+            brls::sync([this, selected, sourceIdStr, tagList, source]() {
+                auto& settings = Application::getInstance().getSettings();
+
+                if (selected == static_cast<int>(tagList.size())) {
+                    // Add new tag - open IME
+                    brls::Application::getImeManager()->openForText([this, sourceIdStr, source](std::string text) {
+                        if (text.empty()) return;
+                        auto& s = Application::getInstance().getSettings();
+                        s.sourceTags[sourceIdStr].insert(text);
+                        Application::getInstance().saveSettings();
+                        brls::Application::notify("Tag '" + text + "' added");
+                        // Re-show the dialog with the new tag
+                        showTagManageDialog(source);
+                    }, "New Tag", "Enter tag name", 32, "");
+                } else if (selected == static_cast<int>(tagList.size()) + 1) {
+                    // Done - refresh source list
+                    showSources();
+                } else if (selected < static_cast<int>(tagList.size())) {
+                    // Toggle tag on this source
+                    const std::string& tag = tagList[selected];
+                    auto& sourceTags = settings.sourceTags[sourceIdStr];
+                    if (sourceTags.count(tag) > 0) {
+                        sourceTags.erase(tag);
+                        if (sourceTags.empty()) {
+                            settings.sourceTags.erase(sourceIdStr);
+                        }
+                    } else {
+                        sourceTags.insert(tag);
+                    }
+                    Application::getInstance().saveSettings();
+                    // Re-show the dialog with updated state
+                    showTagManageDialog(source);
+                }
+            });
+        }, 0);
+    brls::Application::pushActivity(new brls::Activity(dropdown));
 }
 
 void SearchTab::loadPopularManga(int64_t sourceId) {

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -42,12 +42,24 @@ SearchTab::SearchTab() {
     m_buttonContainer->setAxis(brls::Axis::ROW);
     m_buttonContainer->setAlignItems(brls::AlignItems::FLEX_END);
 
-    // Tag filter button (only shown on source list)
+    // Tag filter button with triangle hint above (only shown on source list)
+    auto* tagContainer = new brls::Box();
+    tagContainer->setAxis(brls::Axis::COLUMN);
+    tagContainer->setAlignItems(brls::AlignItems::CENTER);
+    tagContainer->setMarginRight(10);
+
+    auto* triangleHintIcon = new brls::Image();
+    triangleHintIcon->setWidth(16);
+    triangleHintIcon->setHeight(16);
+    triangleHintIcon->setScalingType(brls::ImageScalingType::FIT);
+    triangleHintIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    triangleHintIcon->setMarginBottom(2);
+    tagContainer->addView(triangleHintIcon);
+
     m_tagFilterBtn = new brls::Button();
     m_tagFilterBtn->setWidth(44);
     m_tagFilterBtn->setHeight(44);
     m_tagFilterBtn->setCornerRadius(8);
-    m_tagFilterBtn->setMarginRight(10);
     m_tagFilterBtn->setJustifyContent(brls::JustifyContent::CENTER);
     m_tagFilterBtn->setAlignItems(brls::AlignItems::CENTER);
 
@@ -77,7 +89,8 @@ SearchTab::SearchTab() {
         }
         return false;
     }, true);
-    m_buttonContainer->addView(m_tagFilterBtn);
+    tagContainer->addView(m_tagFilterBtn);
+    m_buttonContainer->addView(tagContainer);
 
     // Search history button with Select icon above
     auto* historyContainer = new brls::Box();
@@ -208,7 +221,7 @@ SearchTab::SearchTab() {
         return true;
     });
 
-    // Register Y button to open source filters when browsing a source
+    // Register Y button (triangle) to open tag filter on source list, or source filters when browsing
     this->registerAction("Filter", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
         if (m_currentSourceId != 0 && (m_browseMode == BrowseMode::POPULAR || m_browseMode == BrowseMode::LATEST)) {
             brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
@@ -217,7 +230,14 @@ SearchTab::SearchTab() {
             });
             return true;
         }
-        return false;  // Let default handling occur (tag management on source list)
+        if (m_browseMode == BrowseMode::SOURCES) {
+            brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
+                auto a = aliveWeak.lock(); if (!a || !*a) return;
+                showTagFilterDialog();
+            });
+            return true;
+        }
+        return false;
     });
 
     // Register Circle button (B) to go back in search/browse modes

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -896,7 +896,7 @@ void SearchTab::showSourceBrowser(const Source& source) {
     m_filtersLoaded = false;
     m_filtersActive = false;
     // Switch header tag button to filter icon for source browsing
-    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/filter-menu-outline.png");
+    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
     m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
 
     // CRITICAL: Move focus away from source list BEFORE clearing views.

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -667,7 +667,7 @@ void SearchTab::showSources() {
     m_backBtn->setVisibility(brls::Visibility::GONE);
     // Restore tag icon on header button and reset background
     if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
-    m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
+    m_tagFilterBtn->setBackgroundColor(Application::getInstance().getButtonColor());
     // Restore search/history buttons when returning to source list
     m_buttonContainer->setVisibility(brls::Visibility::VISIBLE);
     m_historyBtn->setFocusable(true);
@@ -897,7 +897,7 @@ void SearchTab::showSourceBrowser(const Source& source) {
     m_filtersActive = false;
     // Switch header tag button to filter icon for source browsing
     if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
-    m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
+    m_tagFilterBtn->setBackgroundColor(Application::getInstance().getButtonColor());
 
     // CRITICAL: Move focus away from source list BEFORE clearing views.
     // The currently focused view may be a source row that clearViews() will delete.
@@ -1210,7 +1210,7 @@ void SearchTab::showFilterDialog() {
                     } else {
                         // Reset
                         resetFilters();
-                        m_tagFilterBtn->setBackgroundColor(nvgRGBA(0, 0, 0, 0));
+                        m_tagFilterBtn->setBackgroundColor(Application::getInstance().getButtonColor());
                         brls::Application::notify("Filters reset");
                         // Reload popular manga
                         loadPopularManga(m_currentSourceId);


### PR DESCRIPTION
Adds source-tag and source-filter support to the Browse tab (genres, sort, tristate) with navigation fixes and corrected GraphQL filter syntax.

---
_Generated by [Claude Code](https://claude.ai/code)_