### PR TITLE
Replace single-select category dropdown with multi-select dialog

### DIFF
--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -74,6 +74,8 @@ private:
     void showMangaContextMenu(const Manga& manga, int index);
     void showDownloadSubmenu(const std::vector<Manga>& mangaList);
     void showChangeCategoryDialog(const std::vector<Manga>& mangaList);
+    void hideCategoryPanel();
+    bool isFocusInCategoryPanel(brls::View* view) const;
     void showMigrateSourceMenu(const Manga& manga);
 
     // Selection mode
@@ -173,6 +175,13 @@ private:
     bool m_thumbnailsInvalidated = false;  // Set in willDisappear after cancelAll, cleared on reload
     bool m_pendingLibraryChangeScheduled = false;  // Guard to prevent duplicate brls::sync scheduling
     int m_combinedQueryCategoryId = -1; // Category being fetched by combined query (skip redundant fetch)
+
+    // Inline category panel (centered overlay, shown/hidden on same page)
+    brls::Box* m_categoryOverlay = nullptr;
+    brls::Box* m_categoryPanel = nullptr;
+    brls::Box* m_lastHighlightedCatRow = nullptr;
+    brls::View* m_preCategoryPanelFocus = nullptr;
+    bool m_categoryPanelVisible = false;
 
     // Shared pointer to track if this object is still alive
     std::shared_ptr<bool> m_alive;

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -93,6 +93,7 @@ private:
     void onDeleteDownloads();
     void showDownloadOptions();
     void showCategoryDialog();
+    void showCategorySelectionDialog(int mangaId, const std::set<int>& preselected, std::weak_ptr<bool> aliveWeak);
     void showMangaMenu();
 
     // Chapter actions

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -94,6 +94,8 @@ private:
     void showDownloadOptions();
     void showCategoryDialog();
     void showCategorySelectionDialog(int mangaId, const std::set<int>& preselected, std::weak_ptr<bool> aliveWeak);
+    void hideCategoryPanel();
+    bool isFocusInCategoryPanel(brls::View* view) const;
     void showMangaMenu();
 
     // Chapter actions
@@ -227,6 +229,13 @@ private:
 
     // Lightweight: update only download icons on visible cells (no reloadData, no focus loss)
     void refreshVisibleDownloadIcons();
+
+    // Inline category panel (centered overlay, shown/hidden on same page)
+    brls::Box* m_categoryOverlay = nullptr;
+    brls::Box* m_categoryPanel = nullptr;
+    brls::Box* m_lastHighlightedCatRow = nullptr;
+    brls::View* m_preCategoryPanelFocus = nullptr;
+    bool m_categoryPanelVisible = false;
 
     // Friend for data source access
     friend class ChaptersDataSource;

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2818,6 +2818,12 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         return true;
     });
     applyBtn->addGestureRecognizer(new brls::TapGestureRecognizer(applyBtn));
+    applyBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedCatRow) {
+            m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedCatRow = nullptr;
+        }
+    });
 
     auto* resetBtn = new brls::Button();
     resetBtn->setText("Reset");
@@ -2839,6 +2845,12 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         return true;
     });
     resetBtn->addGestureRecognizer(new brls::TapGestureRecognizer(resetBtn));
+    resetBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedCatRow) {
+            m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedCatRow = nullptr;
+        }
+    });
 
     buttonRow->addView(applyBtn);
     buttonRow->addView(resetBtn);

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2580,11 +2580,11 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         }
     }
 
-    // Shared state for toggling checkmarks
+    // Shared state for toggling
     auto selectedCats = std::make_shared<std::set<int>>(checkedCatIds);
-    auto checkLabels = std::make_shared<std::vector<brls::Label*>>();
+    std::vector<Manga> capturedList = mangaList;
 
-    // Create dialog box (matching other dialog designs)
+    // Create dialog box (matching source filter / category visibility style)
     auto* dialogBox = new brls::Box();
     dialogBox->setAxis(brls::Axis::COLUMN);
     dialogBox->setWidth(550);
@@ -2595,115 +2595,26 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
 
     // Title
     auto* titleLabel = new brls::Label();
-    titleLabel->setText("Set Categories");
+    titleLabel->setText("Select Categories");
     titleLabel->setFontSize(22);
     titleLabel->setMarginBottom(10);
     dialogBox->addView(titleLabel);
 
     // Info label
     auto* infoLabel = new brls::Label();
-    infoLabel->setText("Tap to toggle categories");
+    infoLabel->setText("Tap to toggle categories for this manga");
     infoLabel->setFontSize(14);
     infoLabel->setTextColor(Application::getInstance().getSubtitleColor());
     infoLabel->setMarginBottom(15);
     dialogBox->addView(infoLabel);
 
-    // Create buttons early so they can be captured in lambdas
-    std::vector<Manga> capturedList = mangaList;
-
-    auto* saveBtn = new brls::Button();
-    saveBtn->setText("Save");
-    saveBtn->setMarginTop(15);
-    saveBtn->setMarginRight(10);
-
-    auto* cancelBtn = new brls::Button();
-    cancelBtn->setText("Cancel");
-    cancelBtn->setMarginTop(15);
-
-    // Scrollable category list
-    auto* scrollView = new brls::ScrollingFrame();
-    scrollView->setGrow(1.0f);
-
-    auto* catList = new brls::Box();
-    catList->setAxis(brls::Axis::COLUMN);
-
-    for (size_t i = 0; i < m_categories.size(); i++) {
-        const auto& cat = m_categories[i];
-        int catId = cat.id;
-
-        auto* row = new brls::Box();
-        row->setAxis(brls::Axis::ROW);
-        row->setFocusable(true);
-        row->setPadding(10, 12, 10, 12);
-        row->setMarginBottom(6);
-        row->setCornerRadius(8);
-        row->setAlignItems(brls::AlignItems::CENTER);
-
-        bool isChecked = selectedCats->count(catId) > 0;
-        row->setBackgroundColor(isChecked ? Application::getInstance().getActiveRowBackground() : Application::getInstance().getInactiveRowBackground());
-
-        // Checkmark label
-        auto* checkLabel = new brls::Label();
-        checkLabel->setFontSize(16);
-        checkLabel->setWidth(24);
-        checkLabel->setMarginRight(8);
-        if (isChecked) {
-            checkLabel->setText("\u2713");
-            checkLabel->setTextColor(Application::getInstance().getCtaButtonColor());
-        } else {
-            checkLabel->setText("");
-        }
-        row->addView(checkLabel);
-        checkLabels->push_back(checkLabel);
-
-        // Category name
-        auto* nameLabel = new brls::Label();
-        nameLabel->setText(cat.name);
-        nameLabel->setFontSize(16);
-        nameLabel->setGrow(1.0f);
-        row->addView(nameLabel);
-
-        // Toggle on click
-        row->registerClickAction([catId, selectedCats, checkLabels, i, row](brls::View*) {
-            if (selectedCats->count(catId)) {
-                selectedCats->erase(catId);
-                (*checkLabels)[i]->setText("");
-                row->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-            } else {
-                selectedCats->insert(catId);
-                (*checkLabels)[i]->setText("\u2713");
-                (*checkLabels)[i]->setTextColor(Application::getInstance().getCtaButtonColor());
-                row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
-            }
-            return true;
-        });
-        row->addGestureRecognizer(new brls::TapGestureRecognizer(row));
-
-        // Register B button on each row to cancel
-        row->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-            brls::Application::popActivity();
-            return true;
-        }, true);
-
-        catList->addView(row);
-    }
-
-    scrollView->setContentView(catList);
-    dialogBox->addView(scrollView);
-
-    // Button row
-    auto* buttonRow = new brls::Box();
-    buttonRow->setAxis(brls::Axis::ROW);
-    buttonRow->setJustifyContent(brls::JustifyContent::FLEX_END);
-    buttonRow->setMarginTop(15);
-
-    // Save button action
-    saveBtn->registerClickAction([this, capturedList, selectedCats](brls::View*) {
+    // Apply categories helper lambda
+    auto applyCategories = [this, capturedList, selectedCats]() {
         std::vector<int> newCatIds(selectedCats->begin(), selectedCats->end());
 
         if (newCatIds.empty()) {
             brls::Application::notify("Select at least one category");
-            return true;
+            return;
         }
 
         brls::Application::popActivity();
@@ -2803,49 +2714,126 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         });
 
         if (m_selectionMode) exitSelectionMode();
+    };
+
+    // Done button
+    auto* doneBtn = new brls::Button();
+    doneBtn->setText("Done");
+    doneBtn->setMarginTop(15);
+    doneBtn->registerClickAction([applyCategories](brls::View*) {
+        applyCategories();
         return true;
     });
