### PR TITLE
Fix category dropdown pre-selecting first item and library UI not updating on removal

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -292,6 +292,12 @@ public:
     const std::set<int>& getRecentRemovals() const { return m_recentLibraryRemovals; }
     void clearRecentRemovals() { m_recentLibraryRemovals.clear(); }
 
+    // Track category changes for immediate UI update (manga moved to different category)
+    void trackCategoryChange(int mangaId) { m_recentCategoryChanges.insert(mangaId); }
+    bool hasRecentCategoryChanges() const { return !m_recentCategoryChanges.empty(); }
+    const std::set<int>& getRecentCategoryChanges() const { return m_recentCategoryChanges; }
+    void clearRecentCategoryChanges() { m_recentCategoryChanges.clear(); }
+
     // Application settings access
     AppSettings& getSettings() { return m_settings; }
     const AppSettings& getSettings() const { return m_settings; }
@@ -380,6 +386,7 @@ private:
     int m_currentCategoryId = 0;
     std::set<int> m_recentLibraryAdditions;  // Manga IDs added to library this session
     std::set<int> m_recentLibraryRemovals;  // Manga IDs removed from library this session
+    std::set<int> m_recentCategoryChanges;  // Manga IDs whose category was changed
     AppSettings m_settings;
     ReaderResult m_lastReaderResult;
     ReaderResultCallback m_readerResultCallback;

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -283,6 +283,7 @@ public:
     // Track library additions for immediate UI update
     void trackLibraryAddition(int mangaId) { m_recentLibraryAdditions.insert(mangaId); m_recentLibraryRemovals.erase(mangaId); }
     bool isRecentlyAdded(int mangaId) const { return m_recentLibraryAdditions.count(mangaId) > 0; }
+    const std::set<int>& getRecentAdditions() const { return m_recentLibraryAdditions; }
     void clearRecentAdditions() { m_recentLibraryAdditions.clear(); }
 
     // Track library removals for immediate UI update

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -281,9 +281,15 @@ public:
     void setCurrentCategoryId(int id) { m_currentCategoryId = id; }
 
     // Track library additions for immediate UI update
-    void trackLibraryAddition(int mangaId) { m_recentLibraryAdditions.insert(mangaId); }
+    void trackLibraryAddition(int mangaId) { m_recentLibraryAdditions.insert(mangaId); m_recentLibraryRemovals.erase(mangaId); }
     bool isRecentlyAdded(int mangaId) const { return m_recentLibraryAdditions.count(mangaId) > 0; }
     void clearRecentAdditions() { m_recentLibraryAdditions.clear(); }
+
+    // Track library removals for immediate UI update
+    void trackLibraryRemoval(int mangaId) { m_recentLibraryRemovals.insert(mangaId); m_recentLibraryAdditions.erase(mangaId); }
+    bool isRecentlyRemoved(int mangaId) const { return m_recentLibraryRemovals.count(mangaId) > 0; }
+    const std::set<int>& getRecentRemovals() const { return m_recentLibraryRemovals; }
+    void clearRecentRemovals() { m_recentLibraryRemovals.clear(); }
 
     // Application settings access
     AppSettings& getSettings() { return m_settings; }
@@ -372,6 +378,7 @@ private:
     std::string m_authPassword;
     int m_currentCategoryId = 0;
     std::set<int> m_recentLibraryAdditions;  // Manga IDs added to library this session
+    std::set<int> m_recentLibraryRemovals;  // Manga IDs removed from library this session
     AppSettings m_settings;
     ReaderResult m_lastReaderResult;
     ReaderResultCallback m_readerResultCallback;

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -39,6 +39,7 @@ public:
     ~LibrarySectionTab() override;
 
     void onFocusGained() override;
+    void willAppear(bool resetState) override;
     void willDisappear(bool resetState) override;
     void refresh();
 

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -204,6 +204,9 @@ private:
     // Update the read button text based on reading progress
     void updateReadButtonText();
 
+    // Update the library button appearance based on m_manga.inLibrary
+    void updateLibraryButton();
+
     // Apply pending reader result to m_chapters (progress from last reader session)
     void applyReaderResult();
 

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -31,6 +31,7 @@ public:
     void setListRowSize(int rowSize);   // List row size: 0=small, 1=medium, 2=large, 3=auto
     void setGridColumns(int columns);   // Set grid column count (adapts title font/truncation)
     void setShowLibraryBadge(bool show);  // Show star badge for library items (browser/search only)
