### PR TITLE
Fix grid title overlay relayout causing FPS drops

### DIFF
--- a/include/view/media_item_cell.hpp
+++ b/include/view/media_item_cell.hpp
@@ -111,6 +111,7 @@ private:
     std::string m_cachedLine2;        // Pre-split title line 2
     float m_cachedLineHeight = 0;     // Font line height for multi-line spacing
     float m_cachedTitleBlockH = 0;    // Total height of rendered title text
+    float m_cachedSubtitleLineH = 0;  // Subtitle line height
     float m_cachedBadgeTextW = 0;     // Badge text width
     float m_cachedBadgeTextH = 0;     // Badge text height
 

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -12,6 +12,7 @@
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "utils/image_loader.hpp"
+#include <cmath>
 #include <ctime>
 #include <fstream>
 
@@ -323,7 +324,10 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
         float textW = width - m_overlayPadSide * 2.0f;
 
         // Recompute cached text layout when text/font/width changes (not every frame)
-        if (m_overlayDirty || m_cachedCellWidth != width) {
+        // Avoid re-layout on tiny float jitter from layout/animation.
+        // On Vita this check previously retriggered expensive nvgTextBounds work
+        // almost every frame in GRID_NORMAL mode, causing major FPS drops.
+        if (m_overlayDirty || std::fabs(m_cachedCellWidth - width) > 0.5f) {
             m_cachedCellWidth = width;
 
             nvgFontFace(vg, "regular");
@@ -392,10 +396,6 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
         float overlayH = m_overlayMaxHeight;
         float overlayY = y + height - overlayH;
 
-        // Clip to overlay area
-        nvgSave(vg);
-        nvgIntersectScissor(vg, x, overlayY, width, overlayH);
-
         // Semi-transparent background
         nvgBeginPath(vg);
         nvgRect(vg, x, overlayY, width, overlayH);
@@ -426,7 +426,6 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
             nvgText(vg, textX, titleBottom + 1.0f, m_subtitleText.c_str(), nullptr);
         }
 
-        nvgRestore(vg);
     }
 
     // --- Flat-rendered unread badge (uses cached dimensions) ---

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -334,8 +334,9 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
             nvgFontSize(vg, static_cast<float>(m_titleFontSize));
             nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
 
-            // Measure line height from font metrics
+            // Measure line heights from font metrics
             nvgTextMetrics(vg, nullptr, nullptr, &m_cachedLineHeight);
+            m_cachedSubtitleLineH = 0.0f;
 
             // Pre-split title into lines by measuring word-by-word
             m_cachedLine1.clear();
@@ -390,10 +391,20 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
                 m_cachedBadgeTextH = bb[3] - bb[1];
             }
 
+            // Cache subtitle line height for dynamic overlay background height
+            if (!m_subtitleText.empty()) {
+                nvgFontSize(vg, static_cast<float>(m_subtitleFontSize));
+                nvgTextMetrics(vg, nullptr, nullptr, &m_cachedSubtitleLineH);
+            }
+
             m_overlayDirty = false;
         }
 
-        float overlayH = m_overlayMaxHeight;
+        float overlayContentH = m_overlayPadTop + m_cachedTitleBlockH + m_overlayPadBottom;
+        if (!m_subtitleText.empty() && m_cachedSubtitleLineH > 0.0f) {
+            overlayContentH += 1.0f + m_cachedSubtitleLineH;
+        }
+        float overlayH = std::min(m_overlayMaxHeight, overlayContentH);
         float overlayY = y + height - overlayH;
 
         // Semi-transparent background

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -614,9 +614,11 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     // loadThumbnailIfNeeded() checks m_thumbnailLoaded internally,
     // so calling it on already-loaded cells is a no-op (just a bool check).
     // This avoids gaps when the user jumps to a distant row.
