### PR TITLE
Fix FPS dropping to 1 when loading book thumbnails in grids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(APP_SOURCES
     src/utils/http_client.cpp
     src/utils/image_loader.cpp
     src/utils/library_cache.cpp
+    src/utils/perf_overlay.cpp
     src/utils/vita_stubs.c
 )
 

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -138,6 +138,7 @@ struct AppSettings {
     AppTheme theme = AppTheme::DARK;
     bool showClock = true;
     bool debugLogging = false;
+    bool showPerfOverlay = false;  // Show FPS/frame time/GPU debug overlay
 
     // Reader Settings
     ReadingMode readingMode = ReadingMode::RIGHT_TO_LEFT;

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -158,7 +158,7 @@ private:
     static std::queue<PendingTextureUpdate> s_pendingTextures;
     static std::mutex s_pendingMutex;
     static std::atomic<bool> s_pendingScheduled;
-    static constexpr int MAX_TEXTURES_PER_FRAME = 6;  // Limit GPU uploads per frame
+    static constexpr int MAX_TEXTURES_PER_FRAME = 2;  // Limit GPU uploads per frame (reduced from 6 - each upload stalls Vita GPU for ~15-20ms)
 
     // Queue a texture for batched upload on the main thread
     static void queueTextureUpdate(const std::vector<uint8_t>& data, brls::Image* target, LoadCallback callback,

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -168,8 +168,8 @@ private:
 
     // Batched texture upload queue for RotatableImage (webtoon/manga reader pages).
     // Same concept as PendingTextureUpdate but for full-size reader images.
-    // Limits GPU uploads to MAX_ROTATABLE_TEXTURES_PER_FRAME per frame to keep consistent
-    // frame rate while processing preloaded pages. Higher rate reduces upload queue buildup.
+    // Limits GPU uploads to MAX_ROTATABLE_TEXTURES_PER_FRAME per frame to prevent
+    // the "group loading" appearance where multiple images pop in simultaneously.
     struct PendingRotatableTextureUpdate {
         // Single-texture path
         std::vector<uint8_t> data;
@@ -186,7 +186,7 @@ private:
     static std::queue<PendingRotatableTextureUpdate> s_pendingRotatableTextures;
     static std::mutex s_pendingRotatableMutex;
     static std::atomic<bool> s_pendingRotatableScheduled;
-    static constexpr int MAX_ROTATABLE_TEXTURES_PER_FRAME = 2;  // 2 per frame: spreads 8 pending loads over 4 frames, balances throughput vs frame time
+    static constexpr int MAX_ROTATABLE_TEXTURES_PER_FRAME = 1;  // 1 per frame to avoid stutter during scroll
 
     // Queue a RotatableImage texture for batched upload (single-texture path)
     static void queueRotatableTextureUpdate(const std::vector<uint8_t>& data, RotatableImage* target,

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -168,8 +168,8 @@ private:
 
     // Batched texture upload queue for RotatableImage (webtoon/manga reader pages).
     // Same concept as PendingTextureUpdate but for full-size reader images.
-    // Limits GPU uploads to MAX_ROTATABLE_TEXTURES_PER_FRAME per frame to prevent
-    // the "group loading" appearance where multiple images pop in simultaneously.
+    // Limits GPU uploads to MAX_ROTATABLE_TEXTURES_PER_FRAME per frame to keep consistent
+    // frame rate while processing preloaded pages. Higher rate reduces upload queue buildup.
     struct PendingRotatableTextureUpdate {
         // Single-texture path
         std::vector<uint8_t> data;
@@ -186,7 +186,7 @@ private:
     static std::queue<PendingRotatableTextureUpdate> s_pendingRotatableTextures;
     static std::mutex s_pendingRotatableMutex;
     static std::atomic<bool> s_pendingRotatableScheduled;
-    static constexpr int MAX_ROTATABLE_TEXTURES_PER_FRAME = 1;  // 1 per frame to avoid stutter during scroll
+    static constexpr int MAX_ROTATABLE_TEXTURES_PER_FRAME = 2;  // 2 per frame: spreads 8 pending loads over 4 frames, balances throughput vs frame time
 
     // Queue a RotatableImage texture for batched upload (single-texture path)
     static void queueRotatableTextureUpdate(const std::vector<uint8_t>& data, RotatableImage* target,

--- a/include/utils/perf_overlay.hpp
+++ b/include/utils/perf_overlay.hpp
@@ -10,6 +10,7 @@
 #include <borealis.hpp>
 #include <chrono>
 #include <string>
+#include <cstdio>
 
 namespace vitasuwayomi {
 
@@ -40,10 +41,21 @@ public:
     void setEnabled(bool enabled) { m_enabled = enabled; }
     bool isEnabled() const { return m_enabled; }
 
+    // Flush and close log file
+    void closeLog();
+
 private:
     PerfOverlay() = default;
+    ~PerfOverlay();
 
     bool m_enabled = false;
+
+    // Log file
+    FILE* m_logFile = nullptr;
+    int m_logInterval = 60;   // Write to log every N frames (once per second at 60fps)
+    int m_logCounter = 0;
+    void openLogIfNeeded();
+    void writeLogEntry();
 
     // Frame timing
     using Clock = std::chrono::steady_clock;

--- a/include/utils/perf_overlay.hpp
+++ b/include/utils/perf_overlay.hpp
@@ -1,0 +1,89 @@
+/**
+ * VitaSuwayomi - Performance Debug Overlay
+ * Lightweight FPS/frame-time overlay for profiling rendering bottlenecks.
+ * Shows: FPS, frame time, texture upload queue depth, draw call estimate,
+ * and per-section timing breakdown.
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include <chrono>
+#include <string>
+
+namespace vitasuwayomi {
+
+class PerfOverlay {
+public:
+    static PerfOverlay& getInstance();
+
+    // Call at the very START of the frame (before any drawing)
+    void beginFrame();
+
+    // Call at the very END of the frame (after all drawing)
+    void endFrame();
+
+    // Mark a named section start/end for breakdown timing
+    void beginSection(const char* name);
+    void endSection(const char* name);
+
+    // Record texture upload count this frame
+    void recordTextureUploads(int count);
+
+    // Record pending texture queue size
+    void recordPendingTextures(int count);
+
+    // Draw the overlay (call at end of frame, before endFrame)
+    void draw(NVGcontext* vg, float screenWidth, float screenHeight);
+
+    // Enable/disable
+    void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool isEnabled() const { return m_enabled; }
+
+private:
+    PerfOverlay() = default;
+
+    bool m_enabled = false;
+
+    // Frame timing
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    TimePoint m_frameStart;
+    TimePoint m_lastFpsUpdate;
+    int m_frameCount = 0;
+    float m_fps = 0.0f;
+    float m_frameTimeMs = 0.0f;
+    float m_maxFrameTimeMs = 0.0f;  // Worst frame in last second
+
+    // Rolling history for graph
+    static constexpr int HISTORY_SIZE = 60;
+    float m_frameTimeHistory[HISTORY_SIZE] = {};
+    int m_historyIndex = 0;
+
+    // Section timing (up to 8 named sections)
+    static constexpr int MAX_SECTIONS = 8;
+    struct Section {
+        const char* name = nullptr;
+        TimePoint start;
+        float lastMs = 0.0f;
+    };
+    Section m_sections[MAX_SECTIONS];
+    int m_sectionCount = 0;
+
+    // GPU/texture stats
+    int m_textureUploadsThisFrame = 0;
+    int m_pendingTextures = 0;
+
+    // Helpers
+    int findSection(const char* name);
+};
+
+// Convenience macros for easy profiling
+#define PERF_BEGIN_FRAME() PerfOverlay::getInstance().beginFrame()
+#define PERF_END_FRAME()   PerfOverlay::getInstance().endFrame()
+#define PERF_BEGIN(name)   PerfOverlay::getInstance().beginSection(name)
+#define PERF_END(name)     PerfOverlay::getInstance().endSection(name)
+#define PERF_DRAW(vg, w, h) PerfOverlay::getInstance().draw(vg, w, h)
+
+} // namespace vitasuwayomi

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -55,6 +55,13 @@ private:
     void updateSelectionVisual();
     void applyDisplayMode();
 
+    // Lazy creation helpers - these views are only created when first needed
+    brls::Label* ensureNewBadge();
+    brls::Image* ensureStarBadge();
+    brls::Image* ensureStartHintIcon();
+    brls::Box* ensureListInfoBox();  // Also creates m_listTitleLabel
+    brls::Label* ensureDescriptionLabel();
+
     bool m_selected = false;
     bool m_pressed = false;  // Touch press-down state for visual feedback
     bool m_compactMode = false;

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -77,17 +77,32 @@ private:
     bool m_startHintImageLoaded = false;  // Lazy: load start_button.png only when first shown
 
     brls::Image* m_thumbnailImage = nullptr;
-    brls::Box* m_titleOverlay = nullptr;  // Title overlay container (grid mode)
     brls::Box* m_listInfoBox = nullptr;   // Info container (list mode)
     brls::Label* m_listTitleLabel = nullptr;  // Title label for list mode
-    brls::Label* m_titleLabel = nullptr;
-    brls::Label* m_subtitleLabel = nullptr;
     brls::Label* m_descriptionLabel = nullptr;
     brls::Rectangle* m_progressBar = nullptr;
-    brls::Label* m_unreadBadge = nullptr;
     brls::Label* m_newBadge = nullptr;  // NEW indicator for recently updated
     brls::Image* m_startHintIcon = nullptr;  // Start button hint shown on focus
     brls::Image* m_starBadge = nullptr;  // Star icon for manga in library
+
+    // --- Flat-rendered overlay state (no borealis sub-views, drawn directly via NanoVG) ---
+    // Eliminates 4 frame() calls per cell per frame vs view hierarchy approach.
+    std::string m_titleText;
+    std::string m_subtitleText;
+    std::string m_unreadText;
+    int m_titleFontSize = 11;
+    int m_subtitleFontSize = 9;
+    int m_unreadFontSize = 10;
+    float m_overlayMaxHeight = 50.0f;
+    float m_overlayPadTop = 6.0f;
+    float m_overlayPadSide = 6.0f;
+    float m_overlayPadBottom = 4.0f;
+    bool m_showOverlay = true;   // false in compact/list mode
+    bool m_showUnread = false;
+    NVGcolor m_subtitleColor;
+    NVGcolor m_unreadBgColor;
+    int m_unreadMarginTop = 6;
+    int m_unreadMarginLeft = 6;
 
     // Shared flag for async callback safety - set to false in destructor
     // so pending ImageLoader callbacks skip writing to our destroyed m_thumbnailImage

--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -104,6 +104,16 @@ private:
     int m_unreadMarginTop = 6;
     int m_unreadMarginLeft = 6;
 
+    // --- Cached text measurements (avoids per-frame nvgTextBox wrapping + measurement) ---
+    bool m_overlayDirty = true;       // Recompute cached text on next draw
+    float m_cachedCellWidth = 0;      // Cell width when cache was computed
+    std::string m_cachedLine1;        // Pre-split title line 1
+    std::string m_cachedLine2;        // Pre-split title line 2
+    float m_cachedLineHeight = 0;     // Font line height for multi-line spacing
+    float m_cachedTitleBlockH = 0;    // Total height of rendered title text
+    float m_cachedBadgeTextW = 0;     // Badge text width
+    float m_cachedBadgeTextH = 0;     // Badge text height
+
     // Shared flag for async callback safety - set to false in destructor
     // so pending ImageLoader callbacks skip writing to our destroyed m_thumbnailImage
     std::shared_ptr<bool> m_alive;

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -131,6 +131,18 @@ private:
     int m_cachedFirstVisible = -1;
     int m_cachedLastVisible = -1;
 
+    // Virtual row windowing: only keep a small window of rows attached to m_contentBox
+    // to avoid O(totalRows) child iteration in borealis draw loop.
+    // Rows outside the window are detached (not deleted) and spacers maintain scroll height.
+    brls::Box* m_topSpacer = nullptr;
+    brls::Box* m_bottomSpacer = nullptr;
+    int m_windowFirstRow = -1;  // First row currently attached to m_contentBox
+    int m_windowLastRow = -1;   // One past last row attached
+    bool m_virtualScrollEnabled = false;
+    void updateRowWindow(int firstVisible, int lastVisible);
+    void enableVirtualScroll();   // Called after incremental build completes
+    void disableVirtualScroll();  // Called before grid rebuild
+
     // Long-press tracking - when true, the next click should be skipped
     bool m_longPressTriggered = false;
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -127,6 +127,10 @@ private:
     float m_lastScrollLoadY = 0.0f;  // Last scroll Y where we triggered thumbnail loading
     int m_scrollLoadCooldown = 0;   // Frame cooldown to throttle scroll-based loading
 
+    // Cached visible row range to avoid full iteration every frame
+    int m_cachedFirstVisible = -1;
+    int m_cachedLastVisible = -1;
+
     // Long-press tracking - when true, the next click should be skipped
     bool m_longPressTriggered = false;
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -125,6 +125,7 @@ private:
     int m_lastScrollY = 0;
     bool m_needsUpdate = false;
     float m_lastScrollLoadY = 0.0f;  // Last scroll Y where we triggered thumbnail loading
+    int m_scrollLoadCooldown = 0;   // Frame cooldown to throttle scroll-based loading
 
     // Long-press tracking - when true, the next click should be skipped
     bool m_longPressTriggered = false;

--- a/include/view/rotatable_image.hpp
+++ b/include/view/rotatable_image.hpp
@@ -140,9 +140,15 @@ public:
     void setSlideOffset(float x, float y);
     void resetSlideOffset();
 
+    /**
+     * Mark as primary for perf overlay (drives frame timing + draws overlay)
+     */
+    void setPerfPrimary(bool primary) { m_perfPrimary = primary; }
+
     static brls::View* create();
 
 private:
+    bool m_perfPrimary = false;  // If true, drives perf overlay frame timing
     int m_nvgImage = 0;           // NanoVG image handle (single texture)
     int m_imageWidth = 0;
     int m_imageHeight = 0;

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1644,11 +1644,11 @@ void ReaderActivity::loadPage(int index) {
 }
 
 void ReaderActivity::preloadAdjacentPages() {
-    // Preload 2 pages ahead and 2 pages behind for smoother swiping in
-    // both directions. This prevents blank frames when swiping backward
-    // through previously-read pages. The Vita's 20MB LRU cache evicts
-    // the oldest entries, so this won't exceed memory limits.
-    for (int i = 1; i <= 2; i++) {
+    // Preload 1 page ahead and 1 page behind for smooth swiping without excessive
+    // queue buildup. Adjacent previews handle the next swipe direction, so this
+    // keeps the queue manageable while maintaining responsive feel.
+    // The Vita's 20MB LRU cache evicts oldest entries, so this won't exceed memory limits.
+    for (int i = 1; i <= 1; i++) {
         int nextIdx = m_currentPage + i;
         if (nextIdx < static_cast<int>(m_pages.size()) && !isTransitionPage(nextIdx)) {
             ImageLoader::preloadFullSize(m_pages[nextIdx].imageUrl);
@@ -3848,9 +3848,10 @@ void ReaderActivity::preloadNextChapter() {
             m_nextChapterLoaded = true;
             brls::Logger::info("Next chapter preloaded: {} pages", m_nextChapterPages.size());
 
-            // Preload first few images of next chapter (full size for manga reader)
-            for (size_t i = 0; i < std::min(size_t(2), m_nextChapterPages.size()); i++) {
-                ImageLoader::preloadFullSize(m_nextChapterPages[i].imageUrl);
+            // Preload first image of next chapter (full size for manga reader)
+            // Reduces queue buildup; adjacent page preload handles next sequential pages
+            if (!m_nextChapterPages.empty()) {
+                ImageLoader::preloadFullSize(m_nextChapterPages[0].imageUrl);
             }
         }
     });

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1644,11 +1644,11 @@ void ReaderActivity::loadPage(int index) {
 }
 
 void ReaderActivity::preloadAdjacentPages() {
-    // Preload 1 page ahead and 1 page behind for smooth swiping without excessive
-    // queue buildup. Adjacent previews handle the next swipe direction, so this
-    // keeps the queue manageable while maintaining responsive feel.
-    // The Vita's 20MB LRU cache evicts oldest entries, so this won't exceed memory limits.
-    for (int i = 1; i <= 1; i++) {
+    // Preload 2 pages ahead and 2 pages behind for smoother swiping in
+    // both directions. This prevents blank frames when swiping backward
+    // through previously-read pages. The Vita's 20MB LRU cache evicts
+    // the oldest entries, so this won't exceed memory limits.
+    for (int i = 1; i <= 2; i++) {
         int nextIdx = m_currentPage + i;
         if (nextIdx < static_cast<int>(m_pages.size()) && !isTransitionPage(nextIdx)) {
             ImageLoader::preloadFullSize(m_pages[nextIdx].imageUrl);
@@ -3848,10 +3848,9 @@ void ReaderActivity::preloadNextChapter() {
             m_nextChapterLoaded = true;
             brls::Logger::info("Next chapter preloaded: {} pages", m_nextChapterPages.size());
 
-            // Preload first image of next chapter (full size for manga reader)
-            // Reduces queue buildup; adjacent page preload handles next sequential pages
-            if (!m_nextChapterPages.empty()) {
-                ImageLoader::preloadFullSize(m_nextChapterPages[0].imageUrl);
+            // Preload first few images of next chapter (full size for manga reader)
+            for (size_t i = 0; i < std::min(size_t(2), m_nextChapterPages.size()); i++) {
+                ImageLoader::preloadFullSize(m_nextChapterPages[i].imageUrl);
             }
         }
     });

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -84,6 +84,9 @@ brls::View* ReaderActivity::createContentView() {
 void ReaderActivity::onContentAvailable() {
     brls::Logger::info("ReaderActivity: content available for manga {}", m_mangaId);
 
+    // Enable perf overlay on the main page image so it drives frame timing in reader
+    this->pageImage->setPerfPrimary(true);
+
     // Load settings - priority order:
     // 1. Server meta (per-manga settings synced to server)
     // 2. Local per-manga settings cache

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -10,6 +10,7 @@
 #include "activity/login_activity.hpp"
 #include "activity/main_activity.hpp"
 #include "activity/reader_activity.hpp"
+#include "utils/perf_overlay.hpp"
 
 #include <borealis.hpp>
 #include <fstream>
@@ -136,6 +137,7 @@ bool Application::init() {
     // Apply settings
     applyTheme();
     applyLogLevel();
+    PerfOverlay::getInstance().setEnabled(m_settings.showPerfOverlay);
 
     // Initialize library cache
     LibraryCache::getInstance().init();
@@ -388,6 +390,9 @@ void Application::run() {
             pushLoginActivity();
         }
     }
+
+    // Sync perf overlay setting
+    PerfOverlay::getInstance().setEnabled(m_settings.showPerfOverlay);
 
     // Main loop handled by Borealis
     while (brls::Application::mainLoop()) {
@@ -1333,6 +1338,7 @@ bool Application::loadSettings() {
     }
     m_settings.showClock = extractBool("showClock", true);
     m_settings.debugLogging = extractBool("debugLogging", false);
+    m_settings.showPerfOverlay = extractBool("showPerfOverlay", false);
 
     // Load reader settings
     m_settings.readingMode = static_cast<ReadingMode>(extractInt("readingMode"));
@@ -1831,6 +1837,7 @@ bool Application::saveSettings() {
     json += "  \"theme\": " + std::to_string(static_cast<int>(m_settings.theme)) + ",\n";
     json += "  \"showClock\": " + std::string(m_settings.showClock ? "true" : "false") + ",\n";
     json += "  \"debugLogging\": " + std::string(m_settings.debugLogging ? "true" : "false") + ",\n";
+    json += "  \"showPerfOverlay\": " + std::string(m_settings.showPerfOverlay ? "true" : "false") + ",\n";
 
     // Reader settings
     json += "  \"readingMode\": " + std::to_string(static_cast<int>(m_settings.readingMode)) + ",\n";

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "utils/image_loader.hpp"
+#include "utils/perf_overlay.hpp"
 #include "utils/http_client.hpp"
 #include "utils/library_cache.hpp"
 #include "app/suwayomi_client.hpp"
@@ -2119,6 +2120,13 @@ void ImageLoader::processPendingTextures() {
             if (update.callback) update.callback(update.target);
         }
         processed++;
+    }
+
+    // Report stats to perf overlay
+    PerfOverlay::getInstance().recordTextureUploads(processed);
+    {
+        std::lock_guard<std::mutex> lock(s_pendingMutex);
+        PerfOverlay::getInstance().recordPendingTextures(static_cast<int>(s_pendingTextures.size()));
     }
 
     // If more pending, schedule another batch for the next frame

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -2079,9 +2079,21 @@ void ImageLoader::queueTextureUpdate(const std::vector<uint8_t>& data, brls::Ima
 void ImageLoader::processPendingTextures() {
     s_pendingScheduled = false;
 
-    // Process up to MAX_TEXTURES_PER_FRAME textures this frame
+    // Process up to MAX_TEXTURES_PER_FRAME textures this frame, with a time budget.
+    // Each GPU texture upload (setImageFromMem) can take 15-20ms on PS Vita,
+    // so we also enforce a 8ms time limit to avoid blowing the 16.7ms frame budget.
+    auto frameStart = std::chrono::steady_clock::now();
+    static constexpr int64_t MAX_UPLOAD_TIME_US = 8000;  // 8ms time budget
+
     int processed = 0;
     while (processed < MAX_TEXTURES_PER_FRAME) {
+        // Check time budget before processing next texture
+        if (processed > 0) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - frameStart).count();
+            if (elapsed >= MAX_UPLOAD_TIME_US) break;
+        }
+
         PendingTextureUpdate update;
         {
             std::lock_guard<std::mutex> lock(s_pendingMutex);
@@ -2092,10 +2104,6 @@ void ImageLoader::processPendingTextures() {
 
         if (update.target) {
             // Skip if the owning view was destroyed while the image was downloading.
-            // Without this check, writing to a freed brls::Image* causes a crash.
-            // Check alive TWICE: once before and once after validation to narrow
-            // the TOCTOU window (both checks run on main thread, so the real risk
-            // is a brls::sync callback destroying the cell between iterations).
             if (update.alive && !*update.alive) {
                 continue;
             }
@@ -2103,8 +2111,7 @@ void ImageLoader::processPendingTextures() {
             if (update.data.empty()) {
                 continue;
             }
-            // Re-check alive right before the actual GPU upload - a brls::sync
-            // callback processed earlier in this frame could have destroyed the cell.
+            // Re-check alive right before the actual GPU upload
             if (update.alive && !*update.alive) {
                 continue;
             }

--- a/src/utils/perf_overlay.cpp
+++ b/src/utils/perf_overlay.cpp
@@ -9,9 +9,47 @@
 
 namespace vitasuwayomi {
 
+static const char* PERF_LOG_PATH = "ux0:data/VitaSuwayomi/perf.log";
+
 PerfOverlay& PerfOverlay::getInstance() {
     static PerfOverlay instance;
     return instance;
+}
+
+PerfOverlay::~PerfOverlay() {
+    closeLog();
+}
+
+void PerfOverlay::closeLog() {
+    if (m_logFile) {
+        fclose(m_logFile);
+        m_logFile = nullptr;
+    }
+}
+
+void PerfOverlay::openLogIfNeeded() {
+    if (m_logFile) return;
+    m_logFile = fopen(PERF_LOG_PATH, "w");
+    if (m_logFile) {
+        fprintf(m_logFile, "=== VitaSuwayomi Perf Log ===\n");
+        fprintf(m_logFile, "FPS | Frame(ms) | Max(ms) | TexUp | Pending | Sections...\n");
+        fprintf(m_logFile, "-----------------------------------------------------------\n");
+        fflush(m_logFile);
+    }
+}
+
+void PerfOverlay::writeLogEntry() {
+    if (!m_logFile) return;
+
+    fprintf(m_logFile, "FPS:%.0f Frame:%.1fms Max:%.1fms TexUp:%d Pend:%d",
+            m_fps, m_frameTimeMs, m_maxFrameTimeMs,
+            m_textureUploadsThisFrame, m_pendingTextures);
+
+    for (int i = 0; i < m_sectionCount; i++) {
+        fprintf(m_logFile, " | %s:%.1fms", m_sections[i].name, m_sections[i].lastMs);
+    }
+    fprintf(m_logFile, "\n");
+    fflush(m_logFile);
 }
 
 void PerfOverlay::beginFrame() {
@@ -44,6 +82,14 @@ void PerfOverlay::endFrame() {
         m_frameCount = 0;
         m_lastFpsUpdate = now;
         m_maxFrameTimeMs = 0.0f;  // Reset worst frame tracking each second
+    }
+
+    // Write to log file periodically (every m_logInterval frames)
+    m_logCounter++;
+    if (m_logCounter >= m_logInterval) {
+        m_logCounter = 0;
+        openLogIfNeeded();
+        writeLogEntry();
     }
 }
 

--- a/src/utils/perf_overlay.cpp
+++ b/src/utils/perf_overlay.cpp
@@ -1,0 +1,204 @@
+/**
+ * VitaSuwayomi - Performance Debug Overlay implementation
+ */
+
+#include "utils/perf_overlay.hpp"
+#include <cstring>
+#include <cstdio>
+#include <algorithm>
+
+namespace vitasuwayomi {
+
+PerfOverlay& PerfOverlay::getInstance() {
+    static PerfOverlay instance;
+    return instance;
+}
+
+void PerfOverlay::beginFrame() {
+    if (!m_enabled) return;
+    m_frameStart = Clock::now();
+    m_textureUploadsThisFrame = 0;
+}
+
+void PerfOverlay::endFrame() {
+    if (!m_enabled) return;
+
+    auto now = Clock::now();
+    float frameMs = std::chrono::duration<float, std::milli>(now - m_frameStart).count();
+    m_frameTimeMs = frameMs;
+
+    // Record to history
+    m_frameTimeHistory[m_historyIndex] = frameMs;
+    m_historyIndex = (m_historyIndex + 1) % HISTORY_SIZE;
+
+    // Track worst frame
+    if (frameMs > m_maxFrameTimeMs) {
+        m_maxFrameTimeMs = frameMs;
+    }
+
+    // Update FPS every second
+    m_frameCount++;
+    float elapsed = std::chrono::duration<float>(now - m_lastFpsUpdate).count();
+    if (elapsed >= 1.0f) {
+        m_fps = m_frameCount / elapsed;
+        m_frameCount = 0;
+        m_lastFpsUpdate = now;
+        m_maxFrameTimeMs = 0.0f;  // Reset worst frame tracking each second
+    }
+}
+
+void PerfOverlay::beginSection(const char* name) {
+    if (!m_enabled) return;
+    int idx = findSection(name);
+    if (idx < 0) {
+        if (m_sectionCount >= MAX_SECTIONS) return;
+        idx = m_sectionCount++;
+        m_sections[idx].name = name;
+    }
+    m_sections[idx].start = Clock::now();
+}
+
+void PerfOverlay::endSection(const char* name) {
+    if (!m_enabled) return;
+    int idx = findSection(name);
+    if (idx < 0) return;
+    auto now = Clock::now();
+    m_sections[idx].lastMs = std::chrono::duration<float, std::milli>(now - m_sections[idx].start).count();
+}
+
+void PerfOverlay::recordTextureUploads(int count) {
+    m_textureUploadsThisFrame += count;
+}
+
+void PerfOverlay::recordPendingTextures(int count) {
+    m_pendingTextures = count;
+}
+
+int PerfOverlay::findSection(const char* name) {
+    for (int i = 0; i < m_sectionCount; i++) {
+        if (m_sections[i].name == name) return i;  // Pointer comparison (same literal)
+    }
+    return -1;
+}
+
+void PerfOverlay::draw(NVGcontext* vg, float screenWidth, float screenHeight) {
+    if (!m_enabled) return;
+
+    // Overlay position: top-right corner
+    float panelW = 220.0f;
+    float lineH = 14.0f;
+    int numLines = 4 + m_sectionCount;  // FPS, frame time, textures, pending + sections
+    float graphH = 40.0f;
+    float panelH = (numLines * lineH) + graphH + 16.0f;
+    float panelX = screenWidth - panelW - 4.0f;
+    float panelY = 4.0f;
+
+    // Semi-transparent background
+    nvgBeginPath(vg);
+    nvgRoundedRect(vg, panelX, panelY, panelW, panelH, 4.0f);
+    nvgFillColor(vg, nvgRGBA(0, 0, 0, 180));
+    nvgFill(vg);
+
+    // Text setup
+    nvgFontSize(vg, 12.0f);
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+
+    float textX = panelX + 6.0f;
+    float textY = panelY + 4.0f;
+    char buf[128];
+
+    // FPS - color coded
+    NVGcolor fpsColor;
+    if (m_fps >= 50.0f) fpsColor = nvgRGB(0, 255, 0);        // Green: good
+    else if (m_fps >= 30.0f) fpsColor = nvgRGB(255, 255, 0);  // Yellow: ok
+    else if (m_fps >= 15.0f) fpsColor = nvgRGB(255, 128, 0);  // Orange: bad
+    else fpsColor = nvgRGB(255, 0, 0);                         // Red: terrible
+
+    snprintf(buf, sizeof(buf), "FPS: %.0f", m_fps);
+    nvgFillColor(vg, fpsColor);
+    nvgText(vg, textX, textY, buf, nullptr);
+    textY += lineH;
+
+    // Frame time
+    snprintf(buf, sizeof(buf), "Frame: %.1fms (max %.1fms)", m_frameTimeMs, m_maxFrameTimeMs);
+    nvgFillColor(vg, nvgRGB(220, 220, 220));
+    nvgText(vg, textX, textY, buf, nullptr);
+    textY += lineH;
+
+    // Texture upload stats
+    snprintf(buf, sizeof(buf), "Tex uploads: %d  pending: %d", m_textureUploadsThisFrame, m_pendingTextures);
+    NVGcolor texColor = m_pendingTextures > 10 ? nvgRGB(255, 128, 0) : nvgRGB(180, 180, 180);
+    nvgFillColor(vg, texColor);
+    nvgText(vg, textX, textY, buf, nullptr);
+    textY += lineH;
+
+    // Target line label
+    snprintf(buf, sizeof(buf), "Target: 16.7ms (60fps)");
+    nvgFillColor(vg, nvgRGB(120, 120, 120));
+    nvgText(vg, textX, textY, buf, nullptr);
+    textY += lineH;
+
+    // Section breakdown
+    for (int i = 0; i < m_sectionCount; i++) {
+        snprintf(buf, sizeof(buf), "  %s: %.1fms", m_sections[i].name, m_sections[i].lastMs);
+        // Color code: red if section takes more than 8ms
+        NVGcolor secColor = m_sections[i].lastMs > 8.0f ? nvgRGB(255, 100, 100) : nvgRGB(160, 160, 160);
+        nvgFillColor(vg, secColor);
+        nvgText(vg, textX, textY, buf, nullptr);
+        textY += lineH;
+    }
+
+    // Frame time graph
+    float graphX = panelX + 6.0f;
+    float graphY = textY + 4.0f;
+    float graphW = panelW - 12.0f;
+    float maxGraphMs = 50.0f;  // Graph scales to 50ms max
+
+    // Graph background
+    nvgBeginPath(vg);
+    nvgRect(vg, graphX, graphY, graphW, graphH);
+    nvgFillColor(vg, nvgRGBA(20, 20, 20, 200));
+    nvgFill(vg);
+
+    // 16.7ms target line (60fps)
+    float targetY = graphY + graphH - (16.7f / maxGraphMs) * graphH;
+    nvgBeginPath(vg);
+    nvgMoveTo(vg, graphX, targetY);
+    nvgLineTo(vg, graphX + graphW, targetY);
+    nvgStrokeColor(vg, nvgRGBA(0, 255, 0, 80));
+    nvgStrokeWidth(vg, 1.0f);
+    nvgStroke(vg);
+
+    // 33.3ms line (30fps)
+    float target30Y = graphY + graphH - (33.3f / maxGraphMs) * graphH;
+    nvgBeginPath(vg);
+    nvgMoveTo(vg, graphX, target30Y);
+    nvgLineTo(vg, graphX + graphW, target30Y);
+    nvgStrokeColor(vg, nvgRGBA(255, 255, 0, 60));
+    nvgStrokeWidth(vg, 1.0f);
+    nvgStroke(vg);
+
+    // Frame time bars
+    float barW = graphW / HISTORY_SIZE;
+    for (int i = 0; i < HISTORY_SIZE; i++) {
+        int idx = (m_historyIndex + i) % HISTORY_SIZE;
+        float ms = m_frameTimeHistory[idx];
+        if (ms <= 0.0f) continue;
+
+        float barH = std::min((ms / maxGraphMs) * graphH, graphH);
+        float barX = graphX + i * barW;
+        float barY = graphY + graphH - barH;
+
+        NVGcolor barColor;
+        if (ms <= 16.7f) barColor = nvgRGBA(0, 200, 0, 200);       // Under 60fps budget
+        else if (ms <= 33.3f) barColor = nvgRGBA(255, 200, 0, 200); // Under 30fps budget
+        else barColor = nvgRGBA(255, 50, 50, 200);                   // Over 30fps budget
+
+        nvgBeginPath(vg);
+        nvgRect(vg, barX, barY, barW - 0.5f, barH);
+        nvgFillColor(vg, barColor);
+        nvgFill(vg);
+    }
+}
+
+} // namespace vitasuwayomi

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -312,6 +312,10 @@ void MangaItemCell::setPressed(bool pressed) {
 
 void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
+    // PERF: Skip draw entirely for cells in virtual scroll buffer rows that are
+    // off-screen. Saves ~0.33ms per culled cell (texture bind + nvg overlay).
+    if (y + height < 0 || y > 544.0f) return;
+
     // Draw child views via borealis (only Image + lazy badges in hierarchy now)
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -1,6 +1,11 @@
 /**
  * VitaSuwayomi - Manga Item Cell implementation
  * Komikku-style card with cover image, title overlay, and badges
+ *
+ * PERF: Title overlay, title label, subtitle label, and unread badge are
+ * rendered directly via NanoVG instead of borealis sub-views. This eliminates
+ * ~4 frame() traversals per cell per frame on PS Vita's 444MHz CPU, cutting
+ * per-cell draw cost roughly in half.
  */
 
 #include "view/media_item_cell.hpp"
@@ -54,7 +59,11 @@ static void loadLocalCoverToImage(brls::Image* image, const std::string& localPa
 MangaItemCell::MangaItemCell() {
     m_alive = std::make_shared<bool>(true);
 
-    // Komikku-style: card with cover filling the space, title at bottom
+    // Initialize flat-rendered colors from theme
+    m_subtitleColor = Application::getInstance().getSubtitleColor();
+    m_unreadBgColor = Application::getInstance().getTealColor();
+
+    // Komikku-style: card with cover filling the space
     this->setAxis(brls::Axis::COLUMN);
     this->setJustifyContent(brls::JustifyContent::FLEX_END);
     this->setAlignItems(brls::AlignItems::STRETCH);
@@ -63,11 +72,11 @@ MangaItemCell::MangaItemCell() {
     this->setBackgroundColor(Application::getInstance().getCardBackground());
     this->setClipsToBounds(true);
 
-    // Cover image - fills the card (no fixed size, uses parent dimensions)
+    // Cover image - fills the card (only child view that needs borealis frame())
     m_thumbnailImage = new brls::Image();
     m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
     m_thumbnailImage->setCornerRadius(8);
-    m_thumbnailImage->setGrow(1.0f);  // Fill available space
+    m_thumbnailImage->setGrow(1.0f);
     m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
     m_thumbnailImage->setPositionTop(0);
     m_thumbnailImage->setPositionLeft(0);
@@ -75,70 +84,24 @@ MangaItemCell::MangaItemCell() {
     m_thumbnailImage->setPositionBottom(0);
     this->addView(m_thumbnailImage);
 
-    // Bottom overlay for title (gradient effect simulated with solid color)
-    // Use percentage width to match parent
-    m_titleOverlay = new brls::Box();
-    m_titleOverlay->setAxis(brls::Axis::COLUMN);
-    m_titleOverlay->setJustifyContent(brls::JustifyContent::FLEX_END);
-    m_titleOverlay->setAlignItems(brls::AlignItems::STRETCH);
-    m_titleOverlay->setBackgroundColor(nvgRGBA(0, 0, 0, 180));
-    m_titleOverlay->setPadding(6, 6, 4, 6);
-    m_titleOverlay->setPositionType(brls::PositionType::ABSOLUTE);
-    m_titleOverlay->setPositionBottom(0);
-    m_titleOverlay->setPositionLeft(0);
-    m_titleOverlay->setPositionRight(0);  // Stretch to fill width
-    m_titleOverlay->setClipsToBounds(true);
-    // Limit overlay height so titles don't cover the entire cover.
-    // 2 lines of title (fontSize 11, ~14px line height) + 1 line subtitle (~12px) + padding (10px)
-    m_titleOverlay->setMaxHeight(50);
-
-    // Title label - at bottom of card, wraps to 2 lines for longer titles
-    m_titleLabel = new brls::Label();
-    m_titleLabel->setFontSize(11);
-    m_titleLabel->setTextColor(nvgRGB(255, 255, 255));
-    m_titleLabel->setHorizontalAlign(brls::HorizontalAlign::LEFT);
-    m_titleOverlay->addView(m_titleLabel);
-
-    // Subtitle (author) - smaller, below title, single line
-    m_subtitleLabel = new brls::Label();
-    m_subtitleLabel->setFontSize(9);
-    m_subtitleLabel->setTextColor(Application::getInstance().getSubtitleColor());
-    m_subtitleLabel->setHorizontalAlign(brls::HorizontalAlign::LEFT);
-    m_subtitleLabel->setSingleLine(true);
-    m_titleOverlay->addView(m_subtitleLabel);
-
-    this->addView(m_titleOverlay);
-
-    // Unread badge - top left corner (created eagerly since it's commonly visible)
-    m_unreadBadge = new brls::Label();
-    m_unreadBadge->setFontSize(10);
-    m_unreadBadge->setTextColor(nvgRGB(255, 255, 255));
-    m_unreadBadge->setBackgroundColor(Application::getInstance().getTealColor()); // Teal badge
-    m_unreadBadge->setMargins(6, 0, 0, 6);
-    m_unreadBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_unreadBadge->setPositionTop(0);
-    m_unreadBadge->setPositionLeft(0);
-    m_unreadBadge->setVisibility(brls::Visibility::GONE);
-    this->addView(m_unreadBadge);
+    // Title overlay, title label, subtitle label, and unread badge are NOT
+    // added to the view hierarchy. They are rendered directly in draw() via
+    // NanoVG to avoid per-frame borealis frame() traversal overhead.
 
     // Remaining sub-views (listInfoBox, listTitleLabel, newBadge, starBadge,
     // startHintIcon, descriptionLabel) are lazy-created via ensure*() methods
-    // when first needed. This saves ~5 Yoga node insertions per cell during
-    // initial grid build (98 cells × 5 = 490 fewer allocations).
+    // when first needed.
 }
 
 MangaItemCell::~MangaItemCell() {
     // Signal to any in-flight ImageLoader callbacks that our m_thumbnailImage
-    // pointer is no longer valid. Without this, a background worker thread
-    // that finishes downloading after this cell is destroyed would write
-    // to freed memory via processPendingTextures() → target->setImageFromMem().
+    // pointer is no longer valid.
     if (m_alive) {
         *m_alive = false;
     }
 
     // m_descriptionLabel is not added to the view hierarchy (no parent),
-    // so brls won't auto-delete it.  Free it here to prevent a memory leak
-    // that accumulates with every grid rebuild (~each cell leaks one Label).
+    // so brls won't auto-delete it.
     if (m_descriptionLabel) {
         delete m_descriptionLabel;
         m_descriptionLabel = nullptr;
@@ -147,38 +110,34 @@ MangaItemCell::~MangaItemCell() {
 
 void MangaItemCell::updateDisplay() {
     // Set title - Komikku style, left-aligned, up to 2 lines
-    // Truncation and font size adapt to grid column count
-    if (m_titleLabel) {
+    {
         std::string title = m_manga.title;
 
-        // Max characters depends on grid size (wider cells fit more text)
-        int maxChars = 40;  // Default for 6 columns
+        int maxChars = 40;
         if (m_gridColumns <= 4) {
-            maxChars = 55;   // Wider cells: ~27 chars per line x 2 lines
+            maxChars = 55;
         } else if (m_gridColumns <= 6) {
-            maxChars = 40;   // Default: ~20 chars per line x 2 lines
+            maxChars = 40;
         } else {
-            maxChars = 28;   // Narrow cells: ~14 chars per line x 2 lines
+            maxChars = 28;
         }
 
         if (static_cast<int>(title.length()) > maxChars) {
             title = title.substr(0, maxChars - 2) + "..";
         }
         m_originalTitle = title;
-        m_titleLabel->setText(title);
+        m_titleText = title;
     }
 
     // Update list mode title - only if already created (lazy)
     if (m_listTitleLabel) {
         m_listTitleLabel->setText(m_manga.title);
     }
-    // If in list mode and listTitleLabel not created yet, ensureListInfoBox will handle it
 
     // Set subtitle (author or chapter count)
-    if (m_subtitleLabel) {
+    {
         if (!m_manga.author.empty()) {
             std::string author = m_manga.author;
-            // Max subtitle chars depends on grid size
             int maxSubChars = 18;
             if (m_gridColumns <= 4) {
                 maxSubChars = 28;
@@ -190,22 +149,22 @@ void MangaItemCell::updateDisplay() {
             if (static_cast<int>(author.length()) > maxSubChars) {
                 author = author.substr(0, maxSubChars - 2) + "..";
             }
-            m_subtitleLabel->setText(author);
+            m_subtitleText = author;
         } else if (m_manga.chapterCount > 0) {
-            m_subtitleLabel->setText(std::to_string(m_manga.chapterCount) + " ch");
+            m_subtitleText = std::to_string(m_manga.chapterCount) + " ch";
         } else {
-            m_subtitleLabel->setText("");
+            m_subtitleText.clear();
         }
     }
 
     // Show unread badge (teal, top-left) - respects showUnreadBadge setting
-    if (m_unreadBadge) {
+    {
         const auto& settings = Application::getInstance().getSettings();
         if (settings.showUnreadBadge && m_manga.unreadCount > 0) {
-            m_unreadBadge->setText(std::to_string(m_manga.unreadCount));
-            m_unreadBadge->setVisibility(brls::Visibility::VISIBLE);
+            m_unreadText = std::to_string(m_manga.unreadCount);
+            m_showUnread = true;
         } else {
-            m_unreadBadge->setVisibility(brls::Visibility::GONE);
+            m_showUnread = false;
         }
     }
 
@@ -217,7 +176,6 @@ void MangaItemCell::updateDisplay() {
             int64_t sevenDaysMs = 7 * 24 * 60 * 60 * 1000LL;
             showNew = (now - m_manga.inLibraryAt) < sevenDaysMs;
         }
-        // Only create the badge view if we actually need to show it
         if (showNew) {
             ensureNewBadge()->setVisibility(brls::Visibility::VISIBLE);
         } else if (m_newBadge) {
@@ -244,9 +202,6 @@ void MangaItemCell::updateDisplay() {
 }
 
 void MangaItemCell::setManga(const Manga& manga) {
-    // Invalidate any in-flight thumbnail loads for the previous manga.
-    // Without this, a stale worker-thread load could finish after the new load
-    // and overwrite the correct cover (race condition during sort changes).
     if (m_alive) *m_alive = false;
     m_alive = std::make_shared<bool>(true);
 
@@ -257,21 +212,16 @@ void MangaItemCell::setManga(const Manga& manga) {
 }
 
 void MangaItemCell::setMangaDeferred(const Manga& manga) {
-    // Invalidate any in-flight thumbnail loads for the previous manga.
     if (m_alive) *m_alive = false;
     m_alive = std::make_shared<bool>(true);
 
-    // Set manga data but don't load thumbnail yet
     m_manga = manga;
     m_thumbnailLoaded = false;
     updateDisplay();
 }
 
 void MangaItemCell::updateMangaData(const Manga& manga) {
-    // Update manga data in place without reloading thumbnail
-    // Used for incremental updates when only counts/metadata change
     m_manga = manga;
-    // Don't reset m_thumbnailLoaded - keep existing thumbnail
     updateDisplay();
 }
 
@@ -284,31 +234,24 @@ void MangaItemCell::loadThumbnailIfNeeded() {
 void MangaItemCell::unloadThumbnail() {
     if (!m_thumbnailLoaded || !m_thumbnailImage) return;
 
-    // Clear the GPU texture by setting a tiny 1x1 transparent TGA image
-    // This frees VRAM on the Vita's limited 128MB while keeping the cell structure intact
-    // The thumbnail can be reloaded later via loadThumbnailIfNeeded() when scrolled back
     static const unsigned char s_clearPixel[] = {
-        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // TGA header
-        1, 0, 1, 0, 32, 0,                      // 1x1, 32bpp
-        0, 0, 0, 0                               // 1 transparent pixel (BGRA)
+        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 1, 0, 32, 0,
+        0, 0, 0, 0
     };
     m_thumbnailImage->setImageFromMem(s_clearPixel, sizeof(s_clearPixel));
     m_thumbnailLoaded = false;
 }
 
 void MangaItemCell::resetThumbnailLoadState() {
-    // Just reset the load flag without clearing the existing image.
-    // This allows loadThumbnailIfNeeded() to reload the thumbnail from cache/network
-    // while keeping the old image visible until the new one arrives (no visual flash).
     m_thumbnailLoaded = false;
 }
 
 void MangaItemCell::loadThumbnail() {
     if (!m_thumbnailImage || m_thumbnailLoaded) return;
 
-    m_thumbnailLoaded = true;  // Mark as loaded to prevent duplicate loads
+    m_thumbnailLoaded = true;
 
-    // Check for local Vita cover path
     if (!m_manga.thumbnailUrl.empty() && m_manga.thumbnailUrl.find("ux0:") == 0) {
         loadLocalCoverToImage(m_thumbnailImage, m_manga.thumbnailUrl);
         return;
@@ -343,9 +286,7 @@ brls::View* MangaItemCell::create() {
 void MangaItemCell::onFocusGained() {
     brls::Box::onFocusGained();
     updateFocusInfo(true);
-    // Refresh library badge to reflect add/remove changes from detail view
     refreshLibraryBadge();
-    // Show start button hint on focus (but not in browser/search tabs where library badge is shown)
     if (!m_showLibraryBadge) {
         auto* hint = ensureStartHintIcon();
         if (!m_startHintImageLoaded) {
@@ -359,7 +300,6 @@ void MangaItemCell::onFocusGained() {
 void MangaItemCell::onFocusLost() {
     brls::Box::onFocusLost();
     updateFocusInfo(false);
-    // Hide start button hint when focus is lost
     if (m_startHintIcon) {
         m_startHintIcon->setVisibility(brls::Visibility::GONE);
     }
@@ -371,10 +311,79 @@ void MangaItemCell::setPressed(bool pressed) {
 
 void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
-    // Draw normally first
+    // Draw child views via borealis (only Image + lazy badges in hierarchy now)
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 
-    // Overlay a semi-transparent dark rect when pressed for touch feedback
+    // --- Flat-rendered title overlay (saves 3 frame() calls vs sub-view approach) ---
+    if (m_showOverlay && !m_titleText.empty()) {
+        float overlayH = m_overlayMaxHeight;
+        float overlayY = y + height - overlayH;
+
+        // Clip to overlay area (prevents text overflow)
+        nvgSave(vg);
+        nvgIntersectScissor(vg, x, overlayY, width, overlayH);
+
+        // Semi-transparent background
+        nvgBeginPath(vg);
+        nvgRect(vg, x, overlayY, width, overlayH);
+        nvgFillColor(vg, nvgRGBA(0, 0, 0, 180));
+        nvgFill(vg);
+
+        // Title text (white, left-aligned, wraps within overlay width)
+        float textX = x + m_overlayPadSide;
+        float textW = width - m_overlayPadSide * 2.0f;
+        float textY = overlayY + m_overlayPadTop;
+
+        nvgFontFace(vg, "regular");
+        nvgFontSize(vg, static_cast<float>(m_titleFontSize));
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+        nvgFillColor(vg, nvgRGB(255, 255, 255));
+        nvgTextBox(vg, textX, textY, textW, m_titleText.c_str(), nullptr);
+
+        // Subtitle text (below title)
+        if (!m_subtitleText.empty()) {
+            // Measure title height to position subtitle
+            float bounds[4];
+            nvgTextBoxBounds(vg, textX, textY, textW, m_titleText.c_str(), nullptr, bounds);
+            float titleBottom = bounds[3];  // bounds[3] = max y
+
+            nvgFontSize(vg, static_cast<float>(m_subtitleFontSize));
+            nvgFillColor(vg, m_subtitleColor);
+            nvgText(vg, textX, titleBottom + 1.0f, m_subtitleText.c_str(), nullptr);
+        }
+
+        nvgRestore(vg);
+    }
+
+    // --- Flat-rendered unread badge (saves 1 frame() call) ---
+    if (m_showUnread && !m_unreadText.empty()) {
+        float badgeX = x + static_cast<float>(m_unreadMarginLeft);
+        float badgeY = y + static_cast<float>(m_unreadMarginTop);
+
+        // Measure badge text to size the background
+        nvgFontFace(vg, "regular");
+        nvgFontSize(vg, static_cast<float>(m_unreadFontSize));
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+
+        float bounds[4];
+        nvgTextBounds(vg, 0, 0, m_unreadText.c_str(), nullptr, bounds);
+        float textW = bounds[2] - bounds[0];
+        float textH = bounds[3] - bounds[1];
+        float padX = 4.0f;
+        float padY = 2.0f;
+
+        // Badge background (teal)
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, badgeX, badgeY, textW + padX * 2, textH + padY * 2, 2.0f);
+        nvgFillColor(vg, m_unreadBgColor);
+        nvgFill(vg);
+
+        // Badge text (white)
+        nvgFillColor(vg, nvgRGB(255, 255, 255));
+        nvgText(vg, badgeX + padX, badgeY + padY, m_unreadText.c_str(), nullptr);
+    }
+
+    // Pressed overlay for touch feedback
     if (m_pressed) {
         nvgBeginPath(vg);
         nvgRoundedRect(vg, x, y, width, height, 8);
@@ -390,7 +399,7 @@ void MangaItemCell::setSelected(bool selected) {
 
 void MangaItemCell::updateSelectionVisual() {
     if (m_selected) {
-        this->setBorderColor(Application::getInstance().getTealColor());  // Teal border
+        this->setBorderColor(Application::getInstance().getTealColor());
         this->setBorderThickness(3.0f);
     } else {
         this->setBorderColor(nvgRGBA(0, 0, 0, 0));
@@ -399,11 +408,9 @@ void MangaItemCell::updateSelectionVisual() {
 }
 
 void MangaItemCell::updateFocusInfo(bool focused) {
-    if (!m_titleLabel) return;
-
     if (focused) {
-        // Show full title
-        m_titleLabel->setText(m_manga.title);
+        // Show full title on focus
+        m_titleText = m_manga.title;
 
         // Show additional info
         std::string info;
@@ -426,7 +433,7 @@ void MangaItemCell::updateFocusInfo(bool focused) {
         }
     } else {
         // Restore truncated title
-        m_titleLabel->setText(m_originalTitle);
+        m_titleText = m_originalTitle;
         if (m_descriptionLabel) {
             m_descriptionLabel->setVisibility(brls::Visibility::GONE);
         }
@@ -437,56 +444,46 @@ void MangaItemCell::setGridColumns(int columns) {
     if (m_gridColumns == columns) return;
     m_gridColumns = columns;
 
-    // Adapt title font size and re-truncate based on grid column count
-    if (m_titleLabel) {
-        int fontSize = 11;  // Default for 6 columns
-        if (columns <= 4) {
-            fontSize = 14;
-        } else if (columns <= 6) {
-            fontSize = 11;
-        } else {
-            fontSize = 9;
-        }
-        m_titleLabel->setFontSize(fontSize);
-    }
-    if (m_subtitleLabel) {
-        int subFontSize = 9;
-        if (columns <= 4) {
-            subFontSize = 11;
-        } else if (columns <= 6) {
-            subFontSize = 9;
-        } else {
-            subFontSize = 8;
-        }
-        m_subtitleLabel->setFontSize(subFontSize);
-    }
-    // Adjust overlay max height for font size so title stays at most 2 lines
-    if (m_titleOverlay) {
-        if (columns <= 4) {
-            m_titleOverlay->setMaxHeight(66);  // 2 lines @ 14px font + subtitle @ 11px + padding
-        } else if (columns <= 6) {
-            m_titleOverlay->setMaxHeight(50);  // 2 lines @ 11px font + subtitle @ 9px + padding
-        } else {
-            m_titleOverlay->setMaxHeight(42);  // 2 lines @ 9px font + subtitle @ 8px + padding
-        }
+    // Adapt title font size based on grid column count
+    if (columns <= 4) {
+        m_titleFontSize = 14;
+    } else if (columns <= 6) {
+        m_titleFontSize = 11;
+    } else {
+        m_titleFontSize = 9;
     }
 
-    // Scale unread badge font size and padding with grid size
-    if (m_unreadBadge) {
-        int badgeFontSize = 10;
-        int badgeMargin = 6;
-        if (columns <= 4) {
-            badgeFontSize = 13;
-            badgeMargin = 8;
-        } else if (columns <= 6) {
-            badgeFontSize = 10;
-            badgeMargin = 6;
-        } else {
-            badgeFontSize = 8;
-            badgeMargin = 4;
-        }
-        m_unreadBadge->setFontSize(badgeFontSize);
-        m_unreadBadge->setMargins(badgeMargin, 0, 0, badgeMargin);
+    // Adapt subtitle font size
+    if (columns <= 4) {
+        m_subtitleFontSize = 11;
+    } else if (columns <= 6) {
+        m_subtitleFontSize = 9;
+    } else {
+        m_subtitleFontSize = 8;
+    }
+
+    // Adjust overlay max height for font size
+    if (columns <= 4) {
+        m_overlayMaxHeight = 66;
+    } else if (columns <= 6) {
+        m_overlayMaxHeight = 50;
+    } else {
+        m_overlayMaxHeight = 42;
+    }
+
+    // Scale unread badge font size and margin with grid size
+    if (columns <= 4) {
+        m_unreadFontSize = 13;
+        m_unreadMarginTop = 8;
+        m_unreadMarginLeft = 8;
+    } else if (columns <= 6) {
+        m_unreadFontSize = 10;
+        m_unreadMarginTop = 6;
+        m_unreadMarginLeft = 6;
+    } else {
+        m_unreadFontSize = 8;
+        m_unreadMarginTop = 4;
+        m_unreadMarginLeft = 4;
     }
 
     // Scale NEW badge font size and position with grid size (only if already created)
@@ -510,21 +507,20 @@ void MangaItemCell::setGridColumns(int columns) {
 void MangaItemCell::setCompactMode(bool compact) {
     if (m_compactMode == compact) return;
     m_compactMode = compact;
-    m_listMode = false;  // Mutually exclusive
+    m_listMode = false;
     applyDisplayMode();
 }
 
 void MangaItemCell::setListMode(bool listMode) {
     if (m_listMode == listMode) return;
     m_listMode = listMode;
-    m_compactMode = false;  // Mutually exclusive
+    m_compactMode = false;
     applyDisplayMode();
 }
 
 void MangaItemCell::setShowLibraryBadge(bool show) {
     if (m_showLibraryBadge == show) return;
     m_showLibraryBadge = show;
-    // Update star badge visibility (also check recent additions cache)
     bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
                  && !Application::getInstance().isRecentlyRemoved(m_manga.id);
     if (inLib) {
@@ -537,7 +533,6 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     } else if (m_starBadge) {
         m_starBadge->setVisibility(brls::Visibility::GONE);
     }
-    // Hide start hint icon when in browser/search mode
     if (m_startHintIcon && m_showLibraryBadge) {
         m_startHintIcon->setVisibility(brls::Visibility::GONE);
     }
@@ -560,13 +555,10 @@ void MangaItemCell::refreshLibraryBadge() {
 }
 
 void MangaItemCell::setListRowSize(int rowSize) {
-    // No-op: list mode always auto-adapts row height to title length
     (void)rowSize;
 }
 
 // --- Lazy creation helpers ---
-// These views are only created when first needed, saving ~5 Yoga node insertions
-// per cell during initial grid build on PS Vita's 444MHz CPU.
 
 brls::Label* MangaItemCell::ensureNewBadge() {
     if (!m_newBadge) {
@@ -646,47 +638,41 @@ brls::Label* MangaItemCell::ensureDescriptionLabel() {
 
 void MangaItemCell::applyDisplayMode() {
     if (m_listMode) {
-        // List mode: simple horizontal layout with title only (no cover)
+        // List mode: horizontal layout with title only (no cover, no overlay)
         this->setAxis(brls::Axis::ROW);
         this->setJustifyContent(brls::JustifyContent::FLEX_START);
         this->setAlignItems(brls::AlignItems::CENTER);
 
-        // Hide thumbnail in list mode - titles only
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::GONE);
         }
 
-        // Hide grid title overlay
-        if (m_titleOverlay) {
-            m_titleOverlay->setVisibility(brls::Visibility::GONE);
-        }
+        // Hide flat overlay in list mode
+        m_showOverlay = false;
 
-        // Show list info box (lazy-created on first list mode activation)
         ensureListInfoBox()->setVisibility(brls::Visibility::VISIBLE);
         if (m_listTitleLabel) {
             m_listTitleLabel->setFontSize(14);
             m_listTitleLabel->setText(m_manga.title);
         }
 
-        // Position badges for list mode (left side)
-        if (m_unreadBadge) {
-            m_unreadBadge->setPositionTop(4);
-            m_unreadBadge->setPositionLeft(8);
-        }
+        // Adjust badge positions for list mode
         if (m_newBadge) {
             m_newBadge->setPositionTop(4);
-            m_newBadge->setPositionLeft(40);  // Position next to unread badge
+            m_newBadge->setPositionLeft(40);
         }
-        // Position start hint for list mode (top-right)
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(4);
             m_startHintIcon->setPositionRight(4);
         }
-        // Position star badge for list mode (top-right, below start hint)
         if (m_starBadge) {
             m_starBadge->setPositionTop(4);
-            m_starBadge->setPositionRight(72);  // Left of start hint
+            m_starBadge->setPositionRight(72);
         }
+
+        // Adjust flat-rendered unread badge position for list mode
+        m_unreadMarginTop = 4;
+        m_unreadMarginLeft = 8;
 
     } else if (m_compactMode) {
         // Compact mode: grid with covers only (no title overlay)
@@ -694,7 +680,6 @@ void MangaItemCell::applyDisplayMode() {
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore visibility if coming from list mode)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -706,46 +691,39 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setCornerRadius(8);
         }
 
-        // Hide title overlay in compact mode
-        if (m_titleOverlay) {
-            m_titleOverlay->setVisibility(brls::Visibility::GONE);
-        }
+        // Hide flat overlay in compact mode
+        m_showOverlay = false;
 
-        // Hide list info box
         if (m_listInfoBox) {
             m_listInfoBox->setVisibility(brls::Visibility::GONE);
         }
 
-        // Restore badge positions for grid mode (left side)
-        // NEW badge top position scales with grid columns (set in setGridColumns)
-        if (m_unreadBadge) {
-            m_unreadBadge->setPositionTop(0);
-            m_unreadBadge->setPositionLeft(0);
-        }
+        // Restore badge positions for grid mode
         if (m_newBadge) {
             int newTop = (m_gridColumns <= 4) ? 34 : (m_gridColumns >= 8) ? 20 : 26;
             m_newBadge->setPositionTop(newTop);
             m_newBadge->setPositionLeft(0);
         }
-        // Restore start hint position for compact mode (top-right)
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(6);
             m_startHintIcon->setPositionRight(6);
         }
-        // Star badge position for compact mode (top-right, below start hint area)
         if (m_starBadge) {
             int starTop = (m_gridColumns <= 4) ? 34 : (m_gridColumns >= 8) ? 20 : 26;
             m_starBadge->setPositionTop(starTop);
             m_starBadge->setPositionRight(6);
         }
 
+        // Restore flat badge position
+        m_unreadMarginTop = (m_gridColumns <= 4) ? 8 : (m_gridColumns >= 8) ? 4 : 6;
+        m_unreadMarginLeft = m_unreadMarginTop;
+
     } else {
-        // Normal grid mode: cover + title overlay
+        // Normal grid mode: cover + flat-rendered title overlay
         this->setAxis(brls::Axis::COLUMN);
         this->setJustifyContent(brls::JustifyContent::FLEX_END);
         this->setAlignItems(brls::AlignItems::STRETCH);
 
-        // Thumbnail - fill the cell (restore visibility if coming from list mode)
         if (m_thumbnailImage) {
             m_thumbnailImage->setVisibility(brls::Visibility::VISIBLE);
             m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
@@ -757,38 +735,32 @@ void MangaItemCell::applyDisplayMode() {
             m_thumbnailImage->setCornerRadius(8);
         }
 
-        // Show title overlay
-        if (m_titleOverlay) {
-            m_titleOverlay->setVisibility(brls::Visibility::VISIBLE);
-        }
+        // Show flat overlay in normal grid mode
+        m_showOverlay = true;
 
-        // Hide list info box
         if (m_listInfoBox) {
             m_listInfoBox->setVisibility(brls::Visibility::GONE);
         }
 
-        // Restore badge positions for grid mode (left side)
-        // NEW badge top position scales with grid columns (set in setGridColumns)
-        if (m_unreadBadge) {
-            m_unreadBadge->setPositionTop(0);
-            m_unreadBadge->setPositionLeft(0);
-        }
+        // Restore badge positions for grid mode
         if (m_newBadge) {
             int newTop = (m_gridColumns <= 4) ? 34 : (m_gridColumns >= 8) ? 20 : 26;
             m_newBadge->setPositionTop(newTop);
             m_newBadge->setPositionLeft(0);
         }
-        // Restore start hint position for normal grid mode (top-right)
         if (m_startHintIcon) {
             m_startHintIcon->setPositionTop(6);
             m_startHintIcon->setPositionRight(6);
         }
-        // Star badge position for normal grid mode (top-right, below start hint area)
         if (m_starBadge) {
             int starTop = (m_gridColumns <= 4) ? 34 : (m_gridColumns >= 8) ? 20 : 26;
             m_starBadge->setPositionTop(starTop);
             m_starBadge->setPositionRight(6);
         }
+
+        // Restore flat badge position
+        m_unreadMarginTop = (m_gridColumns <= 4) ? 8 : (m_gridColumns >= 8) ? 4 : 6;
+        m_unreadMarginLeft = m_unreadMarginTop;
     }
 }
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -127,6 +127,7 @@ void MangaItemCell::updateDisplay() {
         }
         m_originalTitle = title;
         m_titleText = title;
+        m_overlayDirty = true;
     }
 
     // Update list mode title - only if already created (lazy)
@@ -314,12 +315,84 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
     // Draw child views via borealis (only Image + lazy badges in hierarchy now)
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 
-    // --- Flat-rendered title overlay (saves 3 frame() calls vs sub-view approach) ---
+    // --- Flat-rendered title overlay ---
+    // PERF: Pre-splits title into cached lines on text change, then draws with
+    // nvgText (no wrapping) instead of nvgTextBox (wraps every frame).
+    // Also caches badge text dimensions. Saves ~0.2ms/cell × 18 cells = ~3.6ms/frame.
     if (m_showOverlay && !m_titleText.empty()) {
+        float textW = width - m_overlayPadSide * 2.0f;
+
+        // Recompute cached text layout when text/font/width changes (not every frame)
+        if (m_overlayDirty || m_cachedCellWidth != width) {
+            m_cachedCellWidth = width;
+
+            nvgFontFace(vg, "regular");
+            nvgFontSize(vg, static_cast<float>(m_titleFontSize));
+            nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+
+            // Measure line height from font metrics
+            nvgTextMetrics(vg, nullptr, nullptr, &m_cachedLineHeight);
+
+            // Pre-split title into lines by measuring word-by-word
+            m_cachedLine1.clear();
+            m_cachedLine2.clear();
+            const char* str = m_titleText.c_str();
+            const char* strEnd = str + m_titleText.size();
+
+            // Check if full title fits in one line
+            float fullBounds[4];
+            nvgTextBounds(vg, 0, 0, str, strEnd, fullBounds);
+            float fullW = fullBounds[2] - fullBounds[0];
+
+            if (fullW <= textW) {
+                // Single line - no wrapping needed
+                m_cachedLine1 = m_titleText;
+                m_cachedTitleBlockH = m_cachedLineHeight;
+            } else {
+                // Find word break point for line 1
+                const char* lastSpace = nullptr;
+                const char* lastGoodEnd = str;
+                for (const char* p = str; p <= strEnd; p++) {
+                    if (p == strEnd || *p == ' ') {
+                        float wb[4];
+                        nvgTextBounds(vg, 0, 0, str, p, wb);
+                        if (wb[2] - wb[0] > textW && lastGoodEnd > str) {
+                            break;
+                        }
+                        lastGoodEnd = p;
+                        if (p < strEnd && *p == ' ') lastSpace = p;
+                    }
+                }
+                // Prefer breaking at word boundary
+                const char* breakAt = (lastSpace && lastSpace >= lastGoodEnd) ? lastSpace : lastGoodEnd;
+                if (breakAt <= str) breakAt = lastGoodEnd;  // Fallback
+
+                m_cachedLine1.assign(str, breakAt);
+                const char* line2Start = breakAt;
+                if (line2Start < strEnd && *line2Start == ' ') line2Start++;
+                if (line2Start < strEnd) {
+                    m_cachedLine2.assign(line2Start, strEnd);
+                }
+                int numLines = m_cachedLine2.empty() ? 1 : 2;
+                m_cachedTitleBlockH = numLines * m_cachedLineHeight;
+            }
+
+            // Cache badge text dimensions
+            if (m_showUnread && !m_unreadText.empty()) {
+                nvgFontSize(vg, static_cast<float>(m_unreadFontSize));
+                float bb[4];
+                nvgTextBounds(vg, 0, 0, m_unreadText.c_str(), nullptr, bb);
+                m_cachedBadgeTextW = bb[2] - bb[0];
+                m_cachedBadgeTextH = bb[3] - bb[1];
+            }
+
+            m_overlayDirty = false;
+        }
+
         float overlayH = m_overlayMaxHeight;
         float overlayY = y + height - overlayH;
 
-        // Clip to overlay area (prevents text overflow)
+        // Clip to overlay area
         nvgSave(vg);
         nvgIntersectScissor(vg, x, overlayY, width, overlayH);
 
@@ -329,24 +402,25 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
         nvgFillColor(vg, nvgRGBA(0, 0, 0, 180));
         nvgFill(vg);
 
-        // Title text (white, left-aligned, wraps within overlay width)
+        // Draw pre-split title lines with nvgText (no per-frame wrapping)
         float textX = x + m_overlayPadSide;
-        float textW = width - m_overlayPadSide * 2.0f;
         float textY = overlayY + m_overlayPadTop;
 
         nvgFontFace(vg, "regular");
         nvgFontSize(vg, static_cast<float>(m_titleFontSize));
         nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgFillColor(vg, nvgRGB(255, 255, 255));
-        nvgTextBox(vg, textX, textY, textW, m_titleText.c_str(), nullptr);
 
-        // Subtitle text (below title)
+        if (!m_cachedLine1.empty()) {
+            nvgText(vg, textX, textY, m_cachedLine1.c_str(), nullptr);
+        }
+        if (!m_cachedLine2.empty()) {
+            nvgText(vg, textX, textY + m_cachedLineHeight, m_cachedLine2.c_str(), nullptr);
+        }
+
+        // Subtitle text (below title, using cached title height)
         if (!m_subtitleText.empty()) {
-            // Measure title height to position subtitle
-            float bounds[4];
-            nvgTextBoxBounds(vg, textX, textY, textW, m_titleText.c_str(), nullptr, bounds);
-            float titleBottom = bounds[3];  // bounds[3] = max y
-
+            float titleBottom = textY + m_cachedTitleBlockH;
             nvgFontSize(vg, static_cast<float>(m_subtitleFontSize));
             nvgFillColor(vg, m_subtitleColor);
             nvgText(vg, textX, titleBottom + 1.0f, m_subtitleText.c_str(), nullptr);
@@ -355,30 +429,34 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
         nvgRestore(vg);
     }
 
-    // --- Flat-rendered unread badge (saves 1 frame() call) ---
+    // --- Flat-rendered unread badge (uses cached dimensions) ---
     if (m_showUnread && !m_unreadText.empty()) {
+        // Cache badge dimensions if not already done (handles compact mode where overlay is hidden)
+        if (m_overlayDirty || m_cachedBadgeTextW == 0) {
+            nvgFontFace(vg, "regular");
+            nvgFontSize(vg, static_cast<float>(m_unreadFontSize));
+            nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+            float bb[4];
+            nvgTextBounds(vg, 0, 0, m_unreadText.c_str(), nullptr, bb);
+            m_cachedBadgeTextW = bb[2] - bb[0];
+            m_cachedBadgeTextH = bb[3] - bb[1];
+        }
+
         float badgeX = x + static_cast<float>(m_unreadMarginLeft);
         float badgeY = y + static_cast<float>(m_unreadMarginTop);
-
-        // Measure badge text to size the background
-        nvgFontFace(vg, "regular");
-        nvgFontSize(vg, static_cast<float>(m_unreadFontSize));
-        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-
-        float bounds[4];
-        nvgTextBounds(vg, 0, 0, m_unreadText.c_str(), nullptr, bounds);
-        float textW = bounds[2] - bounds[0];
-        float textH = bounds[3] - bounds[1];
         float padX = 4.0f;
         float padY = 2.0f;
 
-        // Badge background (teal)
+        // Badge background (teal) - uses cached text dimensions
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, badgeX, badgeY, textW + padX * 2, textH + padY * 2, 2.0f);
+        nvgRoundedRect(vg, badgeX, badgeY, m_cachedBadgeTextW + padX * 2, m_cachedBadgeTextH + padY * 2, 2.0f);
         nvgFillColor(vg, m_unreadBgColor);
         nvgFill(vg);
 
         // Badge text (white)
+        nvgFontFace(vg, "regular");
+        nvgFontSize(vg, static_cast<float>(m_unreadFontSize));
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgFillColor(vg, nvgRGB(255, 255, 255));
         nvgText(vg, badgeX + padX, badgeY + padY, m_unreadText.c_str(), nullptr);
     }
@@ -411,6 +489,7 @@ void MangaItemCell::updateFocusInfo(bool focused) {
     if (focused) {
         // Show full title on focus
         m_titleText = m_manga.title;
+        m_overlayDirty = true;
 
         // Show additional info
         std::string info;
@@ -434,6 +513,7 @@ void MangaItemCell::updateFocusInfo(bool focused) {
     } else {
         // Restore truncated title
         m_titleText = m_originalTitle;
+        m_overlayDirty = true;
         if (m_descriptionLabel) {
             m_descriptionLabel->setVisibility(brls::Visibility::GONE);
         }
@@ -443,6 +523,7 @@ void MangaItemCell::updateFocusInfo(bool focused) {
 void MangaItemCell::setGridColumns(int columns) {
     if (m_gridColumns == columns) return;
     m_gridColumns = columns;
+    m_overlayDirty = true;  // Font sizes change with column count
 
     // Adapt title font size based on grid column count
     if (columns <= 4) {
@@ -737,6 +818,7 @@ void MangaItemCell::applyDisplayMode() {
 
         // Show flat overlay in normal grid mode
         m_showOverlay = true;
+        m_overlayDirty = true;
 
         if (m_listInfoBox) {
             m_listInfoBox->setVisibility(brls::Visibility::GONE);

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -109,24 +109,7 @@ MangaItemCell::MangaItemCell() {
 
     this->addView(m_titleOverlay);
 
-    // List mode info box (horizontal layout - initially hidden)
-    m_listInfoBox = new brls::Box();
-    m_listInfoBox->setAxis(brls::Axis::COLUMN);
-    m_listInfoBox->setJustifyContent(brls::JustifyContent::CENTER);
-    m_listInfoBox->setAlignItems(brls::AlignItems::FLEX_START);
-    m_listInfoBox->setPadding(8, 16, 8, 16);
-    m_listInfoBox->setGrow(1.0f);
-    m_listInfoBox->setVisibility(brls::Visibility::GONE);
-
-    // List mode title label (persistent, not dynamically created)
-    m_listTitleLabel = new brls::Label();
-    m_listTitleLabel->setFontSize(14);
-    m_listTitleLabel->setTextColor(nvgRGB(255, 255, 255));
-    m_listInfoBox->addView(m_listTitleLabel);
-
-    this->addView(m_listInfoBox);
-
-    // Unread badge - top left corner
+    // Unread badge - top left corner (created eagerly since it's commonly visible)
     m_unreadBadge = new brls::Label();
     m_unreadBadge->setFontSize(10);
     m_unreadBadge->setTextColor(nvgRGB(255, 255, 255));
@@ -138,47 +121,10 @@ MangaItemCell::MangaItemCell() {
     m_unreadBadge->setVisibility(brls::Visibility::GONE);
     this->addView(m_unreadBadge);
 
-    // NEW badge - top left, below unread badge (shows if recently updated)
-    m_newBadge = new brls::Label();
-    m_newBadge->setFontSize(8);
-    m_newBadge->setText("NEW");
-    m_newBadge->setTextColor(nvgRGB(255, 255, 255));
-    m_newBadge->setBackgroundColor(nvgRGBA(231, 76, 60, 255)); // Red badge
-    m_newBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_newBadge->setPositionTop(26);  // Below unread badge
-    m_newBadge->setPositionLeft(0);
-    m_newBadge->setVisibility(brls::Visibility::GONE);
-    this->addView(m_newBadge);
-
-    // Star badge - top right corner (shows if manga is in library, browser/search only)
-    // Image loaded lazily on first visibility to avoid 98+ useless GPU texture creations
-    m_starBadge = new brls::Image();
-    m_starBadge->setWidth(16);
-    m_starBadge->setHeight(16);
-    m_starBadge->setScalingType(brls::ImageScalingType::FIT);
-    m_starBadge->setPositionType(brls::PositionType::ABSOLUTE);
-    m_starBadge->setPositionTop(6);
-    m_starBadge->setPositionRight(6);
-    m_starBadge->setVisibility(brls::Visibility::GONE);
-    this->addView(m_starBadge);
-
-    // Description label (hidden, for focus state)
-    m_descriptionLabel = new brls::Label();
-    m_descriptionLabel->setFontSize(9);
-    m_descriptionLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
-    m_descriptionLabel->setVisibility(brls::Visibility::GONE);
-
-    // Start button hint icon - shown on focus (top-right) to indicate menu action
-    // Image loaded lazily on first focus to avoid 98+ useless GPU texture creations
-    m_startHintIcon = new brls::Image();
-    m_startHintIcon->setWidth(64);
-    m_startHintIcon->setHeight(16);
-    m_startHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_startHintIcon->setPositionType(brls::PositionType::ABSOLUTE);
-    m_startHintIcon->setPositionTop(6);
-    m_startHintIcon->setPositionRight(6);
-    m_startHintIcon->setVisibility(brls::Visibility::GONE);
-    this->addView(m_startHintIcon);
+    // Remaining sub-views (listInfoBox, listTitleLabel, newBadge, starBadge,
+    // startHintIcon, descriptionLabel) are lazy-created via ensure*() methods
+    // when first needed. This saves ~5 Yoga node insertions per cell during
+    // initial grid build (98 cells × 5 = 490 fewer allocations).
 }
 
 MangaItemCell::~MangaItemCell() {
@@ -222,10 +168,11 @@ void MangaItemCell::updateDisplay() {
         m_titleLabel->setText(title);
     }
 
-    // Update list mode title - show full title (row auto-adapts to fit)
+    // Update list mode title - only if already created (lazy)
     if (m_listTitleLabel) {
         m_listTitleLabel->setText(m_manga.title);
     }
+    // If in list mode and listTitleLabel not created yet, ensureListInfoBox will handle it
 
     // Set subtitle (author or chapter count)
     if (m_subtitleLabel) {
@@ -263,31 +210,36 @@ void MangaItemCell::updateDisplay() {
     }
 
     // Show NEW badge if manga was added to library recently (within 7 days)
-    if (m_newBadge) {
+    {
         bool showNew = false;
-
-        // If manga has unread chapters and was recently added to library
         if (m_manga.unreadCount > 0 && m_manga.inLibraryAt > 0) {
-            // Check if added within the last 7 days
-            int64_t now = std::time(nullptr) * 1000;  // Current time in ms
-            int64_t sevenDaysMs = 7 * 24 * 60 * 60 * 1000LL;  // 7 days in ms
+            int64_t now = std::time(nullptr) * 1000;
+            int64_t sevenDaysMs = 7 * 24 * 60 * 60 * 1000LL;
             showNew = (now - m_manga.inLibraryAt) < sevenDaysMs;
         }
-
-        m_newBadge->setVisibility(showNew ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+        // Only create the badge view if we actually need to show it
+        if (showNew) {
+            ensureNewBadge()->setVisibility(brls::Visibility::VISIBLE);
+        } else if (m_newBadge) {
+            m_newBadge->setVisibility(brls::Visibility::GONE);
+        }
     }
 
     // Show star badge if manga is in library (browser/search tabs only)
-    // Also check recent additions cache for immediate update
-    if (m_starBadge) {
+    {
         bool inLib = (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
                      && !Application::getInstance().isRecentlyRemoved(m_manga.id);
         bool showStar = m_showLibraryBadge && inLib;
-        if (showStar && !m_starImageLoaded) {
-            m_starBadge->setImageFromFile("app0:resources/icons/star.png");
-            m_starImageLoaded = true;
+        if (showStar) {
+            auto* star = ensureStarBadge();
+            if (!m_starImageLoaded) {
+                star->setImageFromFile("app0:resources/icons/star.png");
+                m_starImageLoaded = true;
+            }
+            star->setVisibility(brls::Visibility::VISIBLE);
+        } else if (m_starBadge) {
+            m_starBadge->setVisibility(brls::Visibility::GONE);
         }
-        m_starBadge->setVisibility(showStar ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
 }
 
@@ -394,12 +346,13 @@ void MangaItemCell::onFocusGained() {
     // Refresh library badge to reflect add/remove changes from detail view
     refreshLibraryBadge();
     // Show start button hint on focus (but not in browser/search tabs where library badge is shown)
-    if (m_startHintIcon && !m_showLibraryBadge) {
+    if (!m_showLibraryBadge) {
+        auto* hint = ensureStartHintIcon();
         if (!m_startHintImageLoaded) {
-            m_startHintIcon->setImageFromFile("app0:resources/images/start_button.png");
+            hint->setImageFromFile("app0:resources/images/start_button.png");
             m_startHintImageLoaded = true;
         }
-        m_startHintIcon->setVisibility(brls::Visibility::VISIBLE);
+        hint->setVisibility(brls::Visibility::VISIBLE);
     }
 }
 
@@ -446,7 +399,7 @@ void MangaItemCell::updateSelectionVisual() {
 }
 
 void MangaItemCell::updateFocusInfo(bool focused) {
-    if (!m_titleLabel || !m_descriptionLabel) return;
+    if (!m_titleLabel) return;
 
     if (focused) {
         // Show full title
@@ -467,13 +420,16 @@ void MangaItemCell::updateFocusInfo(bool focused) {
             info += statusStr;
         }
         if (!info.empty()) {
-            m_descriptionLabel->setText(info);
-            m_descriptionLabel->setVisibility(brls::Visibility::VISIBLE);
+            auto* desc = ensureDescriptionLabel();
+            desc->setText(info);
+            desc->setVisibility(brls::Visibility::VISIBLE);
         }
     } else {
         // Restore truncated title
         m_titleLabel->setText(m_originalTitle);
-        m_descriptionLabel->setVisibility(brls::Visibility::GONE);
+        if (m_descriptionLabel) {
+            m_descriptionLabel->setVisibility(brls::Visibility::GONE);
+        }
     }
 }
 
@@ -533,36 +489,19 @@ void MangaItemCell::setGridColumns(int columns) {
         m_unreadBadge->setMargins(badgeMargin, 0, 0, badgeMargin);
     }
 
-    // Scale NEW badge font size and position with grid size
+    // Scale NEW badge font size and position with grid size (only if already created)
     if (m_newBadge) {
-        int newFontSize = 8;
-        int newTopPos = 26;
-        if (columns <= 4) {
-            newFontSize = 10;
-            newTopPos = 34;
-        } else if (columns <= 6) {
-            newFontSize = 8;
-            newTopPos = 26;
-        } else {
-            newFontSize = 7;
-            newTopPos = 20;
-        }
+        int newFontSize = (columns <= 4) ? 10 : (columns >= 8) ? 7 : 8;
+        int newTopPos = (columns <= 4) ? 34 : (columns >= 8) ? 20 : 26;
         m_newBadge->setFontSize(newFontSize);
         if (!m_listMode) {
             m_newBadge->setPositionTop(newTopPos);
         }
     }
 
-    // Scale star badge size with grid size
+    // Scale star badge size with grid size (only if already created)
     if (m_starBadge) {
-        int starSize = 16;
-        if (columns <= 4) {
-            starSize = 20;
-        } else if (columns <= 6) {
-            starSize = 16;
-        } else {
-            starSize = 12;
-        }
+        int starSize = (columns <= 4) ? 20 : (columns >= 8) ? 12 : 16;
         m_starBadge->setWidth(starSize);
         m_starBadge->setHeight(starSize);
     }
@@ -586,14 +525,17 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     if (m_showLibraryBadge == show) return;
     m_showLibraryBadge = show;
     // Update star badge visibility (also check recent additions cache)
-    if (m_starBadge) {
-        bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
-                     && !Application::getInstance().isRecentlyRemoved(m_manga.id);
-        if (inLib && !m_starImageLoaded) {
-            m_starBadge->setImageFromFile("app0:resources/icons/star.png");
+    bool inLib = m_showLibraryBadge && (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
+                 && !Application::getInstance().isRecentlyRemoved(m_manga.id);
+    if (inLib) {
+        auto* star = ensureStarBadge();
+        if (!m_starImageLoaded) {
+            star->setImageFromFile("app0:resources/icons/star.png");
             m_starImageLoaded = true;
         }
-        m_starBadge->setVisibility(inLib ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+        star->setVisibility(brls::Visibility::VISIBLE);
+    } else if (m_starBadge) {
+        m_starBadge->setVisibility(brls::Visibility::GONE);
     }
     // Hide start hint icon when in browser/search mode
     if (m_startHintIcon && m_showLibraryBadge) {
@@ -602,19 +544,104 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
 }
 
 void MangaItemCell::refreshLibraryBadge() {
-    if (!m_starBadge || !m_showLibraryBadge) return;
+    if (!m_showLibraryBadge) return;
     bool inLib = (m_manga.inLibrary || Application::getInstance().isRecentlyAdded(m_manga.id))
                  && !Application::getInstance().isRecentlyRemoved(m_manga.id);
-    if (inLib && !m_starImageLoaded) {
-        m_starBadge->setImageFromFile("app0:resources/icons/star.png");
-        m_starImageLoaded = true;
+    if (inLib) {
+        auto* star = ensureStarBadge();
+        if (!m_starImageLoaded) {
+            star->setImageFromFile("app0:resources/icons/star.png");
+            m_starImageLoaded = true;
+        }
+        star->setVisibility(brls::Visibility::VISIBLE);
+    } else if (m_starBadge) {
+        m_starBadge->setVisibility(brls::Visibility::GONE);
     }
-    m_starBadge->setVisibility(inLib ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 }
 
 void MangaItemCell::setListRowSize(int rowSize) {
     // No-op: list mode always auto-adapts row height to title length
     (void)rowSize;
+}
+
+// --- Lazy creation helpers ---
+// These views are only created when first needed, saving ~5 Yoga node insertions
+// per cell during initial grid build on PS Vita's 444MHz CPU.
+
+brls::Label* MangaItemCell::ensureNewBadge() {
+    if (!m_newBadge) {
+        m_newBadge = new brls::Label();
+        m_newBadge->setFontSize(8);
+        m_newBadge->setText("NEW");
+        m_newBadge->setTextColor(nvgRGB(255, 255, 255));
+        m_newBadge->setBackgroundColor(nvgRGBA(231, 76, 60, 255));
+        m_newBadge->setPositionType(brls::PositionType::ABSOLUTE);
+        m_newBadge->setPositionTop(26);
+        m_newBadge->setPositionLeft(0);
+        m_newBadge->setVisibility(brls::Visibility::GONE);
+        this->addView(m_newBadge);
+    }
+    return m_newBadge;
+}
+
+brls::Image* MangaItemCell::ensureStarBadge() {
+    if (!m_starBadge) {
+        m_starBadge = new brls::Image();
+        m_starBadge->setWidth(16);
+        m_starBadge->setHeight(16);
+        m_starBadge->setScalingType(brls::ImageScalingType::FIT);
+        m_starBadge->setPositionType(brls::PositionType::ABSOLUTE);
+        m_starBadge->setPositionTop(6);
+        m_starBadge->setPositionRight(6);
+        m_starBadge->setVisibility(brls::Visibility::GONE);
+        this->addView(m_starBadge);
+    }
+    return m_starBadge;
+}
+
+brls::Image* MangaItemCell::ensureStartHintIcon() {
+    if (!m_startHintIcon) {
+        m_startHintIcon = new brls::Image();
+        m_startHintIcon->setWidth(64);
+        m_startHintIcon->setHeight(16);
+        m_startHintIcon->setScalingType(brls::ImageScalingType::FIT);
+        m_startHintIcon->setPositionType(brls::PositionType::ABSOLUTE);
+        m_startHintIcon->setPositionTop(6);
+        m_startHintIcon->setPositionRight(6);
+        m_startHintIcon->setVisibility(brls::Visibility::GONE);
+        this->addView(m_startHintIcon);
+    }
+    return m_startHintIcon;
+}
+
+brls::Box* MangaItemCell::ensureListInfoBox() {
+    if (!m_listInfoBox) {
+        m_listInfoBox = new brls::Box();
+        m_listInfoBox->setAxis(brls::Axis::COLUMN);
+        m_listInfoBox->setJustifyContent(brls::JustifyContent::CENTER);
+        m_listInfoBox->setAlignItems(brls::AlignItems::FLEX_START);
+        m_listInfoBox->setPadding(8, 16, 8, 16);
+        m_listInfoBox->setGrow(1.0f);
+        m_listInfoBox->setVisibility(brls::Visibility::GONE);
+
+        m_listTitleLabel = new brls::Label();
+        m_listTitleLabel->setFontSize(14);
+        m_listTitleLabel->setTextColor(nvgRGB(255, 255, 255));
+        m_listInfoBox->addView(m_listTitleLabel);
+
+        this->addView(m_listInfoBox);
+    }
+    return m_listInfoBox;
+}
+
+brls::Label* MangaItemCell::ensureDescriptionLabel() {
+    if (!m_descriptionLabel) {
+        m_descriptionLabel = new brls::Label();
+        m_descriptionLabel->setFontSize(9);
+        m_descriptionLabel->setHorizontalAlign(brls::HorizontalAlign::CENTER);
+        m_descriptionLabel->setVisibility(brls::Visibility::GONE);
+    }
+    return m_descriptionLabel;
 }
 
 void MangaItemCell::applyDisplayMode() {
@@ -634,14 +661,11 @@ void MangaItemCell::applyDisplayMode() {
             m_titleOverlay->setVisibility(brls::Visibility::GONE);
         }
 
-        // Show list info box (title label is already added and updated by updateDisplay)
-        if (m_listInfoBox) {
-            m_listInfoBox->setVisibility(brls::Visibility::VISIBLE);
-        }
-
-        // Font size for list mode
+        // Show list info box (lazy-created on first list mode activation)
+        ensureListInfoBox()->setVisibility(brls::Visibility::VISIBLE);
         if (m_listTitleLabel) {
             m_listTitleLabel->setFontSize(14);
+            m_listTitleLabel->setText(m_manga.title);
         }
 
         // Position badges for list mode (left side)

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -645,7 +645,7 @@ void RecyclingGrid::buildNextRowBatch() {
 
 void RecyclingGrid::enableVirtualScroll() {
     if (m_virtualScrollEnabled) return;
-    if (m_rows.size() <= 14) return;  // Not worth it for small grids
+    if (m_rows.size() <= 7) return;  // Not worth it for small grids (<=42 cells at 6 cols)
     if (m_cellHeight <= 0) return;    // Can't compute row positions with variable heights (list mode)
 
     m_virtualScrollEnabled = true;
@@ -676,9 +676,9 @@ void RecyclingGrid::enableVirtualScroll() {
     float scrollY = this->getContentOffsetY();
     float viewH = this->getHeight();
     float rowH = static_cast<float>(m_cellHeight > 0 ? m_cellHeight + m_rowMargin : 200);
-    int firstVisible = std::max(0, static_cast<int>(scrollY / rowH) - 2);
+    int firstVisible = std::max(0, static_cast<int>(scrollY / rowH) - 1);
     int lastVisible = std::min(static_cast<int>(m_rows.size()),
-                                static_cast<int>((scrollY + viewH) / rowH) + 3);
+                                static_cast<int>((scrollY + viewH) / rowH) + 2);
 
     // Set up initial window
     float topHeight = firstVisible * rowH;
@@ -728,9 +728,12 @@ void RecyclingGrid::disableVirtualScroll() {
 void RecyclingGrid::updateRowWindow(int firstVisible, int lastVisible) {
     if (!m_virtualScrollEnabled) return;
 
-    // Add buffer around visible range - use larger buffer to reduce update frequency
-    int windowFirst = std::max(0, firstVisible - 3);
-    int windowLast = std::min(static_cast<int>(m_rows.size()), lastVisible + 4);
+    // Add tight buffer around visible range to minimize attached cells.
+    // On PS Vita, each cell costs ~0.33-0.46ms to draw (texture + nvg overlay),
+    // so reducing from 12 rows (72 cells, ~33ms) to 6 rows (36 cells, ~15ms)
+    // is critical for maintaining 30+ FPS with large libraries.
+    int windowFirst = std::max(0, firstVisible - 1);
+    int windowLast = std::min(static_cast<int>(m_rows.size()), lastVisible + 2);
 
     if (windowFirst == m_windowFirstRow && windowLast == m_windowLastRow) return;
 

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -674,8 +674,29 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     perf.endFrame();   // End previous frame timing
     perf.beginFrame(); // Start this frame timing
 
+    // Visibility culling: hide off-screen rows so ScrollingFrame::draw() skips them.
+    // Without this, ALL rows (including off-screen) get full NanoVG draw calls issued,
+    // wasting ~80% of CPU frame time on path generation for invisible content.
+    // INVISIBLE preserves layout space (scroll height stays correct) but skips draw.
+    if (!m_rows.empty() && m_cellHeight > 0) {
+        float scrollY = this->getContentOffsetY();
+        float viewH = this->getHeight();
+        float rowH = static_cast<float>(m_cellHeight + m_rowMargin);
+        int firstVisible = std::max(0, static_cast<int>(scrollY / rowH) - 1);
+        int lastVisible = std::min(static_cast<int>(m_rows.size()),
+                                    static_cast<int>((scrollY + viewH) / rowH) + 2);
+
+        for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
+            brls::Visibility desired = (i >= firstVisible && i < lastVisible)
+                ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
+            if (m_rows[i]->getVisibility() != desired) {
+                m_rows[i]->setVisibility(desired);
+            }
+        }
+    }
+
     PERF_BEGIN("grid_draw");
-    // Call parent draw first
+    // Call parent draw - now only visible rows are rendered
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -678,6 +678,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     // Without this, ALL rows (including off-screen) get full NanoVG draw calls issued,
     // wasting ~80% of CPU frame time on path generation for invisible content.
     // INVISIBLE preserves layout space (scroll height stays correct) but skips draw.
+    // Optimization: only update rows at the boundaries of the visible range, not all rows.
     if (!m_rows.empty() && m_cellHeight > 0) {
         float scrollY = this->getContentOffsetY();
         float viewH = this->getHeight();
@@ -686,12 +687,40 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         int lastVisible = std::min(static_cast<int>(m_rows.size()),
                                     static_cast<int>((scrollY + viewH) / rowH) + 2);
 
-        for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
-            brls::Visibility desired = (i >= firstVisible && i < lastVisible)
-                ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
-            if (m_rows[i]->getVisibility() != desired) {
-                m_rows[i]->setVisibility(desired);
+        // Only update rows if visible range changed (avoid O(rows) iteration every frame)
+        if (firstVisible != m_cachedFirstVisible || lastVisible != m_cachedLastVisible) {
+            // Hide rows that are now invisible
+            if (m_cachedFirstVisible >= 0) {
+                // Hide rows above the new range
+                for (int i = m_cachedFirstVisible; i < firstVisible; i++) {
+                    if (i >= 0 && i < static_cast<int>(m_rows.size())) {
+                        m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
+                    }
+                }
+                // Hide rows below the new range
+                for (int i = lastVisible; i < m_cachedLastVisible; i++) {
+                    if (i >= 0 && i < static_cast<int>(m_rows.size())) {
+                        m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
+                    }
+                }
+            } else {
+                // First call: set all visibility in one pass
+                for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
+                    brls::Visibility desired = (i >= firstVisible && i < lastVisible)
+                        ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
+                    m_rows[i]->setVisibility(desired);
+                }
             }
+
+            // Show rows that are now visible
+            for (int i = firstVisible; i < lastVisible; i++) {
+                if (i >= 0 && i < static_cast<int>(m_rows.size())) {
+                    m_rows[i]->setVisibility(brls::Visibility::VISIBLE);
+                }
+            }
+
+            m_cachedFirstVisible = firstVisible;
+            m_cachedLastVisible = lastVisible;
         }
     }
 
@@ -754,12 +783,14 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
     }
 
     // Also apply texture recycling for scroll-based movement (same as focus-based)
+    // Only iterate through actual unload ranges, not all cells
     static constexpr int SCROLL_UNLOAD_DISTANCE_ROWS = 8;  // Reduced from 12
     int centerRow = (firstVisibleRow + lastVisibleRow) / 2;
     int unloadAboveRow = centerRow - SCROLL_UNLOAD_DISTANCE_ROWS;
     int unloadBelowRow = centerRow + SCROLL_UNLOAD_DISTANCE_ROWS;
 
     if (unloadAboveRow > 0) {
+        // Only iterate cells in the range [0, unloadAboveRow)
         int unloadEnd = std::min(unloadAboveRow * m_columns, static_cast<int>(m_cells.size()));
         for (int i = 0; i < unloadEnd; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
@@ -768,8 +799,10 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
         }
     }
     if (unloadBelowRow < totalRows) {
+        // Only iterate cells in the range [unloadBelowRow, end)
         int unloadStart = std::max(0, unloadBelowRow * m_columns);
-        for (int i = unloadStart; i < static_cast<int>(m_cells.size()); i++) {
+        int unloadEnd = static_cast<int>(m_cells.size());
+        for (int i = unloadStart; i < unloadEnd; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
                 m_cells[i]->unloadThumbnail();
             }

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -181,7 +181,7 @@ void RecyclingGrid::updateDataOrder(const std::vector<Manga>& items) {
 
     // Update each cell with the new manga data at its position
     // This preserves the grid structure and just updates the displayed content
-    int maxInitialRows = 6;
+    int maxInitialRows = 3;  // Reduced from 6 to prevent FPS drops
     int cellsInInitialRows = maxInitialRows * m_columns;
 
     for (size_t i = 0; i < m_cells.size() && i < items.size(); i++) {
@@ -200,7 +200,7 @@ void RecyclingGrid::updateDataOrder(const std::vector<Manga>& items) {
     }
 
     // Only load thumbnails for a buffer beyond visible rows (not all remaining)
-    int bufferRows = 3;
+    int bufferRows = 2;  // Reduced from 3
     int preloadUpToCell = std::min((maxInitialRows + bufferRows) * m_columns, static_cast<int>(m_cells.size()));
 
     if (static_cast<int>(m_cells.size()) > cellsInInitialRows) {
@@ -387,8 +387,8 @@ void RecyclingGrid::setupGrid() {
         });
     } else {
         // Small library - all rows built, trigger buffer preload
-        int maxInitialRows = 6;
-        int bufferRows = 3;
+        int maxInitialRows = 3;
+        int bufferRows = 2;  // Reduced from 3 to prevent queue flooding
         int preloadUpToRow = std::min(maxInitialRows + bufferRows, m_totalRowsNeeded);
         int startCell = std::min(maxInitialRows * m_columns, (int)m_cells.size());
         int endCell = std::min(preloadUpToRow * m_columns, (int)m_cells.size());
@@ -399,7 +399,7 @@ void RecyclingGrid::setupGrid() {
 }
 
 void RecyclingGrid::createRowRange(int startRow, int endRow) {
-    int maxInitialRows = 6;
+    int maxInitialRows = 3;  // Reduced from 6 - fewer immediate thumbnail loads to prevent FPS drops
 
     for (int row = startRow; row < endRow; row++) {
         auto* rowBox = new brls::Box();
@@ -581,8 +581,8 @@ void RecyclingGrid::buildNextRowBatch() {
     } else {
         // All rows built - trigger thumbnail preloading for buffer rows
         m_incrementalBuildActive = false;
-        int maxInitialRows = 6;
-        int bufferRows = 3;
+        int maxInitialRows = 3;
+        int bufferRows = 2;  // Reduced from 3 to prevent queue flooding
         int preloadUpToRow = std::min(maxInitialRows + bufferRows, m_totalRowsNeeded);
         int startCell = std::min(maxInitialRows * m_columns, (int)m_cells.size());
         int endCell = std::min(preloadUpToRow * m_columns, (int)m_cells.size());
@@ -600,9 +600,10 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     int focusedRow = index / m_columns;
     int totalRows = (static_cast<int>(m_cells.size()) + m_columns - 1) / m_columns;
 
-    // Load thumbnails for rows around the focused cell: 2 rows above, 6 rows below
-    int loadFromRow = std::max(0, focusedRow - 2);
-    int loadToRow = std::min(totalRows, focusedRow + 7);  // 6 rows below (visible area + buffer)
+    // Load thumbnails for rows around the focused cell: 1 row above, 3 rows below
+    // Reduced from 2+6 to 1+3 to prevent queue flooding that causes FPS drops
+    int loadFromRow = std::max(0, focusedRow - 1);
+    int loadToRow = std::min(totalRows, focusedRow + 4);
 
     int startCell = loadFromRow * m_columns;
     int endCell = std::min(loadToRow * m_columns, static_cast<int>(m_cells.size()));
@@ -620,7 +621,7 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     // On PS Vita with 128MB RAM, keeping 100+ cover textures loaded wastes VRAM.
     // Unload cells more than 12 rows away from focus - they'll reload from
     // ImageLoader's LRU memory cache when scrolled back (fast, no network hit).
-    static constexpr int UNLOAD_DISTANCE_ROWS = 12;
+    static constexpr int UNLOAD_DISTANCE_ROWS = 8;  // Reduced from 12 to free GPU memory faster
     int unloadAboveRow = focusedRow - UNLOAD_DISTANCE_ROWS;
     int unloadBelowRow = focusedRow + UNLOAD_DISTANCE_ROWS;
 
@@ -670,18 +671,23 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     // Call parent draw first
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
 
-    // Check scroll position for thumbnail loading during touch scrolling
+    // Check scroll position for thumbnail loading during touch scrolling.
     // The focus-based loading (loadThumbnailsNearIndex) handles D-pad navigation,
     // but during touch scrolling the focus index doesn't change.
-    // Check every ~half row height of scroll movement to avoid excessive work.
-    if (!m_cells.empty() && m_columns > 0) {
+    // Throttled: require full row of scroll AND 10-frame cooldown to prevent
+    // queue flooding that causes FPS drops to <10 on PS Vita.
+    if (m_scrollLoadCooldown > 0) {
+        m_scrollLoadCooldown--;
+    }
+    if (!m_cells.empty() && m_columns > 0 && m_scrollLoadCooldown == 0) {
         float scrollY = this->getContentOffsetY();
         float scrollDelta = std::abs(scrollY - m_lastScrollLoadY);
         float rowHeight = static_cast<float>(m_cellHeight + m_rowMargin);
 
-        // Trigger when scrolled more than half a row since last load
-        if (scrollDelta > rowHeight * 0.5f) {
+        // Trigger when scrolled more than a full row since last load (was 0.5 row)
+        if (scrollDelta > rowHeight * 1.5f) {
             m_lastScrollLoadY = scrollY;
+            m_scrollLoadCooldown = 10;  // Wait 10 frames before next load trigger
             loadThumbnailsForScrollPosition();
         }
     }
@@ -699,9 +705,10 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
     int firstVisibleRow = std::max(0, static_cast<int>(scrollY / rowHeight));
     int lastVisibleRow = std::min(totalRows, static_cast<int>((scrollY + viewHeight) / rowHeight) + 1);
 
-    // Load 2 rows above and 3 rows below the visible area as buffer
-    int loadFromRow = std::max(0, firstVisibleRow - 2);
-    int loadToRow = std::min(totalRows, lastVisibleRow + 3);
+    // Load 1 row above and 2 rows below the visible area as buffer
+    // Reduced from 2+3 to 1+2 to prevent queue flooding during fast scrolling
+    int loadFromRow = std::max(0, firstVisibleRow - 1);
+    int loadToRow = std::min(totalRows, lastVisibleRow + 2);
 
     int startCell = loadFromRow * m_columns;
     int endCell = std::min(loadToRow * m_columns, static_cast<int>(m_cells.size()));
@@ -713,7 +720,7 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
     }
 
     // Also apply texture recycling for scroll-based movement (same as focus-based)
-    static constexpr int SCROLL_UNLOAD_DISTANCE_ROWS = 12;
+    static constexpr int SCROLL_UNLOAD_DISTANCE_ROWS = 8;  // Reduced from 12
     int centerRow = (firstVisibleRow + lastVisibleRow) / 2;
     int unloadAboveRow = centerRow - SCROLL_UNLOAD_DISTANCE_ROWS;
     int unloadBelowRow = centerRow + SCROLL_UNLOAD_DISTANCE_ROWS;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -6,6 +6,8 @@
 #include "view/recycling_grid.hpp"
 #include "view/media_item_cell.hpp"
 #include "view/long_press_gesture.hpp"
+#include "utils/perf_overlay.hpp"
+#include "app/application.hpp"
 #include <cmath>
 
 namespace vitasuwayomi {
@@ -668,8 +670,14 @@ void RecyclingGrid::resetThumbnailLoadStates() {
 }
 
 void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) {
+    auto& perf = PerfOverlay::getInstance();
+    perf.endFrame();   // End previous frame timing
+    perf.beginFrame(); // Start this frame timing
+
+    PERF_BEGIN("grid_draw");
     // Call parent draw first
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
+    PERF_END("grid_draw");
 
     // Check scroll position for thumbnail loading during touch scrolling.
     // The focus-based loading (loadThumbnailsNearIndex) handles D-pad navigation,
@@ -691,6 +699,11 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             loadThumbnailsForScrollPosition();
         }
     }
+
+    // Draw performance overlay on top (uses screen coordinates, ignores scroll)
+    // Reset scissor so overlay draws over everything
+    nvgResetScissor(vg);
+    perf.draw(vg, 960.0f, 544.0f);
 }
 
 void RecyclingGrid::loadThumbnailsForScrollPosition() {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -79,6 +79,29 @@ RecyclingGrid::~RecyclingGrid() {
         *m_alive = false;
     }
     m_incrementalBuildActive = false;
+
+    // If virtual scroll is active, some rows are detached from m_contentBox
+    // and won't be cleaned up by its destructor. We need to delete them manually.
+    if (m_virtualScrollEnabled) {
+        // First detach everything from m_contentBox (without deleting)
+        auto& children = m_contentBox->getChildren();
+        while (!children.empty()) {
+            m_contentBox->removeView(children.back(), false);
+        }
+        // Now delete ALL rows manually (both windowed and detached)
+        for (auto* row : m_rows) {
+            delete row;
+        }
+        m_rows.clear();
+        m_cells.clear();  // Cells were children of rows, already deleted
+        m_virtualScrollEnabled = false;
+    }
+    // Delete spacers - they may or may not be attached to contentBox
+    // We already detached everything above if virtual scroll was active
+    delete m_topSpacer;
+    m_topSpacer = nullptr;
+    delete m_bottomSpacer;
+    m_bottomSpacer = nullptr;
 }
 
 void RecyclingGrid::setDataSource(const std::vector<Manga>& items) {
@@ -94,6 +117,22 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
     // Cancel any ongoing incremental build before appending
     m_incrementalBuildActive = false;
 
+    // Temporarily disable virtual scroll so rows can be manipulated directly
+    bool wasVirtual = m_virtualScrollEnabled;
+    if (wasVirtual) {
+        // Detach spacers and windowed rows, then re-add all rows to m_contentBox
+        auto& children = m_contentBox->getChildren();
+        while (!children.empty()) {
+            m_contentBox->removeView(children.back(), false);
+        }
+        for (auto* row : m_rows) {
+            m_contentBox->addView(row);
+        }
+        m_virtualScrollEnabled = false;
+        m_windowFirstRow = -1;
+        m_windowLastRow = -1;
+    }
+
     int oldCellCount = static_cast<int>(m_cells.size());
     int oldRowCount = static_cast<int>(m_rows.size());
 
@@ -108,20 +147,13 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
     m_totalRowsNeeded = newTotalRows;
 
     // If the last existing row was partial, remove and rebuild it with new items
-    // Use m_cells.size() (not m_items.size()) to compute the actual number of cells
-    // in the last row, since incremental build may not have created all rows yet.
     int startRow;
     if (oldCellCount > 0 && oldRowCount > 0) {
         int cellsInLastRow = oldCellCount - (oldRowCount - 1) * m_columns;
 
-        // Sanity check: cellsInLastRow must be valid
         if (cellsInLastRow <= 0 || cellsInLastRow > m_columns) {
-            // State is inconsistent - fall back to full rebuild from existing rows
             startRow = oldRowCount;
         } else if (cellsInLastRow < m_columns) {
-            // Partial last row - remove and rebuild it with new items
-
-            // Move focus away if it's on a cell in the partial row being removed
             int partialStart = oldCellCount - cellsInLastRow;
             for (int i = partialStart; i < oldCellCount; i++) {
                 if (m_cells[i] && m_cells[i]->isFocused()) {
@@ -130,19 +162,16 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
                 }
             }
 
-            // Remove cell pointers for the partial row (view memory freed by removeView)
             for (int i = 0; i < cellsInLastRow; i++) {
                 m_cells.pop_back();
             }
 
-            // Remove last row view (deletes the row box and its children)
             brls::Box* lastRow = m_rows.back();
             m_rows.pop_back();
             m_contentBox->removeView(lastRow);
 
             startRow = oldRowCount - 1;
         } else {
-            // Last row is full, just append new rows
             startRow = oldRowCount;
         }
     } else {
@@ -151,6 +180,9 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
 
     // Create only the new rows
     createRowRange(startRow, newTotalRows);
+
+    // Re-enable virtual scroll if it was active (or if grid is now large enough)
+    enableVirtualScroll();
 
     brls::Logger::info("RecyclingGrid: appendItems - added {} items, now {} total ({} rows)",
                         newItems.size(), m_items.size(), newTotalRows);
@@ -320,6 +352,9 @@ void RecyclingGrid::setOnSelectionChanged(std::function<void(int count)> callbac
 void RecyclingGrid::clearViews() {
     m_incrementalBuildActive = false;  // Cancel any pending incremental build
 
+    // Disable virtual scroll - re-adds all rows to m_contentBox and deletes spacers
+    disableVirtualScroll();
+
     // Move focus away from cells before deleting them (same reason as setupGrid)
     for (auto* cell : m_cells) {
         if (cell && cell->isFocused()) {
@@ -345,6 +380,13 @@ void RecyclingGrid::setupGrid() {
 
     // Reset scroll-based loading state
     m_lastScrollLoadY = 0.0f;
+
+    // Disable virtual scroll before clearing - detaches rows without deleting
+    disableVirtualScroll();
+
+    // Reset cached visible range
+    m_cachedFirstVisible = -1;
+    m_cachedLastVisible = -1;
 
     // CRITICAL: Move focus away from cells before deleting them.
     // clearViews() will destroy all cells, but brls may still hold
@@ -594,7 +636,138 @@ void RecyclingGrid::buildNextRowBatch() {
         }
         brls::Logger::info("RecyclingGrid: Incremental build complete - {} cells in {} rows",
                             m_cells.size(), m_totalRowsNeeded);
+
+        // Enable virtual scroll windowing for large grids
+        // This reduces m_contentBox children from 76+ to ~12, cutting draw overhead
+        enableVirtualScroll();
     }
+}
+
+void RecyclingGrid::enableVirtualScroll() {
+    if (m_virtualScrollEnabled) return;
+    if (m_rows.size() <= 14) return;  // Not worth it for small grids
+    if (m_cellHeight <= 0) return;    // Can't compute row positions with variable heights (list mode)
+
+    m_virtualScrollEnabled = true;
+    m_windowFirstRow = -1;
+    m_windowLastRow = -1;
+
+    // Create spacers if needed - these take up vertical space to maintain scroll height
+    if (!m_topSpacer) {
+        m_topSpacer = new brls::Box();
+        m_topSpacer->setGrow(0);
+        m_topSpacer->setShrink(0);
+    }
+    if (!m_bottomSpacer) {
+        m_bottomSpacer = new brls::Box();
+        m_bottomSpacer->setGrow(0);
+        m_bottomSpacer->setShrink(0);
+    }
+
+    // Detach all rows from m_contentBox (without deleting them)
+    // Remove in reverse order to avoid index shifting
+    auto& children = m_contentBox->getChildren();
+    while (!children.empty()) {
+        m_contentBox->removeView(children.back(), false);
+    }
+
+    // Add spacers + initial visible rows
+    // Default to showing first rows
+    float scrollY = this->getContentOffsetY();
+    float viewH = this->getHeight();
+    float rowH = static_cast<float>(m_cellHeight > 0 ? m_cellHeight + m_rowMargin : 200);
+    int firstVisible = std::max(0, static_cast<int>(scrollY / rowH) - 2);
+    int lastVisible = std::min(static_cast<int>(m_rows.size()),
+                                static_cast<int>((scrollY + viewH) / rowH) + 3);
+
+    // Set up initial window
+    float topHeight = firstVisible * rowH;
+    m_topSpacer->setHeight(topHeight > 0 ? topHeight : 0);
+    m_contentBox->addView(m_topSpacer);
+
+    for (int i = firstVisible; i < lastVisible; i++) {
+        m_contentBox->addView(m_rows[i]);
+    }
+
+    int remainingRows = static_cast<int>(m_rows.size()) - lastVisible;
+    m_bottomSpacer->setHeight(remainingRows > 0 ? remainingRows * rowH : 0);
+    m_contentBox->addView(m_bottomSpacer);
+
+    m_windowFirstRow = firstVisible;
+    m_windowLastRow = lastVisible;
+
+    brls::Logger::info("RecyclingGrid: Virtual scroll enabled - {} total rows, window [{}, {})",
+                       m_rows.size(), firstVisible, lastVisible);
+}
+
+void RecyclingGrid::disableVirtualScroll() {
+    if (!m_virtualScrollEnabled) return;
+    m_virtualScrollEnabled = false;
+
+    // Detach spacers and windowed rows without deleting
+    auto& children = m_contentBox->getChildren();
+    while (!children.empty()) {
+        m_contentBox->removeView(children.back(), false);
+    }
+
+    // Re-add ALL rows to m_contentBox so clearViews() can properly delete them
+    for (auto* row : m_rows) {
+        m_contentBox->addView(row);
+    }
+
+    // Delete spacers since they're no longer needed
+    delete m_topSpacer;
+    m_topSpacer = nullptr;
+    delete m_bottomSpacer;
+    m_bottomSpacer = nullptr;
+
+    m_windowFirstRow = -1;
+    m_windowLastRow = -1;
+}
+
+void RecyclingGrid::updateRowWindow(int firstVisible, int lastVisible) {
+    if (!m_virtualScrollEnabled) return;
+
+    // Add buffer around visible range - use larger buffer to reduce update frequency
+    int windowFirst = std::max(0, firstVisible - 3);
+    int windowLast = std::min(static_cast<int>(m_rows.size()), lastVisible + 4);
+
+    if (windowFirst == m_windowFirstRow && windowLast == m_windowLastRow) return;
+
+    // Hysteresis: only update if visible rows are near the window edge
+    // This prevents rebuilding the content box on every single row of scrolling
+    if (m_windowFirstRow >= 0) {
+        bool needsUpdate = (firstVisible <= m_windowFirstRow + 1) ||
+                           (lastVisible >= m_windowLastRow - 1);
+        if (!needsUpdate) return;
+    }
+
+    float rowH = static_cast<float>(m_cellHeight + m_rowMargin);
+
+    // Rebuild the content box with new window
+    // Detach all current children without deleting
+    auto& children = m_contentBox->getChildren();
+    while (!children.empty()) {
+        m_contentBox->removeView(children.back(), false);
+    }
+
+    // Top spacer
+    float topHeight = windowFirst * rowH;
+    m_topSpacer->setHeight(topHeight > 0 ? topHeight : 0);
+    m_contentBox->addView(m_topSpacer);
+
+    // Visible rows
+    for (int i = windowFirst; i < windowLast; i++) {
+        m_contentBox->addView(m_rows[i]);
+    }
+
+    // Bottom spacer
+    int remainingRows = static_cast<int>(m_rows.size()) - windowLast;
+    m_bottomSpacer->setHeight(remainingRows > 0 ? remainingRows * rowH : 0);
+    m_contentBox->addView(m_bottomSpacer);
+
+    m_windowFirstRow = windowFirst;
+    m_windowLastRow = windowLast;
 }
 
 void RecyclingGrid::loadThumbnailsNearIndex(int index) {
@@ -675,11 +848,9 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     perf.endFrame();   // End previous frame timing
     perf.beginFrame(); // Start this frame timing
 
-    // Visibility culling: hide off-screen rows so ScrollingFrame::draw() skips them.
-    // Without this, ALL rows (including off-screen) get full NanoVG draw calls issued,
-    // wasting ~80% of CPU frame time on path generation for invisible content.
-    // INVISIBLE preserves layout space (scroll height stays correct) but skips draw.
-    // Optimization: only update rows at the boundaries of the visible range, not all rows.
+    // Virtual row windowing: only keep ~12 rows attached to m_contentBox.
+    // This eliminates the O(totalRows) child iteration in borealis draw loop
+    // that was causing 10-15ms overhead with 76+ rows (453 items).
     if (!m_rows.empty() && m_cellHeight > 0) {
         float scrollY = this->getContentOffsetY();
         float viewH = this->getHeight();
@@ -688,40 +859,35 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         int lastVisible = std::min(static_cast<int>(m_rows.size()),
                                     static_cast<int>((scrollY + viewH) / rowH) + 2);
 
-        // Only update rows if visible range changed (avoid O(rows) iteration every frame)
-        if (firstVisible != m_cachedFirstVisible || lastVisible != m_cachedLastVisible) {
-            // Hide rows that are now invisible
-            if (m_cachedFirstVisible >= 0) {
-                // Hide rows above the new range
-                for (int i = m_cachedFirstVisible; i < firstVisible; i++) {
-                    if (i >= 0 && i < static_cast<int>(m_rows.size())) {
-                        m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
+        if (m_virtualScrollEnabled) {
+            // Update the row window (only detach/attach rows when range changes)
+            updateRowWindow(firstVisible, lastVisible);
+        } else {
+            // Fallback: visibility-based culling for small grids or during incremental build
+            if (firstVisible != m_cachedFirstVisible || lastVisible != m_cachedLastVisible) {
+                if (m_cachedFirstVisible >= 0) {
+                    for (int i = m_cachedFirstVisible; i < firstVisible; i++) {
+                        if (i >= 0 && i < static_cast<int>(m_rows.size()))
+                            m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
+                    }
+                    for (int i = lastVisible; i < m_cachedLastVisible; i++) {
+                        if (i >= 0 && i < static_cast<int>(m_rows.size()))
+                            m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
+                    }
+                } else {
+                    for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
+                        brls::Visibility desired = (i >= firstVisible && i < lastVisible)
+                            ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
+                        m_rows[i]->setVisibility(desired);
                     }
                 }
-                // Hide rows below the new range
-                for (int i = lastVisible; i < m_cachedLastVisible; i++) {
-                    if (i >= 0 && i < static_cast<int>(m_rows.size())) {
-                        m_rows[i]->setVisibility(brls::Visibility::INVISIBLE);
-                    }
+                for (int i = firstVisible; i < lastVisible; i++) {
+                    if (i >= 0 && i < static_cast<int>(m_rows.size()))
+                        m_rows[i]->setVisibility(brls::Visibility::VISIBLE);
                 }
-            } else {
-                // First call: set all visibility in one pass
-                for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
-                    brls::Visibility desired = (i >= firstVisible && i < lastVisible)
-                        ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
-                    m_rows[i]->setVisibility(desired);
-                }
+                m_cachedFirstVisible = firstVisible;
+                m_cachedLastVisible = lastVisible;
             }
-
-            // Show rows that are now visible
-            for (int i = firstVisible; i < lastVisible; i++) {
-                if (i >= 0 && i < static_cast<int>(m_rows.size())) {
-                    m_rows[i]->setVisibility(brls::Visibility::VISIBLE);
-                }
-            }
-
-            m_cachedFirstVisible = firstVisible;
-            m_cachedLastVisible = lastVisible;
         }
     }
 
@@ -989,6 +1155,19 @@ brls::View* RecyclingGrid::getFirstCell() const {
 
 void RecyclingGrid::focusIndex(int index) {
     if (index >= 0 && index < static_cast<int>(m_cells.size())) {
+        // Ensure the target cell's row is in the window before focusing
+        if (m_virtualScrollEnabled && m_columns > 0) {
+            int targetRow = index / m_columns;
+            if (targetRow < m_windowFirstRow || targetRow >= m_windowLastRow) {
+                // Force window update to include the target row
+                float rowH = static_cast<float>(m_cellHeight + m_rowMargin);
+                int first = std::max(0, targetRow - 1);
+                int last = std::min(static_cast<int>(m_rows.size()), targetRow + 3);
+                // Temporarily widen check by setting m_windowFirstRow to force update
+                m_windowFirstRow = -1;
+                updateRowWindow(first, last);
+            }
+        }
         brls::Application::giveFocus(m_cells[index]);
         m_focusedIndex = index;
         m_pendingFocusIndex = -1;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -582,9 +582,10 @@ void RecyclingGrid::buildNextRowBatch() {
         });
     } else {
         // All rows built - trigger thumbnail preloading for buffer rows
+        // Load visible rows (0-2) + 1 buffer row = 18 cells max, prevents queue buildup
         m_incrementalBuildActive = false;
         int maxInitialRows = 3;
-        int bufferRows = 2;  // Reduced from 3 to prevent queue flooding
+        int bufferRows = 1;  // Reduced from 2: only preload next row to avoid queue flooding
         int preloadUpToRow = std::min(maxInitialRows + bufferRows, m_totalRowsNeeded);
         int startCell = std::min(maxInitialRows * m_columns, (int)m_cells.size());
         int endCell = std::min(preloadUpToRow * m_columns, (int)m_cells.size());
@@ -602,10 +603,10 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     int focusedRow = index / m_columns;
     int totalRows = (static_cast<int>(m_cells.size()) + m_columns - 1) / m_columns;
 
-    // Load thumbnails for rows around the focused cell: 1 row above, 3 rows below
-    // Reduced from 2+6 to 1+3 to prevent queue flooding that causes FPS drops
+    // Load thumbnails for rows around the focused cell: 1 row above, 2 rows below
+    // Reduced from 1+3 to 1+2 to prevent queue flooding: ~18 cells instead of 30
     int loadFromRow = std::max(0, focusedRow - 1);
-    int loadToRow = std::min(totalRows, focusedRow + 4);
+    int loadToRow = std::min(totalRows, focusedRow + 3);
 
     int startCell = loadFromRow * m_columns;
     int endCell = std::min(loadToRow * m_columns, static_cast<int>(m_cells.size()));

--- a/src/view/rotatable_image.cpp
+++ b/src/view/rotatable_image.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "view/rotatable_image.hpp"
+#include "utils/perf_overlay.hpp"
 #include <cmath>
 
 #ifndef NVG_PI
@@ -191,6 +192,13 @@ void RotatableImage::calculateImageBounds(float viewX, float viewY, float viewW,
 
 void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float height,
                           brls::Style style, brls::FrameContext* ctx) {
+    if (m_perfPrimary) {
+        auto& perf = PerfOverlay::getInstance();
+        perf.endFrame();
+        perf.beginFrame();
+    }
+    PERF_BEGIN("reader_draw");
+
     nvgSave(vg);
 
     bool hasSlide = (m_slideX != 0.0f || m_slideY != 0.0f);
@@ -355,6 +363,14 @@ void RotatableImage::draw(NVGcontext* vg, float x, float y, float width, float h
 
     // Restore state (removes scissor, slide offset, rotation transforms)
     nvgRestore(vg);
+
+    PERF_END("reader_draw");
+
+    // Draw perf overlay on top if this is the primary reader image
+    if (m_perfPrimary) {
+        nvgResetScissor(vg);
+        PerfOverlay::getInstance().draw(vg, 960.0f, 544.0f);
+    }
 }
 
 void RotatableImage::setRotation(float degrees) {

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -10,6 +10,7 @@
 #include "utils/library_cache.hpp"
 #include "utils/async.hpp"
 #include "utils/http_client.hpp"
+#include "utils/perf_overlay.hpp"
 #include <algorithm>
 #include <chrono>
 #include <ctime>
@@ -573,6 +574,16 @@ void SettingsTab::createUISection() {
         brls::Application::notify(value ? "Debug logging enabled" : "Debug logging disabled");
     });
     m_contentBox->addView(m_debugLogToggle);
+
+    // Performance overlay toggle - shows FPS, frame time, texture upload stats
+    auto* perfToggle = new brls::BooleanCell();
+    perfToggle->init("Performance Overlay", settings.showPerfOverlay, [](bool value) {
+        Application::getInstance().getSettings().showPerfOverlay = value;
+        PerfOverlay::getInstance().setEnabled(value);
+        Application::getInstance().saveSettings();
+        brls::Application::notify(value ? "Perf overlay enabled" : "Perf overlay disabled");
+    });
+    m_contentBox->addView(perfToggle);
 }
 
 void SettingsTab::createLibrarySection() {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -6,6 +6,7 @@
 #include "view/webtoon_scroll_view.hpp"
 #include "app/application.hpp"
 #include "utils/image_loader.hpp"
+#include "utils/perf_overlay.hpp"
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -1442,6 +1443,11 @@ void WebtoonScrollView::updateCurrentPage() {
 
 void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, float height,
                               brls::Style style, brls::FrameContext* ctx) {
+    auto& perf = PerfOverlay::getInstance();
+    perf.endFrame();
+    perf.beginFrame();
+    PERF_BEGIN("webtoon_draw");
+
     // Update view dimensions
     m_viewWidth = width;
     m_viewHeight = height;
@@ -1575,6 +1581,12 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
 
     // Restore state
     nvgRestore(vg);
+
+    PERF_END("webtoon_draw");
+
+    // Draw perf overlay on top
+    nvgResetScissor(vg);
+    PerfOverlay::getInstance().draw(vg, 960.0f, 544.0f);
 
     // Call onFrame for momentum updates
     onFrame();


### PR DESCRIPTION
Continues the grid-FPS work (culling, lazy sub-views, flattened NanoVG rendering, cached text) and adds virtual row windowing to remove O(n) draw overhead for large libraries (88+ items).

---
_Generated by [Claude Code](https://claude.ai/code)_