+    void refreshLibraryBadge();  // Re-evaluate star badge visibility from recent add/remove state
 
     void onFocusGained() override;
     void onFocusLost() override;

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -39,6 +39,7 @@ public:
     void setListMode(bool listMode);  // List view instead of grid
     void setListRowSize(int rowSize);  // List row size: 0=small(60), 1=medium(80), 2=large(100), 3=auto
     void setShowLibraryBadge(bool show);  // Show star badge for library items (browser/search only)
+    void refreshLibraryBadges();  // Re-evaluate star badge visibility on all cells
     int getGridColumns() const { return m_columns; }
     bool isCompactMode() const { return m_compactMode; }
     bool isListMode() const { return m_listMode; }

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -26,6 +26,7 @@ public:
     ~SearchTab();
 
     void onFocusGained() override;
+    void willAppear(bool resetState) override;
     void willDisappear(bool resetState) override;
     brls::View* getNextFocus(brls::FocusDirection direction, brls::View* currentView) override;
 

--- a/include/view/source_browse_tab.hpp
+++ b/include/view/source_browse_tab.hpp
@@ -26,6 +26,7 @@ public:
     ~SourceBrowseTab();
 
     void onFocusGained() override;
+    void willAppear(bool resetState) override;
     void willDisappear(bool resetState) override;
 
 private:

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -480,6 +480,96 @@ bool LibrarySectionTab::hasFocusWithin() const {
     return false;
 }
 
+void LibrarySectionTab::willAppear(bool resetState) {
+    brls::Box::willAppear(resetState);
+
+    // Check for recent category changes when the tab becomes visible
+    // (e.g., after returning from a detail view where category was changed)
+    if (Application::getInstance().hasRecentCategoryChanges() && m_loaded) {
+        std::set<int> changedIds = Application::getInstance().getRecentCategoryChanges();
+        Application::getInstance().clearRecentCategoryChanges();
+
+        if (m_groupMode == LibraryGroupMode::BY_CATEGORY) {
+            // Remove changed manga from current view and reload
+            std::vector<int> removedIds(changedIds.begin(), changedIds.end());
+            size_t oldSize = m_mangaList.size();
+            m_mangaList.erase(
+                std::remove_if(m_mangaList.begin(), m_mangaList.end(),
+                    [&changedIds](const Manga& m) { return changedIds.count(m.id) > 0; }),
+                m_mangaList.end());
+            m_fullMangaList.erase(
+                std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(),
+                    [&changedIds](const Manga& m) { return changedIds.count(m.id) > 0; }),
+                m_fullMangaList.end());
+
+            if (m_mangaList.size() != oldSize) {
+                m_cachedMangaList.erase(
+                    std::remove_if(m_cachedMangaList.begin(), m_cachedMangaList.end(),
+                        [&changedIds](const CachedMangaItem& c) { return changedIds.count(c.id) > 0; }),
+                    m_cachedMangaList.end());
+
+                if (Application::getInstance().getSettings().cacheLibraryData) {
+                    LibraryCache::getInstance().saveCategoryManga(m_currentCategoryId, m_fullMangaList);
+                }
+
+                if (m_contentGrid) {
+                    m_contentGrid->removeItems(removedIds);
+                }
+            }
+
+            loadCategoryManga(m_currentCategoryId);
+        } else if (m_groupMode == LibraryGroupMode::NO_GROUPING) {
+            loadAllManga();
+        } else if (m_groupMode == LibraryGroupMode::BY_SOURCE) {
+            loadBySource();
+        }
+    }
+
+    // Check for recent library removals and additions
+    if (!Application::getInstance().getRecentRemovals().empty() && m_loaded) {
+        std::set<int> removedIdSet(Application::getInstance().getRecentRemovals().begin(),
+                                    Application::getInstance().getRecentRemovals().end());
+        std::vector<int> removedIds(removedIdSet.begin(), removedIdSet.end());
+        Application::getInstance().clearRecentRemovals();
+
+        size_t oldSize = m_mangaList.size();
+        m_mangaList.erase(
+            std::remove_if(m_mangaList.begin(), m_mangaList.end(),
+                [&removedIdSet](const Manga& m) { return removedIdSet.count(m.id) > 0; }),
+            m_mangaList.end());
+        m_fullMangaList.erase(
+            std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(),
+                [&removedIdSet](const Manga& m) { return removedIdSet.count(m.id) > 0; }),
+            m_fullMangaList.end());
+
+        if (m_mangaList.size() != oldSize) {
+            m_cachedMangaList.erase(
+                std::remove_if(m_cachedMangaList.begin(), m_cachedMangaList.end(),
+                    [&removedIdSet](const CachedMangaItem& c) { return removedIdSet.count(c.id) > 0; }),
+                m_cachedMangaList.end());
+
+            if (Application::getInstance().getSettings().cacheLibraryData) {
+                LibraryCache::getInstance().saveCategoryManga(m_currentCategoryId, m_fullMangaList);
+            }
+
+            if (m_contentGrid) {
+                m_contentGrid->removeItems(removedIds);
+            }
+        }
+    }
+
+    if (!Application::getInstance().getRecentAdditions().empty() && m_loaded) {
+        Application::getInstance().clearRecentAdditions();
+        if (m_groupMode == LibraryGroupMode::NO_GROUPING) {
+            loadAllManga();
+        } else if (m_groupMode == LibraryGroupMode::BY_SOURCE) {
+            loadBySource();
+        } else {
+            loadCategoryManga(m_currentCategoryId);
+        }
+    }
+}
+
 void LibrarySectionTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 