-    saveBtn->addGestureRecognizer(new brls::TapGestureRecognizer(saveBtn));
+    doneBtn->addGestureRecognizer(new brls::TapGestureRecognizer(doneBtn));
 
-    // Register B button on save button
-    saveBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // B button on Done button applies and closes
+    doneBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
+        applyCategories();
         return true;
     }, true);
 
-    // Cancel button action
-    cancelBtn->registerClickAction([](brls::View*) {
-        brls::Application::popActivity();
-        return true;
-    });
-    cancelBtn->addGestureRecognizer(new brls::TapGestureRecognizer(cancelBtn));
+    // Scrollable category list
+    auto* scrollView = new brls::ScrollingFrame();
+    scrollView->setGrow(1.0f);
 
-    // Register B button on cancel button
-    cancelBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    auto* catList = new brls::Box();
+    catList->setAxis(brls::Axis::COLUMN);
+
+    for (size_t i = 0; i < m_categories.size(); i++) {
+        const auto& cat = m_categories[i];
+        int catId = cat.id;
+
+        auto* row = new brls::Box();
+        row->setAxis(brls::Axis::ROW);
+        row->setAlignItems(brls::AlignItems::CENTER);
+        row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+        row->setFocusable(true);
+        row->setPadding(10, 12, 10, 12);
+        row->setMarginBottom(6);
+        row->setCornerRadius(8);
+
+        bool isChecked = selectedCats->count(catId) > 0;
+        row->setBackgroundColor(isChecked ? Application::getInstance().getActiveRowBackground() : Application::getInstance().getInactiveRowBackground());
+
+        // Category info box (name + manga count)
+        auto* infoBox = new brls::Box();
+        infoBox->setAxis(brls::Axis::COLUMN);
+        infoBox->setGrow(1.0f);
+
+        auto* nameLabel = new brls::Label();
+        std::string displayName = cat.name;
+        if (displayName.length() > 20) {
+            displayName = displayName.substr(0, 18) + "..";
+        }
+        nameLabel->setText(displayName);
+        nameLabel->setFontSize(16);
+        infoBox->addView(nameLabel);
+
+        if (cat.mangaCount > 0) {
+            auto* countLabel = new brls::Label();
+            countLabel->setText(std::to_string(cat.mangaCount) + " manga");
+            countLabel->setFontSize(12);
+            countLabel->setTextColor(Application::getInstance().getDimTextColor());
+            infoBox->addView(countLabel);
+        }
+
+        row->addView(infoBox);
+
+        // Status indicator (checkmark on right side)
+        auto* statusLabel = new brls::Label();
+        statusLabel->setText(isChecked ? "\u2713" : "");
+        statusLabel->setFontSize(16);
+        statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
+        statusLabel->setMarginRight(10);
+        row->addView(statusLabel);
+
+        // Toggle on click
+        row->registerClickAction([catId, selectedCats, statusLabel, row](brls::View*) {
+            if (selectedCats->count(catId)) {
+                selectedCats->erase(catId);
+                statusLabel->setText("");
+                row->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            } else {
+                selectedCats->insert(catId);
+                statusLabel->setText("\u2713");
+                statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
+                row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
+            }
+            return true;
+        });
+        row->addGestureRecognizer(new brls::TapGestureRecognizer(row));
+
+        // B button on each row applies and closes
+        row->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
+            applyCategories();
+            return true;
+        }, true);
+
+        catList->addView(row);
+    }
+
+    scrollView->setContentView(catList);
+    dialogBox->addView(scrollView);
+    dialogBox->addView(doneBtn);
+
+    // B button on dialog applies and closes
+    dialogBox->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
+        applyCategories();
         return true;
     }, true);
 
-    buttonRow->addView(saveBtn);
-    buttonRow->addView(cancelBtn);
-    dialogBox->addView(buttonRow);
-
-    // Register B button on dialog box
-    dialogBox->registerAction("Back", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // Circle button applies and closes
+    dialogBox->registerAction("Close", brls::ControllerButton::BUTTON_BACK, [applyCategories](brls::View*) {
+        applyCategories();
         return true;
     }, true);
 
     // Set up navigation
     auto& catChildren = catList->getChildren();
     if (!catChildren.empty()) {
-        catChildren.front()->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.front());
-        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, saveBtn);
-        saveBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
-        cancelBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, doneBtn);
+        doneBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
     }
-    saveBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, saveBtn);
-    cancelBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, cancelBtn);
 
     // Push as new activity
     brls::Application::pushActivity(new brls::Activity(dialogBox));

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2695,10 +2695,18 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         if (m_selectionMode) exitSelectionMode();
     };
 
+    // Centering container (so dialog doesn't fill the whole screen)
+    auto* container = new brls::Box();
+    container->setAxis(brls::Axis::COLUMN);
+    container->setJustifyContent(brls::JustifyContent::CENTER);
+    container->setAlignItems(brls::AlignItems::CENTER);
+    container->setGrow(1.0f);
+
     // Create dialog box (matching source filter menu exactly)
     auto* dialogBox = new brls::Box();
     dialogBox->setAxis(brls::Axis::COLUMN);
     dialogBox->setWidth(300);
+    dialogBox->setHeight(350);
     dialogBox->setPadding(10);
     dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
     dialogBox->setCornerRadius(12);
@@ -2829,7 +2837,8 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
     }, true);
 
     // Push as new activity
-    brls::Application::pushActivity(new brls::Activity(dialogBox));
+    container->addView(dialogBox);
+    brls::Application::pushActivity(new brls::Activity(container));
 }
 
 void LibrarySectionTab::showMigrateSourceMenu(const Manga& manga) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2584,29 +2584,8 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
     auto selectedCats = std::make_shared<std::set<int>>(checkedCatIds);
     std::vector<Manga> capturedList = mangaList;
 
-    // Create dialog box (matching source filter / category visibility style)
-    auto* dialogBox = new brls::Box();
-    dialogBox->setAxis(brls::Axis::COLUMN);
-    dialogBox->setWidth(550);
-    dialogBox->setHeight(450);
-    dialogBox->setPadding(20);
-    dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
-    dialogBox->setCornerRadius(12);
-
-    // Title
-    auto* titleLabel = new brls::Label();
-    titleLabel->setText("Select Categories");
-    titleLabel->setFontSize(22);
-    titleLabel->setMarginBottom(10);
-    dialogBox->addView(titleLabel);
-
-    // Info label
-    auto* infoLabel = new brls::Label();
-    infoLabel->setText("Tap to toggle categories for this manga");
-    infoLabel->setFontSize(14);
-    infoLabel->setTextColor(Application::getInstance().getSubtitleColor());
-    infoLabel->setMarginBottom(15);
-    dialogBox->addView(infoLabel);
+    // Track last highlighted row for hover effect (source filter style)
+    auto lastHighlighted = std::make_shared<brls::Box*>(nullptr);
 
     // Apply categories helper lambda
     auto applyCategories = [this, capturedList, selectedCats]() {
@@ -2716,124 +2695,138 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         if (m_selectionMode) exitSelectionMode();
     };
 
-    // Done button
-    auto* doneBtn = new brls::Button();
-    doneBtn->setText("Done");
-    doneBtn->setMarginTop(15);
-    doneBtn->registerClickAction([applyCategories](brls::View*) {
-        applyCategories();
-        return true;
-    });
-    doneBtn->addGestureRecognizer(new brls::TapGestureRecognizer(doneBtn));
+    // Create dialog box (matching source filter menu exactly)
+    auto* dialogBox = new brls::Box();
+    dialogBox->setAxis(brls::Axis::COLUMN);
+    dialogBox->setWidth(300);
+    dialogBox->setPadding(10);
+    dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
+    dialogBox->setCornerRadius(12);
 
-    // B button on Done button applies and closes
-    doneBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
-        applyCategories();
-        return true;
-    }, true);
+    // Title
+    auto* titleLabel = new brls::Label();
+    titleLabel->setText("Select Categories");
+    titleLabel->setFontSize(18);
+    titleLabel->setSingleLine(true);
+    titleLabel->setMarginBottom(6);
+    dialogBox->addView(titleLabel);
 
