### PR TITLE
Fix focus leaking between filter panel and main content in search tab

### DIFF
--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -27,6 +27,7 @@ public:
 
     void onFocusGained() override;
     void willDisappear(bool resetState) override;
+    brls::View* getNextFocus(brls::FocusDirection direction, brls::View* currentView) override;
 
 private:
     void loadSources();
@@ -112,6 +113,7 @@ private:
     brls::View* m_prePanelFocusView = nullptr;  // View that had focus before panel opened
     brls::Box* m_lastHighlightedRow = nullptr;   // Currently highlighted row in filter panel
     void hideFilterPanel();
+    bool isFocusInPanel(brls::View* view) const;  // Check if view is inside m_filterPanel
     void buildFilterPanel();       // Build source filter content into m_filterPanel
     void buildTagFilterPanel();    // Build tag filter content into m_filterPanel
     void buildTagManagePanel(const Source& source);  // Build tag manage content into m_filterPanel

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -483,6 +483,37 @@ void SearchTab::onFocusGained() {
     }
 }
 
+bool SearchTab::isFocusInPanel(brls::View* view) const {
+    while (view) {
+        if (view == m_filterPanel)
+            return true;
+        view = view->getParent();
+    }
+    return false;
+}
+
+brls::View* SearchTab::getNextFocus(brls::FocusDirection direction, brls::View* currentView) {
+    // When the filter panel is visible, prevent d-pad focus from crossing
+    // between the main content and the panel.  Focus should only enter/leave
+    // the panel via explicit actions (Y to open, B to close).
+    if (m_filterPanelType != FilterPanelType::NONE &&
+        m_filterPanel && m_filterPanel->getVisibility() == brls::Visibility::VISIBLE) {
+
+        brls::View* focused = brls::Application::getCurrentFocus();
+        bool inPanel = isFocusInPanel(focused);
+
+        // Block RIGHT from main content into the panel
+        if (!inPanel && direction == brls::FocusDirection::RIGHT)
+            return focused;  // stay where we are
+
+        // Block LEFT from panel into main content
+        if (inPanel && direction == brls::FocusDirection::LEFT)
+            return focused;  // stay where we are
+    }
+
+    return brls::Box::getNextFocus(direction, currentView);
+}
+
 void SearchTab::loadSources() {
     brls::Logger::debug("SearchTab: Loading sources");
     m_browseMode = BrowseMode::SOURCES;
@@ -1122,10 +1153,12 @@ void SearchTab::applyFilters() {
 
 void SearchTab::hideFilterPanel() {
     if (m_filterPanel) {
+        // Clear highlighted row BEFORE clearViews to avoid use-after-free
+        // (focus events could fire during view deletion and access freed row)
+        m_lastHighlightedRow = nullptr;
+        m_filterPanelType = FilterPanelType::NONE;
         m_filterPanel->clearViews();
         m_filterPanel->setVisibility(brls::Visibility::GONE);
-        m_filterPanelType = FilterPanelType::NONE;
-        m_lastHighlightedRow = nullptr;
         // Restore focus to the view that was focused before the panel opened
         if (m_prePanelFocusView) {
             brls::Application::giveFocus(m_prePanelFocusView);
@@ -1299,7 +1332,7 @@ void SearchTab::buildFilterPanel() {
             childrenBox->setVisibility(collapsed ? brls::Visibility::GONE : brls::Visibility::VISIBLE);
 
             // Update toggle to use childrenBox directly
-            groupRow->registerClickAction([this, groupIdx, childrenBox, arrowLabel](brls::View*) {
+            groupRow->registerClickAction([this, groupIdx, childrenBox, arrowLabel, groupRow](brls::View*) {
                 if (m_collapsedGroups.count(groupIdx)) {
                     m_collapsedGroups.erase(groupIdx);
                     childrenBox->setVisibility(brls::Visibility::VISIBLE);
@@ -1308,6 +1341,18 @@ void SearchTab::buildFilterPanel() {
                     m_collapsedGroups.insert(groupIdx);
                     childrenBox->setVisibility(brls::Visibility::GONE);
                     arrowLabel->setText("\u25B6");
+                    // If focus was inside the collapsed group, move it to the group header
+                    brls::View* focused = brls::Application::getCurrentFocus();
+                    if (focused) {
+                        brls::View* check = focused;
+                        while (check) {
+                            if (check == childrenBox) {
+                                brls::Application::giveFocus(groupRow);
+                                break;
+                            }
+                            check = check->getParent();
+                        }
+                    }
                 }
                 return true;
             });
@@ -1387,7 +1432,7 @@ void SearchTab::buildFilterPanel() {
                         optLabel->setSingleLine(true);
                         optRow->addView(optLabel);
 
-                        optRow->registerClickAction([this, fi, ci, optIdx, childLabel, makeFilterLabel, childOptionsBox, childArrow](brls::View*) {
+                        optRow->registerClickAction([this, fi, ci, optIdx, childLabel, makeFilterLabel, childOptionsBox, childArrow, childRow](brls::View*) {
                             if (fi >= static_cast<int>(m_sourceFilters.size())) return true;
                             auto& parent = m_sourceFilters[fi];
                             if (ci >= static_cast<int>(parent.filters.size())) return true;
@@ -1407,6 +1452,8 @@ void SearchTab::buildFilterPanel() {
                             }
                             childOptionsBox->setVisibility(brls::Visibility::GONE);
                             if (childArrow) childArrow->setText("\u25B6");
+                            // Move focus back to parent row since options are now hidden
+                            brls::Application::giveFocus(childRow);
                             return true;
                         });
                         optRow->addGestureRecognizer(new brls::TapGestureRecognizer(optRow));
@@ -1548,7 +1595,7 @@ void SearchTab::buildFilterPanel() {
                     optRow->addView(optLabel);
 
                     int filterIdx2 = static_cast<int>(i);
-                    optRow->registerClickAction([this, filterIdx2, optIdx, rowLabel, makeFilterLabel, optionsBox, arrowLabel](brls::View*) {
+                    optRow->registerClickAction([this, filterIdx2, optIdx, rowLabel, makeFilterLabel, optionsBox, arrowLabel, row](brls::View*) {
                         if (filterIdx2 >= static_cast<int>(m_sourceFilters.size())) return true;
                         m_sourceFilters[filterIdx2].selectState = optIdx;
                         rowLabel->setText(makeFilterLabel(m_sourceFilters[filterIdx2]));
@@ -1567,6 +1614,8 @@ void SearchTab::buildFilterPanel() {
                         // Collapse after selection
                         optionsBox->setVisibility(brls::Visibility::GONE);
                         if (arrowLabel) arrowLabel->setText("\u25B6");
+                        // Move focus back to parent row since options are now hidden
+                        brls::Application::giveFocus(row);
                         return true;
                     });
                     optRow->addGestureRecognizer(new brls::TapGestureRecognizer(optRow));
@@ -1614,7 +1663,7 @@ void SearchTab::buildFilterPanel() {
                         optRow->addView(optLabel);
 
                         int filterIdx2 = static_cast<int>(i);
-                        optRow->registerClickAction([this, filterIdx2, sIdx, isAsc, rowLabel, makeFilterLabel, optionsBox, arrowLabel](brls::View*) {
+                        optRow->registerClickAction([this, filterIdx2, sIdx, isAsc, rowLabel, makeFilterLabel, optionsBox, arrowLabel, row](brls::View*) {
                             if (filterIdx2 >= static_cast<int>(m_sourceFilters.size())) return true;
                             m_sourceFilters[filterIdx2].sortState.index = sIdx;
                             m_sourceFilters[filterIdx2].sortState.ascending = isAsc;
@@ -1639,6 +1688,8 @@ void SearchTab::buildFilterPanel() {
                             // Collapse after selection
                             optionsBox->setVisibility(brls::Visibility::GONE);
                             if (arrowLabel) arrowLabel->setText("\u25B6");
+                            // Move focus back to parent row since options are now hidden
+                            brls::Application::giveFocus(row);
                             return true;
                         });
                         optRow->addGestureRecognizer(new brls::TapGestureRecognizer(optRow));

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -631,6 +631,7 @@ void SearchTab::showGlobalSearchDialog() {
     brls::Application::getImeManager()->openForText([this](std::string text) {
         if (text.empty()) return;
 
+        hideFilterPanel();
         m_searchQuery = text;
         m_titleLabel->setText("Search: " + text);
         addToSearchHistory(text);
@@ -643,6 +644,7 @@ void SearchTab::showSourceSearchDialog() {
     brls::Application::getImeManager()->openForText([this](std::string text) {
         if (text.empty()) return;
 
+        hideFilterPanel();
         m_searchQuery = text;
         m_titleLabel->setText(m_currentSourceName + " - Search: " + text);
         addToSearchHistory(text);
@@ -681,6 +683,7 @@ void SearchTab::showSearchHistoryDialog() {
                     // Use selected search query
                     auto& history = Application::getInstance().getSettings().searchHistory;
                     if (selected < static_cast<int>(history.size())) {
+                        hideFilterPanel();
                         std::string query = history[selected];
                         m_searchQuery = query;
                         m_titleLabel->setText("Search: " + query);
@@ -1333,13 +1336,30 @@ void SearchTab::buildFilterPanel() {
 
             // Update toggle to use childrenBox directly
             groupRow->registerClickAction([this, groupIdx, childrenBox, arrowLabel, groupRow](brls::View*) {
+                auto setChildrenFocusable = [](brls::Box* box, bool focusable) {
+                    for (auto* child : box->getChildren()) {
+                        auto* childBox = dynamic_cast<brls::Box*>(child);
+                        if (childBox) {
+                            childBox->setFocusable(focusable);
+                            // Also handle nested option boxes (SELECT children)
+                            for (auto* nested : childBox->getChildren()) {
+                                auto* nestedBox = dynamic_cast<brls::Box*>(nested);
+                                if (nestedBox) {
+                                    nestedBox->setFocusable(focusable);
+                                }
+                            }
+                        }
+                    }
+                };
                 if (m_collapsedGroups.count(groupIdx)) {
                     m_collapsedGroups.erase(groupIdx);
                     childrenBox->setVisibility(brls::Visibility::VISIBLE);
+                    setChildrenFocusable(childrenBox, true);
                     arrowLabel->setText("\u25BC");
                 } else {
                     m_collapsedGroups.insert(groupIdx);
                     childrenBox->setVisibility(brls::Visibility::GONE);
+                    setChildrenFocusable(childrenBox, false);
                     arrowLabel->setText("\u25B6");
                     // If focus was inside the collapsed group, move it to the group header
                     brls::View* focused = brls::Application::getCurrentFocus();
@@ -1365,7 +1385,7 @@ void SearchTab::buildFilterPanel() {
 
                 auto* childRow = new brls::Box();
                 childRow->setAxis(brls::Axis::ROW);
-                childRow->setFocusable(true);
+                childRow->setFocusable(!collapsed);
                 childRow->setPadding(4, 8, 4, 8);
                 childRow->setMarginBottom(1);
                 childRow->setCornerRadius(4);
@@ -1410,7 +1430,7 @@ void SearchTab::buildFilterPanel() {
                     for (int optIdx = 0; optIdx < static_cast<int>(child.selectOptions.size()); optIdx++) {
                         auto* optRow = new brls::Box();
                         optRow->setAxis(brls::Axis::ROW);
-                        optRow->setFocusable(true);
+                        optRow->setFocusable(false);  // Hidden by default (GONE), set focusable when expanded
                         optRow->setPadding(3, 8, 3, 8);
                         optRow->setMarginBottom(1);
                         optRow->setCornerRadius(4);
@@ -1451,6 +1471,10 @@ void SearchTab::buildFilterPanel() {
                                 }
                             }
                             childOptionsBox->setVisibility(brls::Visibility::GONE);
+                            for (auto* opt : childOptionsBox->getChildren()) {
+                                auto* optBox = dynamic_cast<brls::Box*>(opt);
+                                if (optBox) optBox->setFocusable(false);
+                            }
                             if (childArrow) childArrow->setText("\u25B6");
                             // Move focus back to parent row since options are now hidden
                             brls::Application::giveFocus(childRow);
@@ -1500,10 +1524,14 @@ void SearchTab::buildFilterPanel() {
                                 }, child.name, "", 256, child.textState);
                             break;
                         case FilterType::SELECT:
-                            // Toggle inline options visibility
+                            // Toggle inline options visibility and focusability
                             if (childOptionsBox) {
                                 bool expanding = childOptionsBox->getVisibility() == brls::Visibility::GONE;
                                 childOptionsBox->setVisibility(expanding ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+                                for (auto* opt : childOptionsBox->getChildren()) {
+                                    auto* optBox = dynamic_cast<brls::Box*>(opt);
+                                    if (optBox) optBox->setFocusable(expanding);
+                                }
                                 if (childArrow) childArrow->setText(expanding ? "\u25BC" : "\u25B6");
                             }
                             break;
@@ -1572,7 +1600,7 @@ void SearchTab::buildFilterPanel() {
                 for (int optIdx = 0; optIdx < static_cast<int>(filter.selectOptions.size()); optIdx++) {
                     auto* optRow = new brls::Box();
                     optRow->setAxis(brls::Axis::ROW);
-                    optRow->setFocusable(true);
+                    optRow->setFocusable(false);  // Hidden by default (GONE), set focusable when expanded
                     optRow->setPadding(4, 8, 4, 8);
                     optRow->setMarginBottom(1);
                     optRow->setCornerRadius(4);
@@ -1613,6 +1641,10 @@ void SearchTab::buildFilterPanel() {
                         }
                         // Collapse after selection
                         optionsBox->setVisibility(brls::Visibility::GONE);
+                        for (auto* opt : optionsBox->getChildren()) {
+                            auto* ob = dynamic_cast<brls::Box*>(opt);
+                            if (ob) ob->setFocusable(false);
+                        }
                         if (arrowLabel) arrowLabel->setText("\u25B6");
                         // Move focus back to parent row since options are now hidden
                         brls::Application::giveFocus(row);
@@ -1640,7 +1672,7 @@ void SearchTab::buildFilterPanel() {
 
                         auto* optRow = new brls::Box();
                         optRow->setAxis(brls::Axis::ROW);
-                        optRow->setFocusable(true);
+                        optRow->setFocusable(false);  // Hidden by default (GONE), set focusable when expanded
                         optRow->setPadding(4, 8, 4, 8);
                         optRow->setMarginBottom(1);
                         optRow->setCornerRadius(4);
@@ -1687,6 +1719,10 @@ void SearchTab::buildFilterPanel() {
                             }
                             // Collapse after selection
                             optionsBox->setVisibility(brls::Visibility::GONE);
+                            for (auto* opt : optionsBox->getChildren()) {
+                                auto* ob = dynamic_cast<brls::Box*>(opt);
+                                if (ob) ob->setFocusable(false);
+                            }
                             if (arrowLabel) arrowLabel->setText("\u25B6");
                             // Move focus back to parent row since options are now hidden
                             brls::Application::giveFocus(row);
@@ -1738,10 +1774,14 @@ void SearchTab::buildFilterPanel() {
                     break;
                 case FilterType::SELECT:
                 case FilterType::SORT:
-                    // Toggle inline options visibility
+                    // Toggle inline options visibility and focusability
                     if (optionsBox) {
                         bool expanding = optionsBox->getVisibility() == brls::Visibility::GONE;
                         optionsBox->setVisibility(expanding ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+                        for (auto* opt : optionsBox->getChildren()) {
+                            auto* optBox = dynamic_cast<brls::Box*>(opt);
+                            if (optBox) optBox->setFocusable(expanding);
+                        }
                         if (arrowLabel) arrowLabel->setText(expanding ? "\u25BC" : "\u25B6");
                     }
                     break;


### PR DESCRIPTION
Fixes focus leaking between the filter panel and the main content in the search tab, and stops hidden filter sections from remaining focusable when the panel hides on search.

---
_Generated by [Claude Code](https://claude.ai/code)_