@@ -591,6 +681,52 @@ void LibrarySectionTab::onFocusGained() {
             if (m_contentGrid) {
                 m_contentGrid->removeItems(removedIds);
             }
+        }
+    }
+
+    // Check for recent category changes and remove affected manga from current category
+    // (manga was moved to a different category from the detail view)
+    if (Application::getInstance().hasRecentCategoryChanges() && m_loaded &&
+        m_groupMode == LibraryGroupMode::BY_CATEGORY) {
+        std::set<int> changedIds = Application::getInstance().getRecentCategoryChanges();
+        Application::getInstance().clearRecentCategoryChanges();
+
+        // Remove changed manga from current category view and reload to get correct state
+        std::vector<int> removedIds(changedIds.begin(), changedIds.end());
+        size_t oldSize = m_mangaList.size();
+        m_mangaList.erase(
+            std::remove_if(m_mangaList.begin(), m_mangaList.end(),
+                [&changedIds](const Manga& m) { return changedIds.count(m.id) > 0; }),
+            m_mangaList.end());
+        m_fullMangaList.erase(
+            std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(),
+                [&changedIds](const Manga& m) { return changedIds.count(m.id) > 0; }),
+            m_fullMangaList.end());
+
+        if (m_mangaList.size() != oldSize) {
+            m_cachedMangaList.erase(
+                std::remove_if(m_cachedMangaList.begin(), m_cachedMangaList.end(),
+                    [&changedIds](const CachedMangaItem& c) { return changedIds.count(c.id) > 0; }),
+                m_cachedMangaList.end());
+
+            if (Application::getInstance().getSettings().cacheLibraryData) {
+                LibraryCache::getInstance().saveCategoryManga(m_currentCategoryId, m_fullMangaList);
+            }
+
+            if (m_contentGrid) {
+                m_contentGrid->removeItems(removedIds);
+            }
+        }
+
+        // Reload to pick up manga that may have been moved INTO this category
+        loadCategoryManga(m_currentCategoryId);
+    } else if (Application::getInstance().hasRecentCategoryChanges() && m_loaded) {
+        // Non-category grouping modes: just clear the flag and reload
+        Application::getInstance().clearRecentCategoryChanges();
+        if (m_groupMode == LibraryGroupMode::NO_GROUPING) {
+            loadAllManga();
+        } else if (m_groupMode == LibraryGroupMode::BY_SOURCE) {
+            loadBySource();
         }
     }
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -558,6 +558,26 @@ void LibrarySectionTab::onFocusGained() {
         this->setActionAvailable(brls::ControllerButton::BUTTON_RB, true);
     }
 