-    // Scrollable category list
-    auto* scrollView = new brls::ScrollingFrame();
-    scrollView->setGrow(1.0f);
+    // Main scrolling frame
+    auto* mainScroll = new brls::ScrollingFrame();
+    mainScroll->setGrow(1.0f);
 
-    auto* catList = new brls::Box();
-    catList->setAxis(brls::Axis::COLUMN);
+    auto* catListBox = new brls::Box();
+    catListBox->setAxis(brls::Axis::COLUMN);
+
+    // Helper: build label text with checkmark prefix
+    auto makeCatLabel = [](const std::string& name, bool checked) -> std::string {
+        return (checked ? "\u2713 " : "   ") + name;
+    };
 
     for (size_t i = 0; i < m_categories.size(); i++) {
         const auto& cat = m_categories[i];
         int catId = cat.id;
+        bool isChecked = selectedCats->count(catId) > 0;
 
         auto* row = new brls::Box();
         row->setAxis(brls::Axis::ROW);
-        row->setAlignItems(brls::AlignItems::CENTER);
-        row->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
         row->setFocusable(true);
-        row->setPadding(10, 12, 10, 12);
-        row->setMarginBottom(6);
-        row->setCornerRadius(8);
+        row->setPadding(5, 8, 5, 8);
+        row->setMarginBottom(2);
+        row->setCornerRadius(6);
+        row->setAlignItems(brls::AlignItems::CENTER);
+        row->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
 
-        bool isChecked = selectedCats->count(catId) > 0;
-        row->setBackgroundColor(isChecked ? Application::getInstance().getActiveRowBackground() : Application::getInstance().getInactiveRowBackground());
+        auto* rowLabel = new brls::Label();
+        rowLabel->setText(makeCatLabel(cat.name, isChecked));
+        rowLabel->setFontSize(13);
+        rowLabel->setSingleLine(true);
+        row->addView(rowLabel);
 
-        // Category info box (name + manga count)
-        auto* infoBox = new brls::Box();
-        infoBox->setAxis(brls::Axis::COLUMN);
-        infoBox->setGrow(1.0f);
+        // Hover highlight (source filter style)
+        row->getFocusEvent()->subscribe([lastHighlighted, row](brls::View*) {
+            if (*lastHighlighted && *lastHighlighted != row) {
+                (*lastHighlighted)->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            }
+            row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
+            *lastHighlighted = row;
+        });
 
-        auto* nameLabel = new brls::Label();
-        std::string displayName = cat.name;
-        if (displayName.length() > 20) {
-            displayName = displayName.substr(0, 18) + "..";
-        }
-        nameLabel->setText(displayName);
-        nameLabel->setFontSize(16);
-        infoBox->addView(nameLabel);
-
-        if (cat.mangaCount > 0) {
-            auto* countLabel = new brls::Label();
-            countLabel->setText(std::to_string(cat.mangaCount) + " manga");
-            countLabel->setFontSize(12);
-            countLabel->setTextColor(Application::getInstance().getDimTextColor());
-            infoBox->addView(countLabel);
-        }
-
-        row->addView(infoBox);
-
-        // Status indicator (checkmark on right side)
-        auto* statusLabel = new brls::Label();
-        statusLabel->setText(isChecked ? "\u2713" : "");
-        statusLabel->setFontSize(16);
-        statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
-        statusLabel->setMarginRight(10);
-        row->addView(statusLabel);
-
-        // Toggle on click
-        row->registerClickAction([catId, selectedCats, statusLabel, row](brls::View*) {
-            if (selectedCats->count(catId)) {
+        // Click to toggle
+        row->registerClickAction([catId, selectedCats, rowLabel, makeCatLabel, cat](brls::View*) {
+            bool currentlySelected = (selectedCats->find(catId) != selectedCats->end());
+            if (currentlySelected) {
                 selectedCats->erase(catId);
-                statusLabel->setText("");
-                row->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
             } else {
                 selectedCats->insert(catId);
-                statusLabel->setText("\u2713");
-                statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
-                row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
             }
+            rowLabel->setText(makeCatLabel(cat.name, !currentlySelected));
             return true;
         });
         row->addGestureRecognizer(new brls::TapGestureRecognizer(row));
 
-        // B button on each row applies and closes
-        row->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
-            applyCategories();
-            return true;
-        }, true);
-
-        catList->addView(row);
+        catListBox->addView(row);
     }
 
-    scrollView->setContentView(catList);
-    dialogBox->addView(scrollView);
-    dialogBox->addView(doneBtn);
+    mainScroll->setContentView(catListBox);
 
-    // B button on dialog applies and closes
-    dialogBox->registerAction("Back", brls::ControllerButton::BUTTON_B, [applyCategories](brls::View*) {
-        applyCategories();
+    // B button on scroll list closes dialog
+    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
+        brls::Application::popActivity();
         return true;
     }, true);
 
-    // Circle button applies and closes
-    dialogBox->registerAction("Close", brls::ControllerButton::BUTTON_BACK, [applyCategories](brls::View*) {
+    dialogBox->addView(mainScroll);
+
+    // Button row (Apply / Reset style matching source filter)
+    auto* buttonRow = new brls::Box();
+    buttonRow->setAxis(brls::Axis::ROW);
+    buttonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
+    buttonRow->setMarginTop(6);
+
+    auto* applyBtn = new brls::Button();
+    applyBtn->setText("Apply");
+    applyBtn->setMarginRight(8);
+    applyBtn->registerClickAction([applyCategories](brls::View*) {
         applyCategories();
         return true;
-    }, true);
+    });
+    applyBtn->addGestureRecognizer(new brls::TapGestureRecognizer(applyBtn));
 
-    // Set up navigation
-    auto& catChildren = catList->getChildren();
-    if (!catChildren.empty()) {
-        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, doneBtn);
-        doneBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
-    }
+    auto* resetBtn = new brls::Button();
+    resetBtn->setText("Reset");
+    resetBtn->registerClickAction([selectedCats, checkedCatIds, catListBox, makeCatLabel, this](brls::View*) {
+        // Reset to original pre-selected state
+        *selectedCats = checkedCatIds;
+        // Update all row labels
+        auto& children = catListBox->getChildren();
+        for (size_t i = 0; i < children.size() && i < m_categories.size(); i++) {
+            auto* rowBox = dynamic_cast<brls::Box*>(children[i]);
+            if (rowBox && !rowBox->getChildren().empty()) {
+                auto* lbl = dynamic_cast<brls::Label*>(rowBox->getChildren()[0]);
+                if (lbl) {
+                    bool checked = selectedCats->find(m_categories[i].id) != selectedCats->end();
+                    lbl->setText(makeCatLabel(m_categories[i].name, checked));
+                }
+            }
+        }
+        return true;
+    });
+    resetBtn->addGestureRecognizer(new brls::TapGestureRecognizer(resetBtn));
+
+    buttonRow->addView(applyBtn);
+    buttonRow->addView(resetBtn);
+    dialogBox->addView(buttonRow);
+
+    // B button on buttons closes dialog
+    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
+        brls::Application::popActivity();
+        return true;
+    }, true);
+    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
+        brls::Application::popActivity();
+        return true;
+    }, true);
 
     // Push as new activity
     brls::Application::pushActivity(new brls::Activity(dialogBox));

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2856,6 +2856,14 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
     buttonRow->addView(resetBtn);
     m_categoryPanel->addView(buttonRow);
 
+    // Custom navigation: link last category row <-> apply button
+    auto& catChildren = catListBox->getChildren();
+    if (!catChildren.empty()) {
+        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, applyBtn);
+        applyBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+        resetBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+    }
+
     // B button on panel buttons to close panel
     applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
         hideCategoryPanel();

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -403,6 +403,29 @@ LibrarySectionTab::LibrarySectionTab() {
 
     this->addView(m_contentGrid);
 
+    // Inline category panel overlay (centered, hidden by default)
+    m_categoryOverlay = new brls::Box();
+    m_categoryOverlay->setAxis(brls::Axis::COLUMN);
+    m_categoryOverlay->setJustifyContent(brls::JustifyContent::CENTER);
+    m_categoryOverlay->setAlignItems(brls::AlignItems::CENTER);
+    m_categoryOverlay->setWidth(960);
+    m_categoryOverlay->setHeight(544);
+    m_categoryOverlay->setPositionType(brls::PositionType::ABSOLUTE);
+    m_categoryOverlay->setPositionTop(0);
+    m_categoryOverlay->setPositionLeft(0);
+    m_categoryOverlay->setVisibility(brls::Visibility::GONE);
+
+    m_categoryPanel = new brls::Box();
+    m_categoryPanel->setAxis(brls::Axis::COLUMN);
+    m_categoryPanel->setWidth(300);
+    m_categoryPanel->setHeight(350);
+    m_categoryPanel->setPadding(10);
+    m_categoryPanel->setBackgroundColor(Application::getInstance().getDialogBackground());
+    m_categoryPanel->setCornerRadius(12);
+    m_categoryOverlay->addView(m_categoryPanel);
+
+    this->addView(m_categoryOverlay);
+
     brls::Logger::debug("LibrarySectionTab: Created");
 
     // Register L/R buttons to navigate between categories
@@ -2572,6 +2595,20 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         return;
     }
 
