### PR TITLE
Filter hidden categories from category selection dialogs and pre-select current categories

### DIFF
--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1716,6 +1716,11 @@ bool SuwayomiClient::fetchCategoryMangaGraphQL(int categoryId, std::vector<Manga
                     latestUploadedChapter {
                         uploadDate
                     }
+                    categories {
+                        nodes {
+                            id
+                        }
+                    }
                 }
             }
         }
@@ -1796,6 +1801,11 @@ bool SuwayomiClient::fetchCategoryMangaGraphQLFallback(int categoryId, std::vect
                         latestUploadedChapter {
                             uploadDate
                         }
+                        categories {
+                            nodes {
+                                id
+                            }
+                        }
                     }
                 }
             }
@@ -1874,6 +1884,11 @@ bool SuwayomiClient::fetchCategoriesWithMangaGraphQL(std::vector<Category>& cate
                     }
                     latestUploadedChapter {
                         uploadDate
+                    }
+                    categories {
+                        nodes {
+                            id
+                        }
                     }
                 }
             }

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2601,6 +2601,20 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         return;
     }
 
+    // Filter out hidden categories for the dialog
+    const auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
+    auto visibleCategories = std::make_shared<std::vector<Category>>();
+    for (const auto& cat : m_categories) {
+        if (hiddenIds.find(cat.id) == hiddenIds.end()) {
+            visibleCategories->push_back(cat);
+        }
+    }
+
+    if (visibleCategories->empty()) {
+        brls::Application::notify("No visible categories available");
+        return;
+    }
+
     // Save current focus so we can restore it when closing
     m_preCategoryPanelFocus = brls::Application::getCurrentFocus();
     m_lastHighlightedCatRow = nullptr;
@@ -2749,8 +2763,8 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
         return (checked ? "\u2713 " : "   ") + name;
     };
 
-    for (size_t i = 0; i < m_categories.size(); i++) {
-        const auto& cat = m_categories[i];
+    for (size_t i = 0; i < visibleCategories->size(); i++) {
+        const auto& cat = (*visibleCategories)[i];
         int catId = cat.id;
         bool isChecked = selectedCats->count(catId) > 0;
 
@@ -2827,18 +2841,18 @@ void LibrarySectionTab::showChangeCategoryDialog(const std::vector<Manga>& manga
 
     auto* resetBtn = new brls::Button();
     resetBtn->setText("Reset");
-    resetBtn->registerClickAction([selectedCats, checkedCatIds, catListBox, makeCatLabel, this](brls::View*) {
+    resetBtn->registerClickAction([selectedCats, checkedCatIds, catListBox, makeCatLabel, visibleCategories](brls::View*) {
         // Reset to original pre-selected state
         *selectedCats = checkedCatIds;
         // Update all row labels
         auto& children = catListBox->getChildren();
-        for (size_t i = 0; i < children.size() && i < m_categories.size(); i++) {
+        for (size_t i = 0; i < children.size() && i < visibleCategories->size(); i++) {
             auto* rowBox = dynamic_cast<brls::Box*>(children[i]);
             if (rowBox && !rowBox->getChildren().empty()) {
                 auto* lbl = dynamic_cast<brls::Label*>(rowBox->getChildren()[0]);
                 if (lbl) {
-                    bool checked = selectedCats->find(m_categories[i].id) != selectedCats->end();
-                    lbl->setText(makeCatLabel(m_categories[i].name, checked));
+                    bool checked = selectedCats->find((*visibleCategories)[i].id) != selectedCats->end();
+                    lbl->setText(makeCatLabel((*visibleCategories)[i].name, checked));
                 }
             }
         }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -2182,8 +2182,17 @@ void MangaDetailView::onAddToLibrary() {
         }
 
         // Fetch categories for selection
+        std::vector<Category> allCategories;
+        client.fetchCategories(allCategories);
+
+        // Filter out hidden categories
+        const auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
         std::vector<Category> categories;
-        client.fetchCategories(categories);
+        for (const auto& cat : allCategories) {
+            if (hiddenIds.find(cat.id) == hiddenIds.end()) {
+                categories.push_back(cat);
+            }
+        }
 
         brls::sync([this, categories, aliveWeak]() {
             auto alive = aliveWeak.lock();
@@ -2751,8 +2760,17 @@ void MangaDetailView::deleteChapterDownload(const Chapter& chapter) {
 void MangaDetailView::showCategoryDialog() {
     asyncRun([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
+        std::vector<Category> allCategories;
+        client.fetchCategories(allCategories);
+
+        // Filter out hidden categories
+        const auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
         std::vector<Category> categories;
-        client.fetchCategories(categories);
+        for (const auto& cat : allCategories) {
+            if (hiddenIds.find(cat.id) == hiddenIds.end()) {
+                categories.push_back(cat);
+            }
+        }
 
         brls::sync([this, categories, aliveWeak]() {
             auto alive = aliveWeak.lock();


### PR DESCRIPTION
Filter hidden categories from category selection dialogs and pre-select current categories

- Filter out user-hidden categories from book detail view category picker (both
  add-to-library and change-category flows)
- Filter out hidden categories from library change-category dialog
- Add categories field to fetchCategoryManga GraphQL queries so manga objects
  have their categoryIds populated, enabling proper pre-selection of current
  categories in the library's change-category dialog

---
_Generated by [Claude Code](https://claude.ai/code)_