+    // Check for recent library removals and update grid immediately
+    const auto& recentRemovals = Application::getInstance().getRecentRemovals();
+    if (!recentRemovals.empty() && m_loaded) {
+        auto shouldRemove = [&recentRemovals](const Manga& m) {
+            return recentRemovals.count(m.id) > 0;
+        };
+        size_t oldSize = m_mangaList.size();
+        m_mangaList.erase(
+            std::remove_if(m_mangaList.begin(), m_mangaList.end(), shouldRemove),
+            m_mangaList.end());
+        m_fullMangaList.erase(
+            std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(), shouldRemove),
+            m_fullMangaList.end());
+        Application::getInstance().clearRecentRemovals();
+
+        if (m_mangaList.size() != oldSize && m_contentGrid) {
+            m_contentGrid->setDataSource(m_mangaList);
+        }
+    }
+
     if (!m_loaded && m_categoriesLoaded) {
         // Reload based on current group mode
         if (m_groupMode == LibraryGroupMode::NO_GROUPING) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -561,20 +561,50 @@ void LibrarySectionTab::onFocusGained() {
     // Check for recent library removals and update grid immediately
     const auto& recentRemovals = Application::getInstance().getRecentRemovals();
     if (!recentRemovals.empty() && m_loaded) {
-        auto shouldRemove = [&recentRemovals](const Manga& m) {
-            return recentRemovals.count(m.id) > 0;
-        };
-        size_t oldSize = m_mangaList.size();
-        m_mangaList.erase(
-            std::remove_if(m_mangaList.begin(), m_mangaList.end(), shouldRemove),
-            m_mangaList.end());
-        m_fullMangaList.erase(
-            std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(), shouldRemove),
-            m_fullMangaList.end());
+        // Copy IDs before clearing the tracking set
+        std::set<int> removedIdSet(recentRemovals.begin(), recentRemovals.end());
+        std::vector<int> removedIds(removedIdSet.begin(), removedIdSet.end());
         Application::getInstance().clearRecentRemovals();
 
-        if (m_mangaList.size() != oldSize && m_contentGrid) {
-            m_contentGrid->setDataSource(m_mangaList);
+        size_t oldSize = m_mangaList.size();
+        m_mangaList.erase(
+            std::remove_if(m_mangaList.begin(), m_mangaList.end(),
+                [&removedIdSet](const Manga& m) { return removedIdSet.count(m.id) > 0; }),
+            m_mangaList.end());
+        m_fullMangaList.erase(
+            std::remove_if(m_fullMangaList.begin(), m_fullMangaList.end(),
+                [&removedIdSet](const Manga& m) { return removedIdSet.count(m.id) > 0; }),
+            m_fullMangaList.end());
+
+        if (m_mangaList.size() != oldSize) {
+            // Update cached manga list
+            m_cachedMangaList.erase(
+                std::remove_if(m_cachedMangaList.begin(), m_cachedMangaList.end(),
+                    [&removedIdSet](const CachedMangaItem& c) { return removedIdSet.count(c.id) > 0; }),
+                m_cachedMangaList.end());
+
+            // Update on-disk cache
+            if (Application::getInstance().getSettings().cacheLibraryData) {
+                LibraryCache::getInstance().saveCategoryManga(m_currentCategoryId, m_fullMangaList);
+            }
+
+            if (m_contentGrid) {
+                m_contentGrid->removeItems(removedIds);
+            }
+        }
+    }
+
+    // Check for recent library additions and trigger a background refresh
+    // to pull the newly added manga into the current category view
+    if (!Application::getInstance().getRecentAdditions().empty() && m_loaded) {
+        Application::getInstance().clearRecentAdditions();
+        // Reload current view to pick up newly added manga
+        if (m_groupMode == LibraryGroupMode::NO_GROUPING) {
+            loadAllManga();
+        } else if (m_groupMode == LibraryGroupMode::BY_SOURCE) {
+            loadBySource();
+        } else {
+            loadCategoryManga(m_currentCategoryId);
         }
     }
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -541,6 +541,8 @@ MangaDetailView::MangaDetailView(const Manga& manga)
             if (!cachedManga.artist.empty() && m_manga.artist.empty()) m_manga.artist = cachedManga.artist;
             if (cachedManga.genre.size() > m_manga.genre.size()) m_manga.genre = cachedManga.genre;
             if (!cachedManga.sourceName.empty() && m_manga.sourceName.empty()) m_manga.sourceName = cachedManga.sourceName;
+            // Restore library state from cache (search/browse results may not have it)
+            if (cachedManga.inLibrary && !m_manga.inLibrary) m_manga.inLibrary = true;
         }
     }
 