+    // Toggle: if already showing, hide and return
+    if (m_categoryPanelVisible) {
+        hideCategoryPanel();
+        return;
+    }
+
+    // Save current focus so we can restore it when closing
+    m_preCategoryPanelFocus = brls::Application::getCurrentFocus();
+    m_lastHighlightedCatRow = nullptr;
+
+    // Clear and repopulate the inline panel
+    m_categoryPanel->clearViews();
+    m_categoryPanelVisible = true;
+
     // Build set of category IDs that any selected manga belongs to
     std::set<int> checkedCatIds;
     for (const auto& manga : mangaList) {
@@ -2584,9 +2621,6 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
     auto selectedCats = std::make_shared<std::set<int>>(checkedCatIds);
     std::vector<Manga> capturedList = mangaList;
 
-    // Track last highlighted row for hover effect (source filter style)
-    auto lastHighlighted = std::make_shared<brls::Box*>(nullptr);
-
     // Apply categories helper lambda
     auto applyCategories = [this, capturedList, selectedCats]() {
         std::vector<int> newCatIds(selectedCats->begin(), selectedCats->end());
@@ -2596,7 +2630,7 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
             return;
         }
 
-        brls::Application::popActivity();
+        hideCategoryPanel();
 
         std::weak_ptr<bool> aliveWeak = m_alive;
         std::vector<Manga> asyncList = capturedList;
@@ -2695,29 +2729,13 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         if (m_selectionMode) exitSelectionMode();
     };
 
-    // Centering container (so dialog doesn't fill the whole screen)
-    auto* container = new brls::Box();
-    container->setAxis(brls::Axis::COLUMN);
-    container->setJustifyContent(brls::JustifyContent::CENTER);
-    container->setAlignItems(brls::AlignItems::CENTER);
-    container->setGrow(1.0f);
-
-    // Create dialog box (matching source filter menu exactly)
-    auto* dialogBox = new brls::Box();
-    dialogBox->setAxis(brls::Axis::COLUMN);
-    dialogBox->setWidth(300);
-    dialogBox->setHeight(350);
-    dialogBox->setPadding(10);
-    dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
-    dialogBox->setCornerRadius(12);
-
     // Title
     auto* titleLabel = new brls::Label();
     titleLabel->setText("Select Categories");
     titleLabel->setFontSize(18);
     titleLabel->setSingleLine(true);
     titleLabel->setMarginBottom(6);
-    dialogBox->addView(titleLabel);
+    m_categoryPanel->addView(titleLabel);
 
     // Main scrolling frame
     auto* mainScroll = new brls::ScrollingFrame();
@@ -2752,12 +2770,12 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         row->addView(rowLabel);
 
         // Hover highlight (source filter style)