-    for (int i = startCell; i < endCell; i++) {
+    int loadBudget = 18;
+    for (int i = startCell; i < endCell && loadBudget > 0; i++) {
         if (m_cells[i]) {
             m_cells[i]->loadThumbnailIfNeeded();
+            loadBudget--;
         }
     }
 
@@ -629,11 +631,16 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     int unloadBelowRow = focusedRow + UNLOAD_DISTANCE_ROWS;
 
     // Unload cells far above
+    constexpr int UNLOAD_BUDGET_PER_CALL = 24;
+    int unloadBudgetAbove = UNLOAD_BUDGET_PER_CALL / 2;
+    int unloadBudgetBelow = UNLOAD_BUDGET_PER_CALL - unloadBudgetAbove;
+
     if (unloadAboveRow > 0) {
         int unloadEnd = std::min(unloadAboveRow * m_columns, static_cast<int>(m_cells.size()));
-        for (int i = 0; i < unloadEnd; i++) {
+        for (int i = 0; i < unloadEnd && unloadBudgetAbove > 0; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
                 m_cells[i]->unloadThumbnail();
+                unloadBudgetAbove--;
             }
         }
     }
@@ -641,9 +648,10 @@ void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     // Unload cells far below
     if (unloadBelowRow < totalRows) {
         int unloadStart = std::max(0, unloadBelowRow * m_columns);
-        for (int i = unloadStart; i < static_cast<int>(m_cells.size()); i++) {
+        for (int i = unloadStart; i < static_cast<int>(m_cells.size()) && unloadBudgetBelow > 0; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
                 m_cells[i]->unloadThumbnail();
+                unloadBudgetBelow--;
             }
         }
     }
@@ -777,9 +785,11 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
     int startCell = loadFromRow * m_columns;
     int endCell = std::min(loadToRow * m_columns, static_cast<int>(m_cells.size()));
 
-    for (int i = startCell; i < endCell; i++) {
+    int loadBudget = 18;
+    for (int i = startCell; i < endCell && loadBudget > 0; i++) {
         if (m_cells[i]) {
             m_cells[i]->loadThumbnailIfNeeded();
+            loadBudget--;
         }
     }
 
@@ -790,12 +800,17 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
     int unloadAboveRow = centerRow - SCROLL_UNLOAD_DISTANCE_ROWS;
     int unloadBelowRow = centerRow + SCROLL_UNLOAD_DISTANCE_ROWS;
 
+    constexpr int UNLOAD_BUDGET_PER_CALL = 24;
+    int unloadBudgetAbove = UNLOAD_BUDGET_PER_CALL / 2;
+    int unloadBudgetBelow = UNLOAD_BUDGET_PER_CALL - unloadBudgetAbove;
+
     if (unloadAboveRow > 0) {
         // Only iterate cells in the range [0, unloadAboveRow)
         int unloadEnd = std::min(unloadAboveRow * m_columns, static_cast<int>(m_cells.size()));
-        for (int i = 0; i < unloadEnd; i++) {
+        for (int i = 0; i < unloadEnd && unloadBudgetAbove > 0; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
                 m_cells[i]->unloadThumbnail();
+                unloadBudgetAbove--;
             }
         }
     }
@@ -803,9 +818,10 @@ void RecyclingGrid::loadThumbnailsForScrollPosition() {
         // Only iterate cells in the range [unloadBelowRow, end)
         int unloadStart = std::max(0, unloadBelowRow * m_columns);
         int unloadEnd = static_cast<int>(m_cells.size());
-        for (int i = unloadStart; i < unloadEnd; i++) {
+        for (int i = unloadStart; i < unloadEnd && unloadBudgetBelow > 0; i++) {
             if (m_cells[i] && m_cells[i]->isThumbnailLoaded()) {
                 m_cells[i]->unloadThumbnail();
+                unloadBudgetBelow--;
             }
         }
     }


### PR DESCRIPTION
Fixes grid FPS drops caused by title-overlay relayout and reduces grid-overlay and scroll thumbnail churn.

---
_Generated by [Claude Code](https://claude.ai/code)_