@@ -679,21 +681,11 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_libraryButton->setHeight(44);
     m_libraryButton->setMarginBottom(10);
     m_libraryButton->setCornerRadius(22);  // Pill-shaped
-    if (m_manga.inLibrary) {
-        m_libraryButton->setBackgroundColor(nvgRGBA(180, 60, 60, 255));  // Red for remove (semantic)
-        m_libraryButton->setText("Remove from Library");
-        m_libraryButton->registerClickAction([this](brls::View* view) {
-            onRemoveFromLibrary();
-            return true;
-        });
-    } else {
-        m_libraryButton->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-        m_libraryButton->setText("Add to Library");
-        m_libraryButton->registerClickAction([this](brls::View* view) {
-            onAddToLibrary();
-            return true;
-        });
+    // Check both server state and recently-added tracking for correct initial state
+    if (!m_manga.inLibrary && Application::getInstance().isRecentlyAdded(m_manga.id)) {
+        m_manga.inLibrary = true;
     }
+    updateLibraryButton();
     m_libraryButton->addGestureRecognizer(new brls::TapGestureRecognizer(m_libraryButton));
     // Hide add/remove library button when offline (server-only action)
     if (!Application::getInstance().isConnected()) {
@@ -1325,6 +1317,13 @@ void MangaDetailView::loadDetails() {
                         }
                         needsUpdate = true;
                     }
+                    // Sync library state from server response
+                    if (updatedManga.inLibrary != m_manga.inLibrary) {
+                        m_manga.inLibrary = updatedManga.inLibrary;
+                        updateLibraryButton();
+                        needsUpdate = true;
+                    }
+
                     if (needsUpdate) {
                         LibraryCache::getInstance().saveMangaDetails(m_manga);
                         brls::Logger::info("MangaDetailView: Updated and cached manga details from combined query");
@@ -1382,6 +1381,12 @@ void MangaDetailView::loadDetails() {
                                 }
                                 m_descriptionLabel->setText(truncatedDesc);
                             }
+                        }
+                        // Sync library state from server response
+                        if (fallbackManga.inLibrary != m_manga.inLibrary) {
+                            m_manga.inLibrary = fallbackManga.inLibrary;
+                            updateLibraryButton();
+                            needsUpdate = true;
                         }
                         if (needsUpdate) {
                             LibraryCache::getInstance().saveMangaDetails(m_manga);
@@ -2167,14 +2172,7 @@ void MangaDetailView::onAddToLibrary() {
             Application::getInstance().trackLibraryAddition(m_manga.id);
 
             // Switch button to "Remove from Library"
-            if (m_libraryButton) {
-                m_libraryButton->setBackgroundColor(nvgRGBA(180, 60, 60, 255));  // Red = semantic
-                m_libraryButton->setText("Remove from Library");
-                m_libraryButton->registerClickAction([this](brls::View* view) {
-                    onRemoveFromLibrary();
-                    return true;
-                });
-            }
+            updateLibraryButton();
 
             // If categories available, show selection dropdown
             if (categories.size() > 1) {
@@ -2233,14 +2231,7 @@ void MangaDetailView::onRemoveFromLibrary() {
                 // Track removal for immediate library UI update
                 Application::getInstance().trackLibraryRemoval(m_manga.id);
 
-                if (m_libraryButton) {
-                    m_libraryButton->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-                    m_libraryButton->setText("Add to Library");
-                    m_libraryButton->registerClickAction([this](brls::View* view) {
-                        onAddToLibrary();
-                        return true;
-                    });
-                }
+                updateLibraryButton();
                 brls::Application::notify("Removed from library");
             });
         } else {
@@ -3411,6 +3402,26 @@ void MangaDetailView::applyReaderResult() {
                 break;
             }
         }
+    }
+}
+
+void MangaDetailView::updateLibraryButton() {
+    if (!m_libraryButton) return;
+
+    if (m_manga.inLibrary) {
+        m_libraryButton->setBackgroundColor(nvgRGBA(180, 60, 60, 255));  // Red for remove
+        m_libraryButton->setText("Remove from Library");
+        m_libraryButton->registerClickAction([this](brls::View* view) {
+            onRemoveFromLibrary();
+            return true;
+        });
+    } else {
+        m_libraryButton->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+        m_libraryButton->setText("Add to Library");
+        m_libraryButton->registerClickAction([this](brls::View* view) {
+            onAddToLibrary();
+            return true;
+        });
     }
 }
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2207,7 +2207,7 @@ void MangaDetailView::onAddToLibrary() {
                                 }
                             });
                         });