-        row->getFocusEvent()->subscribe([lastHighlighted, row](brls::View*) {
-            if (*lastHighlighted && *lastHighlighted != row) {
-                (*lastHighlighted)->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+        row->getFocusEvent()->subscribe([this, row](brls::View*) {
+            if (m_lastHighlightedCatRow && m_lastHighlightedCatRow != row) {
+                m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
             }
             row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
-            *lastHighlighted = row;
+            m_lastHighlightedCatRow = row;
         });
 
         // Click to toggle
@@ -2778,13 +2796,13 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
 
     mainScroll->setContentView(catListBox);
 
-    // B button on scroll list closes dialog
-    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // B button on scroll list closes panel
+    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
 
-    dialogBox->addView(mainScroll);
+    m_categoryPanel->addView(mainScroll);
 
     // Button row (Apply / Reset style matching source filter)
     auto* buttonRow = new brls::Box();
@@ -2824,21 +2842,58 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
 
     buttonRow->addView(applyBtn);
     buttonRow->addView(resetBtn);
-    dialogBox->addView(buttonRow);
+    m_categoryPanel->addView(buttonRow);
 
-    // B button on buttons closes dialog
-    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // B button on panel buttons to close panel
+    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
-    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
 
-    // Push as new activity
-    container->addView(dialogBox);
-    brls::Application::pushActivity(new brls::Activity(container));
+    // Show the overlay and give focus to first category row
+    m_categoryOverlay->setVisibility(brls::Visibility::VISIBLE);
+    if (!catListBox->getChildren().empty()) {
+        brls::Application::giveFocus(catListBox->getChildren()[0]);
+    }
+}
+
+void LibrarySectionTab::hideCategoryPanel() {
+    if (!m_categoryPanelVisible) return;
+    m_lastHighlightedCatRow = nullptr;
+    m_categoryPanelVisible = false;
+    m_categoryPanel->clearViews();
+    m_categoryOverlay->setVisibility(brls::Visibility::GONE);
+
+    // Restore focus
+    if (m_preCategoryPanelFocus) {
+        brls::View* check = m_preCategoryPanelFocus;
+        bool valid = false;
+        while (check) {
+            if (check == this) { valid = true; break; }
+            check = check->getParent();
+        }
+        if (valid) {
+            brls::Application::giveFocus(m_preCategoryPanelFocus);
+        } else {
+            if (m_contentGrid) {
+                brls::Application::giveFocus(m_contentGrid);
+            }
+        }
+        m_preCategoryPanelFocus = nullptr;
+    }
+}
+
+bool LibrarySectionTab::isFocusInCategoryPanel(brls::View* view) const {
+    while (view) {
+        if (view == m_categoryOverlay)
+            return true;
+        view = view->getParent();
+    }
+    return false;
 }
 
 void LibrarySectionTab::showMigrateSourceMenu(const Manga& manga) {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1015,6 +1015,29 @@ MangaDetailView::MangaDetailView(const Manga& manga)
 
     this->addView(rightPanel);
 
+    // Inline category panel overlay (centered, hidden by default)
+    m_categoryOverlay = new brls::Box();
+    m_categoryOverlay->setAxis(brls::Axis::COLUMN);
+    m_categoryOverlay->setJustifyContent(brls::JustifyContent::CENTER);
+    m_categoryOverlay->setAlignItems(brls::AlignItems::CENTER);
+    m_categoryOverlay->setWidth(960);
+    m_categoryOverlay->setHeight(544);
+    m_categoryOverlay->setPositionType(brls::PositionType::ABSOLUTE);
+    m_categoryOverlay->setPositionTop(0);
+    m_categoryOverlay->setPositionLeft(0);
+    m_categoryOverlay->setVisibility(brls::Visibility::GONE);
+
+    m_categoryPanel = new brls::Box();
+    m_categoryPanel->setAxis(brls::Axis::COLUMN);
+    m_categoryPanel->setWidth(300);
+    m_categoryPanel->setHeight(350);
+    m_categoryPanel->setPadding(10);
+    m_categoryPanel->setBackgroundColor(Application::getInstance().getDialogBackground());
+    m_categoryPanel->setCornerRadius(12);
+    m_categoryOverlay->addView(m_categoryPanel);
+
+    this->addView(m_categoryOverlay);
+
     // Load button icons immediately (avoids blank→loaded flash)
     selectIcon->setImageFromFile("app0:resources/images/select_button.png");
     rButtonIcon->setImageFromFile("app0:resources/images/r_button.png");
@@ -2751,27 +2774,22 @@ void MangaDetailView::showCategoryDialog() {
 }
 
 void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<int>& preselected, std::weak_ptr<bool> aliveWeak) {
+    // Toggle: if already showing, hide and return
+    if (m_categoryPanelVisible) {
+        hideCategoryPanel();
+        return;
+    }
+
+    // Save current focus so we can restore it when closing
+    m_preCategoryPanelFocus = brls::Application::getCurrentFocus();
+    m_lastHighlightedCatRow = nullptr;
+
+    // Clear and repopulate the inline panel
+    m_categoryPanel->clearViews();
+    m_categoryPanelVisible = true;
+
     // Shared set of selected category IDs
     auto selectedIds = std::make_shared<std::set<int>>(preselected);
-
-    // Track last highlighted row for hover effect (source filter style)
-    auto lastHighlighted = std::make_shared<brls::Box*>(nullptr);
-
-    // Centering container (so dialog doesn't fill the whole screen)
-    auto* container = new brls::Box();
-    container->setAxis(brls::Axis::COLUMN);
-    container->setJustifyContent(brls::JustifyContent::CENTER);
-    container->setAlignItems(brls::AlignItems::CENTER);
-    container->setGrow(1.0f);
-
-    // Create dialog box (matching source filter menu exactly)
-    auto* dialogBox = new brls::Box();
-    dialogBox->setAxis(brls::Axis::COLUMN);
-    dialogBox->setWidth(300);
-    dialogBox->setHeight(350);
-    dialogBox->setPadding(10);
-    dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
-    dialogBox->setCornerRadius(12);
 
     // Title
     auto* titleLabel = new brls::Label();
@@ -2779,7 +2797,7 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
     titleLabel->setFontSize(18);
     titleLabel->setSingleLine(true);
     titleLabel->setMarginBottom(6);
-    dialogBox->addView(titleLabel);
+    m_categoryPanel->addView(titleLabel);
 
     // Main scrolling frame
     auto* mainScroll = new brls::ScrollingFrame();
@@ -2814,12 +2832,12 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
         row->addView(rowLabel);
 
         // Hover highlight (source filter style)
-        row->getFocusEvent()->subscribe([lastHighlighted, row](brls::View*) {
-            if (*lastHighlighted && *lastHighlighted != row) {
-                (*lastHighlighted)->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+        row->getFocusEvent()->subscribe([this, row](brls::View*) {
+            if (m_lastHighlightedCatRow && m_lastHighlightedCatRow != row) {
+                m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
             }
             row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
-            *lastHighlighted = row;
+            m_lastHighlightedCatRow = row;
         });
 
         // Click to toggle
@@ -2848,13 +2866,13 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
 
     mainScroll->setContentView(catListBox);
 
-    // B button on scroll list closes dialog
-    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // B button on scroll list closes panel
+    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
 
-    dialogBox->addView(mainScroll);
+    m_categoryPanel->addView(mainScroll);
 
     // Button row (Apply / Reset style matching source filter)
     auto* buttonRow = new brls::Box();
@@ -2865,8 +2883,8 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
     auto* applyBtn = new brls::Button();
     applyBtn->setText("Apply");
     applyBtn->setMarginRight(8);
-    applyBtn->registerClickAction([mangaId, selectedIds, aliveWeak](brls::View*) {
-        brls::Application::popActivity();
+    applyBtn->registerClickAction([this, mangaId, selectedIds, aliveWeak](brls::View*) {
+        hideCategoryPanel();
         std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
         brls::sync([mangaId, catIds, aliveWeak]() {
             auto alive = aliveWeak.lock();
@@ -2907,20 +2925,54 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
 
     buttonRow->addView(applyBtn);
     buttonRow->addView(resetBtn);
-    dialogBox->addView(buttonRow);
+    m_categoryPanel->addView(buttonRow);
 
-    // B button on buttons closes dialog
-    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    // B button on panel buttons to close panel
+    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
-    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
-        brls::Application::popActivity();
+    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
+        hideCategoryPanel();
         return true;
     }, true);
 
-    container->addView(dialogBox);
-    brls::Application::pushActivity(new brls::Activity(container));
+    // Show the overlay and give focus to first category row
+    m_categoryOverlay->setVisibility(brls::Visibility::VISIBLE);
+    if (!catListBox->getChildren().empty()) {
+        brls::Application::giveFocus(catListBox->getChildren()[0]);
+    }
+}
+
+void MangaDetailView::hideCategoryPanel() {
+    if (!m_categoryPanelVisible) return;
+    m_lastHighlightedCatRow = nullptr;
+    m_categoryPanelVisible = false;
+    m_categoryPanel->clearViews();
+    m_categoryOverlay->setVisibility(brls::Visibility::GONE);
+
+    // Restore focus
+    if (m_preCategoryPanelFocus) {
+        brls::View* check = m_preCategoryPanelFocus;
+        bool valid = false;
+        while (check) {
+            if (check == this) { valid = true; break; }
+            check = check->getParent();
+        }
+        if (valid) {
+            brls::Application::giveFocus(m_preCategoryPanelFocus);
+        }
+        m_preCategoryPanelFocus = nullptr;
+    }
+}
+
+bool MangaDetailView::isFocusInCategoryPanel(brls::View* view) const {
+    while (view) {
+        if (view == m_categoryOverlay)
+            return true;
+        view = view->getParent();
+    }
+    return false;
 }
 
 void MangaDetailView::showTrackingDialog() {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2754,37 +2754,111 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
     // Shared set of selected category IDs
     auto selectedIds = std::make_shared<std::set<int>>(preselected);
 
-    // Create dialog box (matching source filter / category visibility style)
+    // Track last highlighted row for hover effect (source filter style)
+    auto lastHighlighted = std::make_shared<brls::Box*>(nullptr);
+
+    // Create dialog box (matching source filter menu exactly)
     auto* dialogBox = new brls::Box();
     dialogBox->setAxis(brls::Axis::COLUMN);
-    dialogBox->setWidth(550);
-    dialogBox->setHeight(450);
-    dialogBox->setPadding(20);
+    dialogBox->setWidth(300);
+    dialogBox->setPadding(10);
     dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
     dialogBox->setCornerRadius(12);
 
     // Title
     auto* titleLabel = new brls::Label();
     titleLabel->setText("Select Categories");
-    titleLabel->setFontSize(22);
-    titleLabel->setMarginBottom(10);
+    titleLabel->setFontSize(18);
+    titleLabel->setSingleLine(true);
+    titleLabel->setMarginBottom(6);
     dialogBox->addView(titleLabel);
 
-    // Info label
-    auto* infoLabel = new brls::Label();
-    infoLabel->setText("Tap to toggle categories for this manga");
-    infoLabel->setFontSize(14);
-    infoLabel->setTextColor(Application::getInstance().getSubtitleColor());
-    infoLabel->setMarginBottom(15);
-    dialogBox->addView(infoLabel);
+    // Main scrolling frame
+    auto* mainScroll = new brls::ScrollingFrame();
+    mainScroll->setGrow(1.0f);
 
-    // Create Done button early so it can be captured in lambdas
-    auto* doneBtn = new brls::Button();
-    doneBtn->setText("Done");
-    doneBtn->setMarginTop(15);
-    doneBtn->registerClickAction([this, mangaId, selectedIds, aliveWeak](brls::View*) {
+    auto* catListBox = new brls::Box();
+    catListBox->setAxis(brls::Axis::COLUMN);
+
+    // Helper: build label text with checkmark prefix
+    auto makeCatLabel = [](const std::string& name, bool checked) -> std::string {
+        return (checked ? "\u2713 " : "   ") + name;
+    };
+
+    for (size_t i = 0; i < m_categories.size(); i++) {
+        const auto& cat = m_categories[i];
+        int catId = cat.id;
+        bool isSelected = (selectedIds->find(catId) != selectedIds->end());
+
+        auto* row = new brls::Box();
+        row->setAxis(brls::Axis::ROW);
+        row->setFocusable(true);
+        row->setPadding(5, 8, 5, 8);
+        row->setMarginBottom(2);
+        row->setCornerRadius(6);
+        row->setAlignItems(brls::AlignItems::CENTER);
+        row->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+
+        auto* rowLabel = new brls::Label();
+        rowLabel->setText(makeCatLabel(cat.name, isSelected));
+        rowLabel->setFontSize(13);
+        rowLabel->setSingleLine(true);
+        row->addView(rowLabel);
+
+        // Hover highlight (source filter style)
+        row->getFocusEvent()->subscribe([lastHighlighted, row](brls::View*) {
+            if (*lastHighlighted && *lastHighlighted != row) {
+                (*lastHighlighted)->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            }
+            row->setBackgroundColor(Application::getInstance().getActiveRowBackground());
+            *lastHighlighted = row;
+        });
+
+        // Click to toggle
+        row->registerClickAction([catId, selectedIds, rowLabel, makeCatLabel, cat](brls::View*) {
+            bool currentlySelected = (selectedIds->find(catId) != selectedIds->end());
+            if (currentlySelected) {
+                selectedIds->erase(catId);
+            } else {
+                selectedIds->insert(catId);
+            }
+            rowLabel->setText(makeCatLabel(cat.name, !currentlySelected));
+            return true;
+        });
+        row->addGestureRecognizer(new brls::TapGestureRecognizer(row));
+
+        catListBox->addView(row);
+    }
+
+    if (m_categories.empty()) {
+        auto* label = new brls::Label();
+        label->setText("No categories found");
+        label->setFontSize(13);
+        label->setMarginTop(6);
+        catListBox->addView(label);
+    }
+
+    mainScroll->setContentView(catListBox);
+
+    // B button on scroll list closes dialog
+    catListBox->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
         brls::Application::popActivity();
-        // Apply selected categories
+        return true;
+    }, true);
+
+    dialogBox->addView(mainScroll);
+
+    // Button row (Apply / Reset style matching source filter)
+    auto* buttonRow = new brls::Box();
+    buttonRow->setAxis(brls::Axis::ROW);
+    buttonRow->setJustifyContent(brls::JustifyContent::FLEX_START);
+    buttonRow->setMarginTop(6);
+
+    auto* applyBtn = new brls::Button();
+    applyBtn->setText("Apply");
+    applyBtn->setMarginRight(8);
+    applyBtn->registerClickAction([mangaId, selectedIds, aliveWeak](brls::View*) {
+        brls::Application::popActivity();
         std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
         brls::sync([mangaId, catIds, aliveWeak]() {
             auto alive = aliveWeak.lock();
@@ -2800,160 +2874,42 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
         });
         return true;
     });
-    doneBtn->addGestureRecognizer(new brls::TapGestureRecognizer(doneBtn));
+    applyBtn->addGestureRecognizer(new brls::TapGestureRecognizer(applyBtn));
 
-    // B button on Done button closes dialog and applies
-    doneBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
-        brls::Application::popActivity();
-        std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
-        brls::sync([mangaId, catIds, aliveWeak]() {
-            auto alive = aliveWeak.lock();
-            if (!alive || !*alive) return;
-            asyncRun([mangaId, catIds]() {
-                SuwayomiClient& client = SuwayomiClient::getInstance();
-                if (client.setMangaCategories(mangaId, catIds)) {
-                    brls::sync([mangaId]() {
-                        Application::getInstance().trackCategoryChange(mangaId);
-                    });
+    auto* resetBtn = new brls::Button();
+    resetBtn->setText("Reset");
+    resetBtn->registerClickAction([selectedIds, preselected, catListBox, makeCatLabel, this](brls::View*) {
+        // Reset to original pre-selected state
+        *selectedIds = preselected;
+        // Update all row labels
+        auto& children = catListBox->getChildren();
+        for (size_t i = 0; i < children.size() && i < m_categories.size(); i++) {
+            auto* rowBox = dynamic_cast<brls::Box*>(children[i]);
+            if (rowBox && !rowBox->getChildren().empty()) {
+                auto* lbl = dynamic_cast<brls::Label*>(rowBox->getChildren()[0]);
+                if (lbl) {
+                    bool checked = selectedIds->find(m_categories[i].id) != selectedIds->end();
+                    lbl->setText(makeCatLabel(m_categories[i].name, checked));
                 }
-            });
-        });
-        return true;
-    }, true);
-
-    // Scrollable category list
-    auto* scrollView = new brls::ScrollingFrame();
-    scrollView->setGrow(1.0f);
-
-    auto* catList = new brls::Box();
-    catList->setAxis(brls::Axis::COLUMN);
-
-    for (size_t i = 0; i < m_categories.size(); i++) {
-        const auto& cat = m_categories[i];
-
-        auto* catRow = new brls::Box();
-        catRow->setAxis(brls::Axis::ROW);
-        catRow->setAlignItems(brls::AlignItems::CENTER);
-        catRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
-        catRow->setPadding(10, 12, 10, 12);
-        catRow->setMarginBottom(6);
-        catRow->setCornerRadius(8);
-        catRow->setFocusable(true);
-
-        bool isSelected = (selectedIds->find(cat.id) != selectedIds->end());
-        catRow->setBackgroundColor(isSelected ? Application::getInstance().getActiveRowBackground() : Application::getInstance().getInactiveRowBackground());
-
-        // Category info box
-        auto* infoBox = new brls::Box();
-        infoBox->setAxis(brls::Axis::COLUMN);
-        infoBox->setGrow(1.0f);
-
-        auto* nameLabel = new brls::Label();
-        std::string displayName = cat.name;
-        if (displayName.length() > 20) {
-            displayName = displayName.substr(0, 18) + "..";
-        }
-        nameLabel->setText(displayName);
-        nameLabel->setFontSize(16);
-        infoBox->addView(nameLabel);
-
-        if (cat.mangaCount > 0) {
-            auto* countLabel = new brls::Label();
-            countLabel->setText(std::to_string(cat.mangaCount) + " manga");
-            countLabel->setFontSize(12);
-            countLabel->setTextColor(Application::getInstance().getDimTextColor());
-            infoBox->addView(countLabel);
-        }
-
-        catRow->addView(infoBox);
-
-        // Status indicator (checkmark)
-        auto* statusLabel = new brls::Label();
-        statusLabel->setText(isSelected ? "\u2713" : "");
-        statusLabel->setFontSize(16);
-        statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
-        statusLabel->setMarginRight(10);
-        catRow->addView(statusLabel);
-
-        int catId = cat.id;
-
-        // Click to toggle category selection
-        catRow->registerClickAction([catRow, catId, statusLabel, selectedIds](brls::View*) {
-            bool currentlySelected = (selectedIds->find(catId) != selectedIds->end());
-
-            if (currentlySelected) {
-                selectedIds->erase(catId);
-                catRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
-                statusLabel->setText("");
-            } else {
-                selectedIds->insert(catId);
-                catRow->setBackgroundColor(Application::getInstance().getActiveRowBackground());
-                statusLabel->setText("\u2713");
-                statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
             }
-            return true;
-        });
-        catRow->addGestureRecognizer(new brls::TapGestureRecognizer(catRow));
+        }
+        return true;
+    });
+    resetBtn->addGestureRecognizer(new brls::TapGestureRecognizer(resetBtn));
 
-        // B button on rows closes dialog and applies
-        catRow->registerAction("Back", brls::ControllerButton::BUTTON_B, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
-            brls::Application::popActivity();
-            std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
-            brls::sync([mangaId, catIds, aliveWeak]() {
-                auto alive = aliveWeak.lock();
-                if (!alive || !*alive) return;
-                asyncRun([mangaId, catIds]() {
-                    SuwayomiClient& client = SuwayomiClient::getInstance();
-                    if (client.setMangaCategories(mangaId, catIds)) {
-                        brls::sync([mangaId]() {
-                            Application::getInstance().trackCategoryChange(mangaId);
-                        });
-                    }
-                });
-            });
-            return true;
-        }, true);
+    buttonRow->addView(applyBtn);
+    buttonRow->addView(resetBtn);
+    dialogBox->addView(buttonRow);
 
-        catList->addView(catRow);
-    }
-
-    if (m_categories.empty()) {
-        auto* label = new brls::Label();
-        label->setText("No categories found");
-        label->setFontSize(16);
-        label->setMarginTop(20);
-        catList->addView(label);
-    }
-
-    scrollView->setContentView(catList);
-    dialogBox->addView(scrollView);
-    dialogBox->addView(doneBtn);
-
-    // Circle button closes dialog and applies
-    dialogBox->registerAction("Close", brls::ControllerButton::BUTTON_BACK, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
+    // B button on buttons closes dialog
+    applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
         brls::Application::popActivity();
-        std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
-        brls::sync([mangaId, catIds, aliveWeak]() {
-            auto alive = aliveWeak.lock();
-            if (!alive || !*alive) return;
-            asyncRun([mangaId, catIds]() {
-                SuwayomiClient& client = SuwayomiClient::getInstance();
-                if (client.setMangaCategories(mangaId, catIds)) {
-                    brls::sync([mangaId]() {
-                        Application::getInstance().trackCategoryChange(mangaId);
-                    });
-                }
-            });
-        });
         return true;
     }, true);
-
-    // Navigation: last row -> down goes to doneBtn, doneBtn -> up goes to last row
-    auto& catChildren = catList->getChildren();
-    if (!catChildren.empty()) {
-        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, doneBtn);
-        doneBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
-    }
+    resetBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [](brls::View*) {
+        brls::Application::popActivity();
+        return true;
+    }, true);
 
     brls::Application::pushActivity(new brls::Activity(dialogBox));
 }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2923,9 +2923,30 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
     });
     resetBtn->addGestureRecognizer(new brls::TapGestureRecognizer(resetBtn));
 
+    applyBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedCatRow) {
+            m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedCatRow = nullptr;
+        }
+    });
+    resetBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedCatRow) {
+            m_lastHighlightedCatRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedCatRow = nullptr;
+        }
+    });
+
     buttonRow->addView(applyBtn);
     buttonRow->addView(resetBtn);
     m_categoryPanel->addView(buttonRow);