-                    }, 0);
+                    }, -1);
                 brls::Application::pushActivity(new brls::Activity(dropdown));
             } else {
                 brls::Application::notify("Added to library");
@@ -2228,6 +2228,10 @@ void MangaDetailView::onRemoveFromLibrary() {
                 auto alive = aliveWeak.lock();
                 if (!alive || !*alive) return;
                 m_manga.inLibrary = false;
+
+                // Track removal for immediate library UI update
+                Application::getInstance().trackLibraryRemoval(m_manga.id);
+
                 if (m_libraryButton) {
                     m_libraryButton->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
                     m_libraryButton->setText("Add to Library");

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2197,7 +2197,8 @@ void MangaDetailView::onAddToLibrary() {
                             asyncRun([mangaId, categoryId]() {
                                 SuwayomiClient& client = SuwayomiClient::getInstance();
                                 if (client.setMangaCategories(mangaId, {categoryId})) {
-                                    brls::sync([]() {
+                                    brls::sync([mangaId]() {
+                                        Application::getInstance().trackCategoryChange(mangaId);
                                         brls::Application::notify("Added to library");
                                     });
                                 } else {
@@ -2808,7 +2809,8 @@ void MangaDetailView::showCategoryDialog() {
                         asyncRun([mangaId, categoryId]() {
                             SuwayomiClient& client = SuwayomiClient::getInstance();
                             if (client.setMangaCategories(mangaId, {categoryId})) {
-                                brls::sync([]() {
+                                brls::sync([mangaId]() {
+                                    Application::getInstance().trackCategoryChange(mangaId);
                                     brls::Application::notify("Category updated");
                                 });
                             } else {

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -280,7 +280,8 @@ void MangaItemCell::updateDisplay() {
     // Show star badge if manga is in library (browser/search tabs only)
     // Also check recent additions cache for immediate update
     if (m_starBadge) {
-        bool inLib = m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id);
+        bool inLib = (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
+                     && !Application::getInstance().isRecentlyRemoved(m_manga.id);
         bool showStar = m_showLibraryBadge && inLib;
         if (showStar && !m_starImageLoaded) {
             m_starBadge->setImageFromFile("app0:resources/icons/star.png");
@@ -584,7 +585,8 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     m_showLibraryBadge = show;
     // Update star badge visibility (also check recent additions cache)
     if (m_starBadge) {
-        bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id));
+        bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
+                     && !Application::getInstance().isRecentlyRemoved(m_manga.id);
         if (inLib && !m_starImageLoaded) {
             m_starBadge->setImageFromFile("app0:resources/icons/star.png");
             m_starImageLoaded = true;

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -391,6 +391,8 @@ brls::View* MangaItemCell::create() {
 void MangaItemCell::onFocusGained() {
     brls::Box::onFocusGained();
     updateFocusInfo(true);
+    // Refresh library badge to reflect add/remove changes from detail view
+    refreshLibraryBadge();
     // Show start button hint on focus (but not in browser/search tabs where library badge is shown)
     if (m_startHintIcon && !m_showLibraryBadge) {
         if (!m_startHintImageLoaded) {

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -599,6 +599,17 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     }
 }
 
+void MangaItemCell::refreshLibraryBadge() {
+    if (!m_starBadge || !m_showLibraryBadge) return;
+    bool inLib = (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
+                 && !Application::getInstance().isRecentlyRemoved(m_manga.id);
+    if (inLib && !m_starImageLoaded) {
+        m_starBadge->setImageFromFile("app0:resources/icons/star.png");
+        m_starImageLoaded = true;
+    }
+    m_starBadge->setVisibility(inLib ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+}
+
 void MangaItemCell::setListRowSize(int rowSize) {
     // No-op: list mode always auto-adapts row height to title length
     (void)rowSize;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -887,6 +887,12 @@ void RecyclingGrid::setShowLibraryBadge(bool show) {
     }
 }
 
+void RecyclingGrid::refreshLibraryBadges() {
+    for (auto* cell : m_cells) {
+        cell->refreshLibraryBadge();
+    }
+}
+
 brls::View* RecyclingGrid::getFirstCell() const {
     if (m_cells.empty()) {
         return nullptr;

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -429,6 +429,30 @@ SearchTab::~SearchTab() {
     if (m_sourceIconsAlive) *m_sourceIconsAlive = false;
 }
 
+void SearchTab::willAppear(bool resetState) {
+    brls::Box::willAppear(resetState);
+
+    // Refresh star badges on all cells to reflect library add/remove changes
+    // made while this tab was covered by another activity (e.g. detail view)
+    if (m_contentGrid) {
+        m_contentGrid->refreshLibraryBadges();
+    }
+
+    // Also refresh star badges in search-results-by-source horizontal rows
+    if (m_searchResultsBox) {
+        for (auto* row : m_searchResultsBox->getChildren()) {
+            auto* rowBox = dynamic_cast<brls::Box*>(row);
+            if (!rowBox) continue;
+            for (auto* child : rowBox->getChildren()) {
+                auto* cell = dynamic_cast<MangaItemCell*>(child);
+                if (cell) {
+                    cell->refreshLibraryBadge();
+                }
+            }
+        }
+    }
+}
+
 void SearchTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -473,6 +473,26 @@ void SearchTab::onFocusGained() {
     if (m_sources.empty()) {
         loadSources();
     }
+
+    // Refresh star badges on visible cells to reflect library add/remove changes
+    // made from the detail view (uses recent additions/removals tracking)
+    if (m_contentGrid) {
+        m_contentGrid->refreshLibraryBadges();
+    }
+
+    // Also refresh star badges in search-results-by-source horizontal rows
+    if (m_searchResultsBox) {
+        for (auto* row : m_searchResultsBox->getChildren()) {
+            auto* rowBox = dynamic_cast<brls::Box*>(row);
+            if (!rowBox) continue;
+            for (auto* child : rowBox->getChildren()) {
+                auto* cell = dynamic_cast<MangaItemCell*>(child);
+                if (cell) {
+                    cell->refreshLibraryBadge();
+                }
+            }
+        }
+    }
 }
 
 bool SearchTab::isFocusInPanel(brls::View* view) const {

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -179,6 +179,16 @@ SourceBrowseTab::~SourceBrowseTab() {
     if (m_alive) *m_alive = false;
 }
 
+void SourceBrowseTab::willAppear(bool resetState) {
+    brls::Box::willAppear(resetState);
+
+    // Refresh star badges on all cells to reflect library add/remove changes
+    // made while this tab was covered by another activity (e.g. detail view)
+    if (m_contentGrid) {
+        m_contentGrid->refreshLibraryBadges();
+    }
+}
+
 void SourceBrowseTab::willDisappear(bool resetState) {
     brls::Box::willDisappear(resetState);
 

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -191,6 +191,11 @@ void SourceBrowseTab::willDisappear(bool resetState) {
 
 void SourceBrowseTab::onFocusGained() {
     brls::Box::onFocusGained();
+
+    // Refresh star badges to reflect library add/remove changes from detail view
+    if (m_contentGrid) {
+        m_contentGrid->refreshLibraryBadges();
+    }
 }
 
 void SourceBrowseTab::loadPopular() {


### PR DESCRIPTION
Fixes real-time library UI updates: category dropdown pre-selecting the first item, the grid/star badge not updating on add/remove, and avoiding a full refresh from the detail view.

---
_Generated by [Claude Code](https://claude.ai/code)_