+
+    // Custom navigation: link last category row <-> apply button
+    auto& catChildren = catListBox->getChildren();
+    if (!catChildren.empty()) {
+        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, applyBtn);
+        applyBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+        resetBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+    }
 
     // B button on panel buttons to close panel
     applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2757,10 +2757,18 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
     // Track last highlighted row for hover effect (source filter style)
     auto lastHighlighted = std::make_shared<brls::Box*>(nullptr);
 
+    // Centering container (so dialog doesn't fill the whole screen)
+    auto* container = new brls::Box();
+    container->setAxis(brls::Axis::COLUMN);
+    container->setJustifyContent(brls::JustifyContent::CENTER);
+    container->setAlignItems(brls::AlignItems::CENTER);
+    container->setGrow(1.0f);
+
     // Create dialog box (matching source filter menu exactly)
     auto* dialogBox = new brls::Box();
     dialogBox->setAxis(brls::Axis::COLUMN);
     dialogBox->setWidth(300);
+    dialogBox->setHeight(350);
     dialogBox->setPadding(10);
     dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
     dialogBox->setCornerRadius(12);
@@ -2911,7 +2919,8 @@ void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<in
         return true;
     }, true);
 
-    brls::Application::pushActivity(new brls::Activity(dialogBox));
+    container->addView(dialogBox);
+    brls::Application::pushActivity(new brls::Activity(container));
 }
 
 void MangaDetailView::showTrackingDialog() {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2174,40 +2174,11 @@ void MangaDetailView::onAddToLibrary() {
             // Switch button to "Remove from Library"
             updateLibraryButton();
 
-            // If categories available, show selection dropdown
+            // If categories available, show multi-select dialog
             if (categories.size() > 1) {
                 m_categories = categories;
-                std::vector<std::string> options;
-                for (const auto& cat : categories) {
-                    options.push_back(cat.name);
-                }
-
                 int mangaId = m_manga.id;
-                brls::Dropdown* dropdown = new brls::Dropdown(
-                    "Select Category", options,
-                    [this, mangaId, aliveWeak](int selected) {
-                        if (selected < 0 || selected >= static_cast<int>(m_categories.size())) return;
-
-                        int categoryId = m_categories[selected].id;
-                        brls::sync([mangaId, categoryId, aliveWeak]() {
-                            auto alive = aliveWeak.lock();
-                            if (!alive || !*alive) return;
-                            asyncRun([mangaId, categoryId]() {
-                                SuwayomiClient& client = SuwayomiClient::getInstance();
-                                if (client.setMangaCategories(mangaId, {categoryId})) {
-                                    brls::sync([mangaId]() {
-                                        Application::getInstance().trackCategoryChange(mangaId);
-                                        // Notification removed per user request
-                                    });
-                                } else {
-                                    brls::sync([]() {
-                                        // Notification removed per user request
-                                    });
-                                }
-                            });
-                        });
-                    }, -1);
-                brls::Application::pushActivity(new brls::Activity(dropdown));
+                showCategorySelectionDialog(mangaId, {}, aliveWeak);
             } else {
                 // Notification removed per user request
             }
@@ -2770,51 +2741,221 @@ void MangaDetailView::showCategoryDialog() {
             }
 
             m_categories = categories;
-            std::vector<std::string> options;
-            for (const auto& cat : categories) {
-                options.push_back(cat.name);
-            }
-
             int mangaId = m_manga.id;
 
-            // Find current category index so we don't falsely pre-select the first one
-            int currentIdx = -1;
-            if (!m_manga.categoryIds.empty()) {
-                for (int i = 0; i < static_cast<int>(categories.size()); i++) {
-                    if (categories[i].id == m_manga.categoryIds[0]) {
-                        currentIdx = i;
-                        break;
-                    }
-                }
-            }
-
-            brls::Dropdown* dropdown = new brls::Dropdown(
-                "Move to Category", options,
-                [this, mangaId, aliveWeak](int selected) {
-                    if (selected < 0 || selected >= static_cast<int>(m_categories.size())) return;
-
-                    int categoryId = m_categories[selected].id;
-                    brls::sync([mangaId, categoryId, aliveWeak]() {
-                        auto alive = aliveWeak.lock();
-                        if (!alive || !*alive) return;
-                        asyncRun([mangaId, categoryId]() {
-                            SuwayomiClient& client = SuwayomiClient::getInstance();
-                            if (client.setMangaCategories(mangaId, {categoryId})) {
-                                brls::sync([mangaId]() {
-                                    Application::getInstance().trackCategoryChange(mangaId);
-                                    brls::Application::notify("Category updated");
-                                });
-                            } else {
-                                brls::sync([]() {
-                                    brls::Application::notify("Failed to update category");
-                                });
-                            }
-                        });
-                    });
-                }, currentIdx);
-            brls::Application::pushActivity(new brls::Activity(dropdown));
+            // Build set of current category IDs for pre-selection
+            std::set<int> currentCatIds(m_manga.categoryIds.begin(), m_manga.categoryIds.end());
+            showCategorySelectionDialog(mangaId, currentCatIds, aliveWeak);
         });
     });
+}
+
+void MangaDetailView::showCategorySelectionDialog(int mangaId, const std::set<int>& preselected, std::weak_ptr<bool> aliveWeak) {
+    // Shared set of selected category IDs
+    auto selectedIds = std::make_shared<std::set<int>>(preselected);
+
+    // Create dialog box (matching source filter / category visibility style)
+    auto* dialogBox = new brls::Box();
+    dialogBox->setAxis(brls::Axis::COLUMN);
+    dialogBox->setWidth(550);
+    dialogBox->setHeight(450);
+    dialogBox->setPadding(20);
+    dialogBox->setBackgroundColor(Application::getInstance().getDialogBackground());
+    dialogBox->setCornerRadius(12);
+
+    // Title
+    auto* titleLabel = new brls::Label();
+    titleLabel->setText("Select Categories");
+    titleLabel->setFontSize(22);
+    titleLabel->setMarginBottom(10);
+    dialogBox->addView(titleLabel);
+
+    // Info label
+    auto* infoLabel = new brls::Label();
+    infoLabel->setText("Tap to toggle categories for this manga");
+    infoLabel->setFontSize(14);
+    infoLabel->setTextColor(Application::getInstance().getSubtitleColor());
+    infoLabel->setMarginBottom(15);
+    dialogBox->addView(infoLabel);
+
+    // Create Done button early so it can be captured in lambdas
+    auto* doneBtn = new brls::Button();
+    doneBtn->setText("Done");
+    doneBtn->setMarginTop(15);
+    doneBtn->registerClickAction([this, mangaId, selectedIds, aliveWeak](brls::View*) {
+        brls::Application::popActivity();
+        // Apply selected categories
+        std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
+        brls::sync([mangaId, catIds, aliveWeak]() {
+            auto alive = aliveWeak.lock();
+            if (!alive || !*alive) return;
+            asyncRun([mangaId, catIds]() {
+                SuwayomiClient& client = SuwayomiClient::getInstance();
+                if (client.setMangaCategories(mangaId, catIds)) {
+                    brls::sync([mangaId]() {
+                        Application::getInstance().trackCategoryChange(mangaId);
+                    });
+                }
+            });
+        });
+        return true;
+    });
+    doneBtn->addGestureRecognizer(new brls::TapGestureRecognizer(doneBtn));
+
+    // B button on Done button closes dialog and applies
+    doneBtn->registerAction("Back", brls::ControllerButton::BUTTON_B, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
+        brls::Application::popActivity();
+        std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
+        brls::sync([mangaId, catIds, aliveWeak]() {
+            auto alive = aliveWeak.lock();
+            if (!alive || !*alive) return;
+            asyncRun([mangaId, catIds]() {
+                SuwayomiClient& client = SuwayomiClient::getInstance();
+                if (client.setMangaCategories(mangaId, catIds)) {
+                    brls::sync([mangaId]() {
+                        Application::getInstance().trackCategoryChange(mangaId);
+                    });
+                }
+            });
+        });
+        return true;
+    }, true);
+
+    // Scrollable category list
+    auto* scrollView = new brls::ScrollingFrame();
+    scrollView->setGrow(1.0f);
+
+    auto* catList = new brls::Box();
+    catList->setAxis(brls::Axis::COLUMN);
+
+    for (size_t i = 0; i < m_categories.size(); i++) {
+        const auto& cat = m_categories[i];
+
+        auto* catRow = new brls::Box();
+        catRow->setAxis(brls::Axis::ROW);
+        catRow->setAlignItems(brls::AlignItems::CENTER);
+        catRow->setJustifyContent(brls::JustifyContent::SPACE_BETWEEN);
+        catRow->setPadding(10, 12, 10, 12);
+        catRow->setMarginBottom(6);
+        catRow->setCornerRadius(8);
+        catRow->setFocusable(true);
+
+        bool isSelected = (selectedIds->find(cat.id) != selectedIds->end());
+        catRow->setBackgroundColor(isSelected ? Application::getInstance().getActiveRowBackground() : Application::getInstance().getInactiveRowBackground());
+
+        // Category info box
+        auto* infoBox = new brls::Box();
+        infoBox->setAxis(brls::Axis::COLUMN);
+        infoBox->setGrow(1.0f);
+
+        auto* nameLabel = new brls::Label();
+        std::string displayName = cat.name;
+        if (displayName.length() > 20) {
+            displayName = displayName.substr(0, 18) + "..";
+        }
+        nameLabel->setText(displayName);
+        nameLabel->setFontSize(16);
+        infoBox->addView(nameLabel);
+
+        if (cat.mangaCount > 0) {
+            auto* countLabel = new brls::Label();
+            countLabel->setText(std::to_string(cat.mangaCount) + " manga");
+            countLabel->setFontSize(12);
+            countLabel->setTextColor(Application::getInstance().getDimTextColor());
+            infoBox->addView(countLabel);
+        }
+
+        catRow->addView(infoBox);
+
+        // Status indicator (checkmark)
+        auto* statusLabel = new brls::Label();
+        statusLabel->setText(isSelected ? "\u2713" : "");
+        statusLabel->setFontSize(16);
+        statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
+        statusLabel->setMarginRight(10);
+        catRow->addView(statusLabel);
+
+        int catId = cat.id;
+
+        // Click to toggle category selection
+        catRow->registerClickAction([catRow, catId, statusLabel, selectedIds](brls::View*) {
+            bool currentlySelected = (selectedIds->find(catId) != selectedIds->end());
+
+            if (currentlySelected) {
+                selectedIds->erase(catId);
+                catRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+                statusLabel->setText("");
+            } else {
+                selectedIds->insert(catId);
+                catRow->setBackgroundColor(Application::getInstance().getActiveRowBackground());
+                statusLabel->setText("\u2713");
+                statusLabel->setTextColor(Application::getInstance().getSuccessTextColor());
+            }
+            return true;
+        });
+        catRow->addGestureRecognizer(new brls::TapGestureRecognizer(catRow));
+
+        // B button on rows closes dialog and applies
+        catRow->registerAction("Back", brls::ControllerButton::BUTTON_B, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
+            brls::Application::popActivity();
+            std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
+            brls::sync([mangaId, catIds, aliveWeak]() {
+                auto alive = aliveWeak.lock();
+                if (!alive || !*alive) return;
+                asyncRun([mangaId, catIds]() {
+                    SuwayomiClient& client = SuwayomiClient::getInstance();
+                    if (client.setMangaCategories(mangaId, catIds)) {
+                        brls::sync([mangaId]() {
+                            Application::getInstance().trackCategoryChange(mangaId);
+                        });
+                    }
+                });
+            });
+            return true;
+        }, true);
+
+        catList->addView(catRow);
+    }
+
+    if (m_categories.empty()) {
+        auto* label = new brls::Label();
+        label->setText("No categories found");
+        label->setFontSize(16);
+        label->setMarginTop(20);
+        catList->addView(label);
+    }
+
+    scrollView->setContentView(catList);
+    dialogBox->addView(scrollView);
+    dialogBox->addView(doneBtn);
+
+    // Circle button closes dialog and applies
+    dialogBox->registerAction("Close", brls::ControllerButton::BUTTON_BACK, [this, mangaId, selectedIds, aliveWeak](brls::View*) {
+        brls::Application::popActivity();
+        std::vector<int> catIds(selectedIds->begin(), selectedIds->end());
+        brls::sync([mangaId, catIds, aliveWeak]() {
+            auto alive = aliveWeak.lock();
+            if (!alive || !*alive) return;
+            asyncRun([mangaId, catIds]() {
+                SuwayomiClient& client = SuwayomiClient::getInstance();
+                if (client.setMangaCategories(mangaId, catIds)) {
+                    brls::sync([mangaId]() {
+                        Application::getInstance().trackCategoryChange(mangaId);
+                    });
+                }
+            });
+        });
+        return true;
+    }, true);
+
+    // Navigation: last row -> down goes to doneBtn, doneBtn -> up goes to last row
+    auto& catChildren = catList->getChildren();
+    if (!catChildren.empty()) {
+        catChildren.back()->setCustomNavigationRoute(brls::FocusDirection::DOWN, doneBtn);
+        doneBtn->setCustomNavigationRoute(brls::FocusDirection::UP, catChildren.back());
+    }
+
+    brls::Application::pushActivity(new brls::Activity(dialogBox));
 }
 
 void MangaDetailView::showTrackingDialog() {

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -1819,6 +1819,12 @@ void SearchTab::buildFilterPanel() {
         return true;
     });
     applyBtn->addGestureRecognizer(new brls::TapGestureRecognizer(applyBtn));
+    applyBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     auto* resetBtn = new brls::Button();
     resetBtn->setText("Reset");
@@ -1831,6 +1837,12 @@ void SearchTab::buildFilterPanel() {
         return true;
     });
     resetBtn->addGestureRecognizer(new brls::TapGestureRecognizer(resetBtn));
+    resetBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     buttonRow->addView(applyBtn);
     buttonRow->addView(resetBtn);
@@ -2009,6 +2021,12 @@ void SearchTab::buildTagFilterPanel() {
         return true;
     });
     applyBtn->addGestureRecognizer(new brls::TapGestureRecognizer(applyBtn));
+    applyBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     auto* clearBtn = new brls::Button();
     clearBtn->setText("Clear");
@@ -2024,6 +2042,12 @@ void SearchTab::buildTagFilterPanel() {
         return true;
     });
     clearBtn->addGestureRecognizer(new brls::TapGestureRecognizer(clearBtn));
+    clearBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     // B button on panel buttons to close panel
     applyBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {
@@ -2193,6 +2217,12 @@ void SearchTab::buildTagManagePanel(const Source& source) {
         return true;
     });
     addBtn->addGestureRecognizer(new brls::TapGestureRecognizer(addBtn));
+    addBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     auto* doneBtn = new brls::Button();
     doneBtn->setText("Done");
@@ -2202,6 +2232,12 @@ void SearchTab::buildTagManagePanel(const Source& source) {
         return true;
     });
     doneBtn->addGestureRecognizer(new brls::TapGestureRecognizer(doneBtn));
+    doneBtn->getFocusEvent()->subscribe([this](brls::View*) {
+        if (m_lastHighlightedRow) {
+            m_lastHighlightedRow->setBackgroundColor(Application::getInstance().getInactiveRowBackground());
+            m_lastHighlightedRow = nullptr;
+        }
+    });
 
     // B button on panel buttons to close panel
     addBtn->registerAction("Close", brls::ControllerButton::BUTTON_B, [this](brls::View*) {


### PR DESCRIPTION
Replaces the single-select category dropdown with a centered, inline multi-select dialog styled to match the source-filter menu, with hover-highlight clearing and D-pad-to-Apply navigation fixes.

---
_Generated by [Claude Code](https://claude.ai/code)_