### PR TITLE
Build libromfs-generator before Android CMake fallback

### DIFF
--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -319,24 +319,37 @@ jobs:
       - name: Build Android APK (switchfin-style)
         if: ${{ hashFiles('app/platform/android/gradlew') != '' }}
         run: |
-          if [ -f lib/borealis/build_libromfs_generator.sh ]; then
-            (cd lib/borealis && bash build_libromfs_generator.sh)
-          elif [ -f library/borealis/build_libromfs_generator.sh ]; then
-            (cd library/borealis && bash build_libromfs_generator.sh)
+          if [ -d lib/borealis/library/lib/extern/libromfs/generator ]; then
+            GEN_SRC="lib/borealis/library/lib/extern/libromfs/generator"
+          elif [ -d library/borealis/library/lib/extern/libromfs/generator ]; then
+            GEN_SRC="library/borealis/library/lib/extern/libromfs/generator"
+          else
+            echo "Could not find libromfs generator source directory"
+            exit 1
           fi
+          cmake -S "$GEN_SRC" -B /tmp/libromfs-generator -G Ninja
+          cmake --build /tmp/libromfs-generator
+          sudo install -m 0755 /tmp/libromfs-generator/libromfs-generator /usr/local/bin/libromfs-generator
+          [ -d lib/borealis ] && install -m 0755 /tmp/libromfs-generator/libromfs-generator lib/borealis/libromfs-generator || true
+          [ -d library/borealis ] && install -m 0755 /tmp/libromfs-generator/libromfs-generator library/borealis/libromfs-generator || true
           cd app/platform/android && ./gradlew assembleRelease
 
       - name: Prepare libromfs-generator (fallback CMake)
         if: ${{ hashFiles('app/platform/android/gradlew') == '' }}
         run: |
-          if [ -f lib/borealis/build_libromfs_generator.sh ]; then
-            (cd lib/borealis && bash build_libromfs_generator.sh)
-          elif [ -f library/borealis/build_libromfs_generator.sh ]; then
-            (cd library/borealis && bash build_libromfs_generator.sh)
+          if [ -d lib/borealis/library/lib/extern/libromfs/generator ]; then
+            GEN_SRC="lib/borealis/library/lib/extern/libromfs/generator"
+          elif [ -d library/borealis/library/lib/extern/libromfs/generator ]; then
+            GEN_SRC="library/borealis/library/lib/extern/libromfs/generator"
           else
-            echo "Could not find build_libromfs_generator.sh"
+            echo "Could not find libromfs generator source directory"
             exit 1
           fi
+          cmake -S "$GEN_SRC" -B /tmp/libromfs-generator -G Ninja
+          cmake --build /tmp/libromfs-generator
+          sudo install -m 0755 /tmp/libromfs-generator/libromfs-generator /usr/local/bin/libromfs-generator
+          [ -d lib/borealis ] && install -m 0755 /tmp/libromfs-generator/libromfs-generator lib/borealis/libromfs-generator || true
+          [ -d library/borealis ] && install -m 0755 /tmp/libromfs-generator/libromfs-generator library/borealis/libromfs-generator || true
 
       - name: Build Android shared library (fallback CMake)
         if: ${{ hashFiles('app/platform/android/gradlew') == '' }}

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -643,7 +643,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
@@ -668,7 +668,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -546,7 +546,14 @@ jobs:
         run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: Install dependencies
         run: |
-          flatpak install -y --noninteractive flathub org.freedesktop.Sdk//25.08 org.freedesktop.Platform//25.08 || true
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            cmake ninja-build pkg-config \
+            libcurl4-openssl-dev libmbedtls-dev libmpv-dev \
+            libavcodec-dev libavformat-dev libavfilter-dev libswresample-dev libswscale-dev libavutil-dev \
+            libmp3lame-dev libass-dev libfreetype-dev libharfbuzz-dev libfribidi-dev \
+            libpng-dev libwebp-dev libzstd-dev libdbus-1-dev \
+            libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build desktop target in flatpak container
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_GLES2=${{ matrix.gles2 }}

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -71,19 +71,27 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install switchfin portlibs package
+        run: |
+          curl -fsSL -o /tmp/switch-libmpv.pkg.tar.zst \
+            https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs/switch-libmpv-0.41.0-5-any.pkg.tar.zst
+          curl -fsSL -o /tmp/switch-dav1d.pkg.tar.zst \
+            https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs/switch-dav1d-1.5.3-1-any.pkg.tar.zst
+          dkp-pacman -U --noconfirm /tmp/switch-libmpv.pkg.tar.zst
+          dkp-pacman -U --noconfirm /tmp/switch-dav1d.pkg.tar.zst
+
       - name: Install Switch dependencies
         run: |
           dkp-pacman -Sy --noconfirm \
             switch-curl \
             switch-mbedtls \
             switch-ffmpeg \
-            switch-mpv \
+            switch-libmpv \
             switch-libass \
             switch-freetype \
             switch-harfbuzz \
             switch-libpng \
-            switch-libwebp \
-            switch-zstd
+            switch-libwebp
 
       - name: Build
         run: |
@@ -114,7 +122,15 @@ jobs:
             libcurl4-openssl-dev \
             libmbedtls-dev \
             libmpv-dev \
+            libavcodec-dev \
+            libavformat-dev \
+            libavfilter-dev \
+            libswresample-dev \
+            libswscale-dev \
+            libavutil-dev \
+            libmp3lame-dev \
             libass-dev \
+            libdbus-1-dev \
             libfreetype-dev \
             libharfbuzz-dev \
             libfribidi-dev \
@@ -125,7 +141,11 @@ jobs:
             libgl1-mesa-dev \
             libx11-dev \
             libxrandr-dev \
-            libxi-dev
+            libxi-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libwayland-dev \
+            libxkbcommon-dev
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -134,6 +154,11 @@ jobs:
 
       - name: Build
         run: |
+          export HOMEBREW_PREFIX="$(brew --prefix)"
+          export CPATH="${HOMEBREW_PREFIX}/include:${CPATH}"
+          export LIBRARY_PATH="${HOMEBREW_PREFIX}/lib:${LIBRARY_PATH}"
+          export CPPFLAGS="-I${HOMEBREW_PREFIX}/include"
+          export LDFLAGS="-L${HOMEBREW_PREFIX}/lib"
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
           cmake --build build
 
@@ -190,7 +215,24 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             cmake ninja-build git pkg-config \
-            mingw-w64
+            mingw-w64 \
+            libdbus-1-dev \
+            libwebp-dev \
+            libcurl4-openssl-dev \
+            libmbedtls-dev \
+            libmpv-dev \
+            libavcodec-dev \
+            libavformat-dev \
+            libavfilter-dev \
+            libswresample-dev \
+            libswscale-dev \
+            libavutil-dev \
+            libmp3lame-dev \
+            libass-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libfreetype-dev \
+            libpng-dev
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -200,13 +242,15 @@ jobs:
       - name: Install Windows deps via vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: '2024.06.15'
+          vcpkgGitCommitId: 'f7423ee180c4b7f40d43402c2feb3859161ef625'
 
       - name: Build
         run: |
           cmake -B build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_TARGET_TRIPLET=x64-mingw-static \
+            -DGLFW_BUILD_WAYLAND=OFF \
+            -DGLFW_BUILD_X11=OFF \
             -DPLATFORM_DESKTOP=ON
           cmake --build build
 
@@ -217,3 +261,421 @@ jobs:
           path: |
             build/VitaSuwayomi.exe
             build/resources/
+
+  # ───────────────────────────────────────────────
+  # Android — arm64-v8a
+  # ───────────────────────────────────────────────
+  build-android:
+    name: Android (arm64-v8a)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Install build requirements
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y cmake ninja-build git pkg-config
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r27d
+          link-to-sdk: true
+
+      - name: Install Android dependency toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build pkg-config meson nasm make
+
+      - name: Cache Android deps (switchfin-style)
+        if: ${{ hashFiles('scripts/android/Makefile') != '' }}
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: jniLibs
+          key: jniLibs-${{ hashFiles('scripts/android/Makefile') }}
+
+      - name: Build Android packages (switchfin-style)
+        if: ${{ hashFiles('scripts/android/Makefile') != '' && steps.cache-deps.outputs.cache-hit != 'true' }}
+        run: |
+          make -C scripts/android TMPDIR=${{ runner.temp }} download
+          make -C scripts/android TMPDIR=${{ runner.temp }} ABI=armeabi-v7a \
+            ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }} build
+          make -C scripts/android TMPDIR=${{ runner.temp }} ABI=arm64-v8a \
+            ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }} build
+
+      - name: Bump Android version (switchfin-style)
+        if: ${{ hashFiles('app/platform/android/app/build.gradle') != '' }}
+        uses: chkfung/android-version-actions@v1.2.2
+        with:
+          gradlePath: app/platform/android/app/build.gradle
+          versionCode: ${{ github.run_number }}
+
+      - name: Build Android APK (switchfin-style)
+        if: ${{ hashFiles('app/platform/android/gradlew') != '' }}
+        run: |
+          if [ -f lib/borealis/build_libromfs_generator.sh ]; then
+            (cd lib/borealis && bash build_libromfs_generator.sh)
+          elif [ -f library/borealis/build_libromfs_generator.sh ]; then
+            (cd library/borealis && bash build_libromfs_generator.sh)
+          fi
+          cd app/platform/android && ./gradlew assembleRelease
+
+      - name: Prepare libromfs-generator (fallback CMake)
+        if: ${{ hashFiles('app/platform/android/gradlew') == '' }}
+        run: |
+          if [ -f lib/borealis/build_libromfs_generator.sh ]; then
+            (cd lib/borealis && bash build_libromfs_generator.sh)
+          elif [ -f library/borealis/build_libromfs_generator.sh ]; then
+            (cd library/borealis && bash build_libromfs_generator.sh)
+          else
+            echo "Could not find build_libromfs_generator.sh"
+            exit 1
+          fi
+
+      - name: Build Android shared library (fallback CMake)
+        if: ${{ hashFiles('app/platform/android/gradlew') == '' }}
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cmake -B build-android -G Ninja \
+            -DPLATFORM_ANDROID=ON \
+            -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-24 \
+            -DANDROID_STL=c++_shared
+          cmake --build build-android
+
+      - name: Upload Android APK
+        if: ${{ hashFiles('app/platform/android/gradlew') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-android-apk-${{ github.run_number }}
+          path: app/platform/android/app/build/outputs/apk/release/*.apk
+
+      - name: Upload Android shared library
+        if: ${{ hashFiles('app/platform/android/gradlew') == '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-android-${{ github.run_number }}
+          path: |
+            build-android/libVitaSuwayomi.so
+
+  # ───────────────────────────────────────────────
+  # Desktop — macOS Matrix (Silicon + Intel)
+  # ───────────────────────────────────────────────
+  build-desktop-macos-matrix:
+    name: Desktop (macOS ${{ matrix.tag }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { tag: Silicon, arch: arm64, target: "11.0", runner: macos-14 }
+        - { tag: Intel, arch: x86_64, target: "10.15", runner: macos-13 }
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install deps
+        run: |
+          brew install cmake ninja pkg-config curl mbedtls mpv libass freetype harfbuzz fribidi libpng webp zstd glfw
+
+      - name: Build
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPLATFORM_DESKTOP=ON \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.target }}
+          cmake --build build
+
+      - name: Upload macOS binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-macos-${{ matrix.tag }}-${{ github.run_number }}
+          path: |
+            build/VitaSuwayomi
+            build/resources/
+
+  # ───────────────────────────────────────────────
+  # Desktop — Windows Matrix via MSYS2 (x64/x86/arm64)
+  # ───────────────────────────────────────────────
+  build-desktop-windows-matrix:
+    name: Desktop (Windows ${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { arch: x64, sys: mingw64, env: x86_64, runner: windows-latest }
+        - { arch: x86, sys: mingw32, env: i686, runner: windows-latest }
+        - { arch: arm64, sys: clangarm64, env: clang-aarch64, runner: windows-11-arm }
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          path-type: inherit
+          cache: false
+          release: ${{ contains(matrix.sys, 'arm64') }}
+          install: >-
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-cc
+            mingw-w64-${{ matrix.env }}-cmake
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependency
+        run: |
+          for pkg in glfw-3.5.0-1 curl-8.16.0-1 mpv-0.41.0-1 libwebp-1.6.0-1; do
+            curl -sLO https://github.com/dragonflylee/switchfin/releases/download/mingw-packages/${MINGW_PACKAGE_PREFIX}-${pkg}-any.pkg.tar.zst
+          done
+          pacman -U --noconfirm *.pkg.tar.zst
+      - name: Build
+        run: |
+          cmake -B build -G Ninja \
+            -DPLATFORM_DESKTOP=ON \
+            -DWIN32_TERMINAL=OFF \
+            -DZLIB_USE_STATIC_LIBS=ON \
+            -DUSE_SYSTEM_GLFW=ON
+          cmake --build build
+      - name: Upload Windows binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-windows-${{ matrix.arch }}-${{ github.run_number }}
+          path: |
+            build/VitaSuwayomi.exe
+            build/resources/
+
+  # ───────────────────────────────────────────────
+  # Flatpak — Linux Matrix (x86_64 + aarch64, OpenGL)
+  # ───────────────────────────────────────────────
+  build-flatpak:
+    name: Flatpak (${{ matrix.arch }}-${{ matrix.driver }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { arch: x86_64, runner: ubuntu-24.04, driver: gl, gles2: "OFF" }
+        - { arch: aarch64, runner: ubuntu-24.04-arm, driver: gl, gles2: "OFF" }
+        - { arch: aarch64, runner: ubuntu-24.04-arm, driver: gles2, gles2: "ON" }
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set workspace permissions
+        run: git config --system --add safe.directory $GITHUB_WORKSPACE
+      - name: Install dependencies
+        run: |
+          flatpak install -y --noninteractive flathub org.freedesktop.Sdk//25.08 org.freedesktop.Platform//25.08 || true
+      - name: Build desktop target in flatpak container
+        run: |
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_GLES2=${{ matrix.gles2 }}
+          cmake --build build
+          tar -czf VitaSuwayomi-Linux-${{ matrix.arch }}-${{ matrix.driver }}-${{ github.run_number }}.tar.gz -C build VitaSuwayomi resources
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-Flatpak-${{ matrix.arch }}-${{ matrix.driver }}-${{ github.run_number }}
+          path: VitaSuwayomi-Linux-${{ matrix.arch }}-${{ matrix.driver }}-${{ github.run_number }}.tar.gz
+
+  # ───────────────────────────────────────────────
+  # Nintendo Switch — Matrix (opengl + deko3d)
+  # ───────────────────────────────────────────────
+  build-nx:
+    name: NX (${{ matrix.driver }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { driver: opengl, mpv_pkg: switch-libmpv-0.41.0-5-any.pkg.tar.zst, cmake_extra: "" }
+        - { driver: deko3d, mpv_pkg: switch-libmpv-deko3d-0.41.0-5-any.pkg.tar.zst, cmake_extra: "-DUSE_DEKO3D=ON" }
+    container:
+      image: devkitpro/devkita64:20260219
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install switchfin portlibs
+        run: |
+          BASE_URL="https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs"
+          dkp-pacman --noconfirm -U $BASE_URL/hacBrewPack-3.05-1-x86_64.pkg.tar.zst
+          dkp-pacman --noconfirm -U $BASE_URL/switch-dav1d-1.5.3-1-any.pkg.tar.zst
+          dkp-pacman --noconfirm -U $BASE_URL/${{ matrix.mpv_pkg }}
+      - name: Build
+        run: |
+          cmake -B build -G Ninja \
+            -DPLATFORM_SWITCH=ON \
+            ${{ matrix.cmake_extra }}
+          cmake --build build
+      - name: Upload NRO
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-nx-${{ matrix.driver }}-${{ github.run_number }}
+          path: build/VitaSuwayomi.nro
+
+  # ───────────────────────────────────────────────
+  # PS4
+  # ───────────────────────────────────────────────
+  build-ps4:
+    name: PS4
+    runs-on: ubuntu-latest
+    container:
+      image: xfangfang/pacbrew:250221
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        env:
+          OPENORBIS: /opt/pacbrew/ps4/openorbis
+        run: |
+          cmake -B build -DPLATFORM_PS4=ON
+          cmake --build build
+      - name: Upload PS4 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-ps4-${{ github.run_number }}
+          path: |
+            build/*.pkg
+            build/*.oelf
+
+  # ───────────────────────────────────────────────
+  # macOS matrix (explicit job name parity)
+  # ───────────────────────────────────────────────
+  build-macos:
+    name: macOS (${{ matrix.tag }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { tag: Silicon, arch: arm64, target: "11.0", runner: macos-14 }
+        - { tag: Intel, arch: x86_64, target: "10.15", runner: macos-13 }
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: brew install cmake ninja pkg-config curl mbedtls mpv libass freetype harfbuzz fribidi libpng webp zstd glfw
+      - name: Build
+        run: |
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.target }}
+          cmake --build build
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-macos-${{ matrix.tag }}-${{ github.run_number }}
+          path: |
+            build/VitaSuwayomi
+            build/resources/
+
+  # ───────────────────────────────────────────────
+  # MinGW matrix (x64/x86/arm64)
+  # ───────────────────────────────────────────────
+  build-mingw:
+    name: MinGW (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { arch: x64, sys: mingw64, env: x86_64, runner: windows-latest }
+        - { arch: x86, sys: mingw32, env: i686, runner: windows-latest }
+        - { arch: arm64, sys: clangarm64, env: clang-aarch64, runner: windows-11-arm }
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          path-type: inherit
+          cache: false
+          release: ${{ contains(matrix.sys, 'arm64') }}
+          install: >-
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-cc
+            mingw-w64-${{ matrix.env }}-cmake
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        run: |
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON
+          cmake --build build
+      - name: Upload mingw artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-mingw-${{ matrix.arch }}-${{ github.run_number }}
+          path: |
+            build/VitaSuwayomi.exe
+            build/resources/
+
+  # ───────────────────────────────────────────────
+  # Debian package-like build
+  # ───────────────────────────────────────────────
+  build-deb:
+    name: Deb build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev
+      - name: Build
+        run: |
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
+          cmake --build build
+          tar -czf VitaSuwayomi-deb-${{ github.run_number }}.tar.gz -C build VitaSuwayomi resources
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-deb-${{ github.run_number }}
+          path: VitaSuwayomi-deb-${{ github.run_number }}.tar.gz
+
+  # ───────────────────────────────────────────────
+  # AUR-like build
+  # ───────────────────────────────────────────────
+  build-aur:
+    name: AUR build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev
+      - name: Build
+        run: |
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
+          cmake --build build
+          tar --zstd -cf VitaSuwayomi-aur-${{ github.run_number }}.pkg.tar.zst -C build VitaSuwayomi resources
+      - name: Upload aur artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VitaSuwayomi-aur-${{ github.run_number }}
+          path: VitaSuwayomi-aur-${{ github.run_number }}.pkg.tar.zst

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -656,7 +656,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config libdbus-1-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
@@ -681,7 +681,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd libdbus-1-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -712,7 +712,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config libdbus-1-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config libdbus-1-dev libwebp-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON
@@ -738,7 +738,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd libdbus-1-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
+          sudo apt-get install -y cmake ninja-build build-essential git pkg-config zstd libdbus-1-dev libwebp-dev wayland-protocols libwayland-bin libwayland-dev libxkbcommon-dev xorg-dev
       - name: Build
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -6,16 +6,65 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      platform:
+        description: which platform to build
+        type: choice
+        options:
+        - mingw64
+        - macos
+        - nx
+        - psvita
+        - ps4
+        - flatpak
+        - android
+        - aur
+        - deb
+      disable_builtin_nsp:
+        description: disable builtin NSP
+        type: boolean
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Build matrix
 # ─────────────────────────────────────────────────────────────────────────────
 jobs:
 
+  upload-release:
+    needs: [ build-mingw, build-nx, build-macos, build-flatpak, build-aur, build-ps4, build-vita, build-android ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download Assets
+        uses: actions/download-artifact@v4
+      - name: Package Windows assets
+        run: |
+          for p in VitaSuwayomi-windows-*; do
+            [[ -d $p ]] && 7z a -mx=9 $p.7z ./$p/* && rm -rf $p
+          done
+      - name: Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          name: VitaSuwayomi ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: true
+          files: |
+            VitaSuwayomi-windows-*.7z
+            VitaSuwayomi-macos-*/*
+            VitaSuwayomi-nx-*/*.nro
+            VitaSuwayomi-ps4-*/*
+            VitaSuwayomi-vita-*/*.vpk
+            VitaSuwayomi-Flatpak-*/*
+            VitaSuwayomi-aur-*/*.pkg.tar.*
+            VitaSuwayomi-android-*/*
+
   # ───────────────────────────────────────────────
   # PS Vita — VPK
   # ───────────────────────────────────────────────
   build-vita:
+    if: ${{ inputs.platform == 'psvita' || github.event_name != 'workflow_dispatch' }}
     name: PS Vita
     runs-on: ubuntu-latest
     container:
@@ -268,6 +317,7 @@ jobs:
   build-android:
     name: Android (arm64-v8a)
     runs-on: ubuntu-22.04
+    if: ${{ inputs.platform == 'android' || startsWith(github.ref, 'refs/tags/') }}
 
     steps:
       - name: Install build requirements
@@ -475,6 +525,7 @@ jobs:
   # Flatpak — Linux Matrix (x86_64 + aarch64, OpenGL)
   # ───────────────────────────────────────────────
   build-flatpak:
+    if: ${{ inputs.platform == 'flatpak' || github.event_name != 'workflow_dispatch' }}
     name: Flatpak (${{ matrix.arch }}-${{ matrix.driver }})
     strategy:
       fail-fast: false
@@ -511,6 +562,7 @@ jobs:
   # Nintendo Switch — Matrix (opengl + deko3d)
   # ───────────────────────────────────────────────
   build-nx:
+    if: ${{ inputs.platform == 'nx' || github.event_name != 'workflow_dispatch' }}
     name: NX (${{ matrix.driver }})
     runs-on: ubuntu-latest
     strategy:
@@ -547,6 +599,7 @@ jobs:
   # PS4
   # ───────────────────────────────────────────────
   build-ps4:
+    if: ${{ inputs.platform == 'ps4' || github.event_name != 'workflow_dispatch' }}
     name: PS4
     runs-on: ubuntu-latest
     container:
@@ -573,6 +626,7 @@ jobs:
   # macOS matrix (explicit job name parity)
   # ───────────────────────────────────────────────
   build-macos:
+    if: ${{ inputs.platform == 'macos' || github.event_name != 'workflow_dispatch' }}
     name: macOS (${{ matrix.tag }})
     strategy:
       fail-fast: false
@@ -605,6 +659,7 @@ jobs:
   # MinGW matrix (x64/x86/arm64)
   # ───────────────────────────────────────────────
   build-mingw:
+    if: ${{ inputs.platform == 'mingw64' || github.event_name != 'workflow_dispatch' }}
     name: MinGW (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -647,6 +702,7 @@ jobs:
   # Debian package-like build
   # ───────────────────────────────────────────────
   build-deb:
+    if: ${{ inputs.platform == 'deb' || github.event_name != 'workflow_dispatch' }}
     name: Deb build
     runs-on: ubuntu-24.04
     steps:
@@ -672,6 +728,7 @@ jobs:
   # AUR-like build
   # ───────────────────────────────────────────────
   build-aur:
+    if: ${{ inputs.platform == 'aur' || github.event_name != 'workflow_dispatch' }}
     name: AUR build
     runs-on: ubuntu-24.04
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,13 @@ cmake_minimum_required(VERSION 3.16)
 
 option(PLATFORM_PSV     "Build for PlayStation Vita"                   OFF)
 option(PLATFORM_SWITCH  "Build for Nintendo Switch"                    OFF)
+option(PLATFORM_PS4     "Build for PlayStation 4"                      OFF)
 option(PLATFORM_DESKTOP "Build for Desktop (Linux/macOS/Windows)"      OFF)
 option(PLATFORM_ANDROID "Build for Android"                            OFF)
 
 # Default to desktop when nothing is specified
 set(_PLATFORM_COUNT 0)
-foreach(_P PSV SWITCH DESKTOP ANDROID)
+foreach(_P PSV SWITCH PS4 DESKTOP ANDROID)
     if(PLATFORM_${_P})
         math(EXPR _PLATFORM_COUNT "${_PLATFORM_COUNT} + 1")
     endif()
@@ -36,7 +37,7 @@ set(BOREALIS_LIBRARY ${BOREALIS_DIR}/library)
 set(PLATFORM_DESKTOP ${PLATFORM_DESKTOP} CACHE BOOL "" FORCE)
 set(PLATFORM_SWITCH  ${PLATFORM_SWITCH}  CACHE BOOL "" FORCE)
 set(PLATFORM_PSV     ${PLATFORM_PSV}     CACHE BOOL "" FORCE)
-set(PLATFORM_PS4     OFF                 CACHE BOOL "" FORCE)
+set(PLATFORM_PS4     ${PLATFORM_PS4}     CACHE BOOL "" FORCE)
 set(PLATFORM_IOS     OFF                 CACHE BOOL "" FORCE)
 set(PLATFORM_ANDROID ${PLATFORM_ANDROID} CACHE BOOL "" FORCE)
 
@@ -143,18 +144,29 @@ else()
 endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${APP_INCLUDES})
+if(PLATFORM_DESKTOP AND APPLE)
+    target_include_directories(${PROJECT_NAME} PRIVATE
+        /opt/homebrew/include
+        /usr/local/include
+    )
+    target_link_directories(${PROJECT_NAME} PRIVATE
+        /opt/homebrew/lib
+        /usr/local/lib
+    )
+endif()
+
+if(PLATFORM_PSV)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE RESOURCE_PREFIX=\"app0:resources/\")
+elseif(PLATFORM_SWITCH)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE RESOURCE_PREFIX=\"romfs:/\")
+else()
+    target_compile_definitions(${PROJECT_NAME} PRIVATE RESOURCE_PREFIX=\"resources/\")
+endif()
 
 # ---------------------------------------------------------------------------
 # Link libraries
 # ---------------------------------------------------------------------------
-target_link_libraries(${PROJECT_NAME}
-    borealis
-    ${APP_PLATFORM_LIB}
-    curl
-    mbedtls
-    mbedx509
-    mbedcrypto
-    -Wl,--start-group
+set(APP_FFMPEG_LIBS
     mpv
     avfilter
     avformat
@@ -162,8 +174,22 @@ target_link_libraries(${PROJECT_NAME}
     swresample
     swscale
     avutil
-    -Wl,--end-group
-    mp3lame
+)
+
+if(APPLE)
+    set(APP_FFMPEG_LINK_BLOCK ${APP_FFMPEG_LIBS})
+else()
+    set(APP_FFMPEG_LINK_BLOCK -Wl,--start-group ${APP_FFMPEG_LIBS} -Wl,--end-group)
+endif()
+
+target_link_libraries(${PROJECT_NAME}
+    borealis
+    ${APP_PLATFORM_LIB}
+    curl
+    mbedtls
+    mbedx509
+    mbedcrypto
+    ${APP_FFMPEG_LINK_BLOCK}
     zstd
     ass
     freetype
@@ -175,6 +201,10 @@ target_link_libraries(${PROJECT_NAME}
     z
     c
 )
+
+if(NOT PLATFORM_SWITCH)
+    target_link_libraries(${PROJECT_NAME} mp3lame)
+endif()
 
 if(PLATFORM_PSV)
     target_link_libraries(${PROJECT_NAME}
@@ -196,10 +226,13 @@ if(PLATFORM_PSV)
         SceVshBridge_stub
     )
 elseif(PLATFORM_SWITCH)
-    target_link_libraries(${PROJECT_NAME} nx)
+    target_link_libraries(${PROJECT_NAME} nx dav1d)
 elseif(PLATFORM_DESKTOP)
     find_package(Threads REQUIRED)
     target_link_libraries(${PROJECT_NAME} Threads::Threads)
+    if(APPLE)
+        target_link_libraries(${PROJECT_NAME} "-framework CoreWLAN")
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -357,7 +357,7 @@ struct Tracker {
 
 // Source preference types (matches Suwayomi preference types)
 enum class SourcePreferenceType {
-    SWITCH,
+    SWITCH_TOGGLE,
     CHECKBOX,
     EDIT_TEXT,
     LIST,
@@ -366,7 +366,7 @@ enum class SourcePreferenceType {
 
 // Source preference (for source settings/configuration)
 struct SourcePreference {
-    SourcePreferenceType type = SourcePreferenceType::SWITCH;
+    SourcePreferenceType type = SourcePreferenceType::SWITCH_TOGGLE;
     std::string key;
     std::string title;
     std::string summary;

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -1182,7 +1182,6 @@ int DownloadsManager::countIncompleteDownloads() const {
 }
 
 void DownloadsManager::saveStateUnlocked() {
-#ifdef __vita__
     // Debounce state saves - minimum 500ms between saves to reduce disk I/O
     auto now = std::chrono::steady_clock::now();
     auto timeSinceLastSave = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastSaveTime).count();
@@ -1257,7 +1256,8 @@ void DownloadsManager::saveStateUnlocked() {
 
     std::string json = ss.str();
 
-    SceUID fd = sceIoOpen(STATE_FILE_PATH, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0666);
+#ifdef __vita__
+    SceUID fd = sceIoOpen(STATE_FILE_PATH.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0666);
     if (fd >= 0) {
         sceIoWrite(fd, json.c_str(), json.length());
         sceIoClose(fd);
@@ -1358,7 +1358,7 @@ static size_t findMatchingBracket(const std::string& json, size_t start, char op
 
 void DownloadsManager::loadState() {
 #ifdef __vita__
-    SceUID fd = sceIoOpen(STATE_FILE_PATH, SCE_O_RDONLY, 0);
+    SceUID fd = sceIoOpen(STATE_FILE_PATH.c_str(), SCE_O_RDONLY, 0);
     if (fd < 0) {
         brls::Logger::debug("DownloadsManager: No saved state found");
         return;

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -31,7 +31,11 @@
 #include <psp2/io/stat.h>
 #include <psp2/io/dirent.h>
 #else
+#if defined(_WIN32)
+#include <direct.h>
+#else
 #include <unistd.h>
+#endif
 #include <sys/stat.h>
 #include <dirent.h>
 #include <cerrno>
@@ -50,7 +54,11 @@ static bool createDirectory(const std::string& path) {
     int ret = sceIoMkdir(path.c_str(), 0777);
     return ret >= 0 || ret == 0x80010011;  // Success or already exists
 #else
+#if defined(_WIN32)
+    int ret = _mkdir(path.c_str());
+#else
     int ret = mkdir(path.c_str(), 0755);
+#endif
     return ret == 0 || errno == EEXIST;
 #endif
 }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -6294,7 +6294,7 @@ SourcePreference SuwayomiClient::parseSourcePreferenceFromGraphQL(const std::str
 
     bool knownType = true;
     if (typeName == "SwitchPreference") {
-        pref.type = SourcePreferenceType::SWITCH;
+        pref.type = SourcePreferenceType::SWITCH_TOGGLE;
     } else if (typeName == "CheckBoxPreference") {
         pref.type = SourcePreferenceType::CHECKBOX;
     } else if (typeName == "EditTextPreference") {
@@ -6338,7 +6338,7 @@ SourcePreference SuwayomiClient::parseSourcePreferenceFromGraphQL(const std::str
     // else: keep default enabled = true
 
     // Type-specific fields (using aliased field names from GraphQL query)
-    if (pref.type == SourcePreferenceType::SWITCH || pref.type == SourcePreferenceType::CHECKBOX) {
+    if (pref.type == SourcePreferenceType::SWITCH_TOGGLE || pref.type == SourcePreferenceType::CHECKBOX) {
         pref.currentValue = extractJsonBool(json, "boolValue");
         pref.defaultValue = extractJsonBool(json, "boolDefault");
     } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -214,7 +214,7 @@ DownloadsTab::DownloadsTab() {
     m_clearIcon->setWidth(16);
     m_clearIcon->setHeight(16);
     m_clearIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_clearIcon->setImageFromFile("app0:resources/icons/delete.png");
+    m_clearIcon->setImageFromFile(RESOURCE_PREFIX "icons/delete.png");
     m_clearIcon->setMarginRight(4);
     m_clearBtn->addView(m_clearIcon);
 
@@ -1123,7 +1123,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     xButtonIcon->setWidth(24);
     xButtonIcon->setHeight(24);
     xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    xButtonIcon->setImageFromFile("app0:resources/images/square_button.png");
+    xButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/square_button.png");
     xButtonIcon->setMarginLeft(8);
     xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
     outXButtonIcon = xButtonIcon;
@@ -1530,7 +1530,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     xButtonIcon->setWidth(24);
     xButtonIcon->setHeight(24);
     xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    xButtonIcon->setImageFromFile("app0:resources/images/square_button.png");
+    xButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/square_button.png");
     xButtonIcon->setMarginLeft(8);
     xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
     outXButtonIcon = xButtonIcon;

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -77,7 +77,7 @@ ExtensionCell::ExtensionCell() {
 
     auto* settingsIcon = new brls::Image();
     settingsIcon->setSize(brls::Size(20, 20));
-    settingsIcon->setImageFromFile("app0:resources/icons/options.png");
+    settingsIcon->setImageFromFile(RESOURCE_PREFIX "icons/options.png");
     settingsBtn->addView(settingsIcon);
     settingsBtn->addGestureRecognizer(new brls::TapGestureRecognizer(settingsBtn));
 
@@ -694,7 +694,7 @@ ExtensionsTab::ExtensionsTab() {
     selectButtonIcon->setWidth(64);
     selectButtonIcon->setHeight(16);
     selectButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    selectButtonIcon->setImageFromFile("app0:resources/images/select_button.png");
+    selectButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/select_button.png");
     selectButtonIcon->setMarginBottom(2);
     repoContainer->addView(selectButtonIcon);
 
@@ -705,7 +705,7 @@ ExtensionsTab::ExtensionsTab() {
     repoBox->setBackgroundColor(Application::getInstance().getCardBackground());
     auto* repoIcon = new brls::Image();
     repoIcon->setSize(brls::Size(24, 24));
-    repoIcon->setImageFromFile("app0:resources/icons/import.png");
+    repoIcon->setImageFromFile(RESOURCE_PREFIX "icons/import.png");
     repoBox->addView(repoIcon);
     repoBox->registerClickAction([this](brls::View*) {
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() { auto a = aliveWeak.lock(); if (!a || !*a) return; showAddRepoDialog(); });
@@ -725,7 +725,7 @@ ExtensionsTab::ExtensionsTab() {
     startButtonIcon->setWidth(64);
     startButtonIcon->setHeight(16);
     startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
     startButtonIcon->setMarginBottom(2);
     searchContainer->addView(startButtonIcon);
 
@@ -736,7 +736,7 @@ ExtensionsTab::ExtensionsTab() {
     searchBox->setBackgroundColor(Application::getInstance().getCardBackground());
     m_searchIcon = new brls::Image();
     m_searchIcon->setSize(brls::Size(24, 24));
-    m_searchIcon->setImageFromFile("app0:resources/icons/search.png");
+    m_searchIcon->setImageFromFile(RESOURCE_PREFIX "icons/search.png");
     searchBox->addView(m_searchIcon);
     searchBox->registerClickAction([this](brls::View*) {
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() { auto a = aliveWeak.lock(); if (!a || !*a) return; showSearchDialog(); });
@@ -755,7 +755,7 @@ ExtensionsTab::ExtensionsTab() {
     triangleButtonIcon->setWidth(16);
     triangleButtonIcon->setHeight(16);
     triangleButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    triangleButtonIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    triangleButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/triangle_button.png");
     triangleButtonIcon->setMarginBottom(2);
     refreshContainer->addView(triangleButtonIcon);
 
@@ -766,7 +766,7 @@ ExtensionsTab::ExtensionsTab() {
     m_refreshBox->setBackgroundColor(Application::getInstance().getCardBackground());
     m_refreshIcon = new brls::Image();
     m_refreshIcon->setSize(brls::Size(24, 24));
-    m_refreshIcon->setImageFromFile("app0:resources/icons/refresh.png");
+    m_refreshIcon->setImageFromFile(RESOURCE_PREFIX "icons/refresh.png");
     m_refreshBox->addView(m_refreshIcon);
     m_refreshBox->registerClickAction([this](brls::View*) {
         brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() { auto a = aliveWeak.lock(); if (!a || !*a) return; refreshExtensions(); });
@@ -1467,7 +1467,7 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
                 auto* valueLabel = new brls::Label();
                 valueLabel->setFontSize(13);
 
-                if (pref.type == SourcePreferenceType::CHECKBOX || pref.type == SourcePreferenceType::SWITCH) {
+                if (pref.type == SourcePreferenceType::CHECKBOX || pref.type == SourcePreferenceType::SWITCH_TOGGLE) {
                     valueLabel->setText(pref.currentValue ? "Enabled" : "Disabled");
 
                     // Toggle on click
@@ -1475,7 +1475,7 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
                         bool newValue = !pref.currentValue;
                         SourcePreferenceChange change;
                         change.position = prefIdx;
-                        if (pref.type == SourcePreferenceType::SWITCH) {
+                        if (pref.type == SourcePreferenceType::SWITCH_TOGGLE) {
                             change.switchState = newValue;
                         } else {
                             change.checkBoxState = newValue;

--- a/src/view/history_tab.cpp
+++ b/src/view/history_tab.cpp
@@ -46,7 +46,7 @@ HistoryTab::HistoryTab() {
     triangleIcon->setWidth(16);
     triangleIcon->setHeight(16);
     triangleIcon->setScalingType(brls::ImageScalingType::FIT);
-    triangleIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    triangleIcon->setImageFromFile(RESOURCE_PREFIX "images/triangle_button.png");
     triangleIcon->setMarginBottom(2);
     refreshContainer->addView(triangleIcon);
 
@@ -61,7 +61,7 @@ HistoryTab::HistoryTab() {
     refreshIcon->setWidth(24);
     refreshIcon->setHeight(24);
     refreshIcon->setScalingType(brls::ImageScalingType::FIT);
-    refreshIcon->setImageFromFile("app0:resources/icons/refresh.png");
+    refreshIcon->setImageFromFile(RESOURCE_PREFIX "icons/refresh.png");
     m_refreshBtn->addView(refreshIcon);
 
     m_refreshBtn->registerClickAction([this](brls::View* view) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -83,7 +83,7 @@ LibrarySectionTab::LibrarySectionTab() {
     m_lHintIcon->setWidth(24);
     m_lHintIcon->setHeight(24);
     m_lHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_lHintIcon->setImageFromFile("app0:resources/images/l_button.png");
+    m_lHintIcon->setImageFromFile(RESOURCE_PREFIX "images/l_button.png");
     m_lHintIcon->setMarginRight(6);
     topRow->addView(m_lHintIcon);
 
@@ -136,7 +136,7 @@ LibrarySectionTab::LibrarySectionTab() {
     m_rHintIcon->setWidth(24);
     m_rHintIcon->setHeight(24);
     m_rHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_rHintIcon->setImageFromFile("app0:resources/images/r_button.png");
+    m_rHintIcon->setImageFromFile(RESOURCE_PREFIX "images/r_button.png");
     m_rHintIcon->setMarginRight(10);
     topRow->addView(m_rHintIcon);
 
@@ -156,7 +156,7 @@ LibrarySectionTab::LibrarySectionTab() {
     sortHintIcon->setWidth(16);
     sortHintIcon->setHeight(16);
     sortHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    sortHintIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    sortHintIcon->setImageFromFile(RESOURCE_PREFIX "images/triangle_button.png");
     sortHintIcon->setMarginBottom(2);
     sortContainer->addView(sortHintIcon);
 
@@ -200,7 +200,7 @@ LibrarySectionTab::LibrarySectionTab() {
     auto* updateHintIcon = new brls::Image();
     updateHintIcon->setHeight(16);
     updateHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    updateHintIcon->setImageFromFile("app0:resources/images/select_button.png");
+    updateHintIcon->setImageFromFile(RESOURCE_PREFIX "images/select_button.png");
     updateHintIcon->setMarginBottom(2);
     m_updateContainer->addView(updateHintIcon);
 
@@ -215,7 +215,7 @@ LibrarySectionTab::LibrarySectionTab() {
     updateIcon->setWidth(24);
     updateIcon->setHeight(24);
     updateIcon->setScalingType(brls::ImageScalingType::FIT);
-    updateIcon->setImageFromFile("app0:resources/icons/refresh.png");
+    updateIcon->setImageFromFile(RESOURCE_PREFIX "icons/refresh.png");
     m_updateBtn->addView(updateIcon);
 
     m_updateBtn->registerClickAction([this](brls::View* view) {
@@ -241,7 +241,7 @@ LibrarySectionTab::LibrarySectionTab() {
     groupHintIcon->setWidth(16);
     groupHintIcon->setHeight(16);
     groupHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    groupHintIcon->setImageFromFile("app0:resources/images/square_button.png");
+    groupHintIcon->setImageFromFile(RESOURCE_PREFIX "images/square_button.png");
     groupHintIcon->setMarginBottom(2);
     groupContainer->addView(groupHintIcon);
 
@@ -256,7 +256,7 @@ LibrarySectionTab::LibrarySectionTab() {
     groupIcon->setWidth(24);
     groupIcon->setHeight(24);
     groupIcon->setScalingType(brls::ImageScalingType::FIT);
-    groupIcon->setImageFromFile("app0:resources/icons/format-list-group.png");
+    groupIcon->setImageFromFile(RESOURCE_PREFIX "icons/format-list-group.png");
     groupBtn->addView(groupIcon);
 
     groupBtn->registerClickAction([this](brls::View* view) {
@@ -2303,37 +2303,37 @@ void LibrarySectionTab::updateSortButtonText() {
     switch (effectiveMode) {
         case LibrarySortMode::TITLE_ASC:
         default:
-            iconPath = "app0:resources/icons/az.png";  // A-Z
+            iconPath = RESOURCE_PREFIX "icons/az.png";  // A-Z
             break;
         case LibrarySortMode::TITLE_DESC:
-            iconPath = "app0:resources/icons/za.png";  // Z-A
+            iconPath = RESOURCE_PREFIX "icons/za.png";  // Z-A
             break;
         case LibrarySortMode::UNREAD_DESC:
-            iconPath = "app0:resources/icons/sort-9-1.png";  // Most unread first
+            iconPath = RESOURCE_PREFIX "icons/sort-9-1.png";  // Most unread first
             break;
         case LibrarySortMode::UNREAD_ASC:
-            iconPath = "app0:resources/icons/sort-1-9.png";  // Least unread first
+            iconPath = RESOURCE_PREFIX "icons/sort-1-9.png";  // Least unread first
             break;
         case LibrarySortMode::RECENTLY_ADDED_DESC:
-            iconPath = "app0:resources/icons/sort-clock-descending.png";  // Recently added (newest)
+            iconPath = RESOURCE_PREFIX "icons/sort-clock-descending.png";  // Recently added (newest)
             break;
         case LibrarySortMode::RECENTLY_ADDED_ASC:
-            iconPath = "app0:resources/icons/sort-clock-ascending.png";  // Recently added (oldest)
+            iconPath = RESOURCE_PREFIX "icons/sort-clock-ascending.png";  // Recently added (oldest)
             break;
         case LibrarySortMode::LAST_READ:
-            iconPath = "app0:resources/icons/book-open-page-variant.png";  // Last read
+            iconPath = RESOURCE_PREFIX "icons/book-open-page-variant.png";  // Last read
             break;
         case LibrarySortMode::DATE_UPDATED_DESC:
-            iconPath = "app0:resources/icons/sort-calendar-descending.png";  // Date updated (newest)
+            iconPath = RESOURCE_PREFIX "icons/sort-calendar-descending.png";  // Date updated (newest)
             break;
         case LibrarySortMode::DATE_UPDATED_ASC:
-            iconPath = "app0:resources/icons/sort-calendar-ascending.png";  // Date updated (oldest)
+            iconPath = RESOURCE_PREFIX "icons/sort-calendar-ascending.png";  // Date updated (oldest)
             break;
         case LibrarySortMode::TOTAL_CHAPTERS:
-            iconPath = "app0:resources/icons/book-multiple.png";  // Total chapters
+            iconPath = RESOURCE_PREFIX "icons/book-multiple.png";  // Total chapters
             break;
         case LibrarySortMode::DOWNLOADED_ONLY:
-            iconPath = "app0:resources/icons/book-arrow-down.png";  // Downloaded only
+            iconPath = RESOURCE_PREFIX "icons/book-arrow-down.png";  // Downloaded only
             break;
     }
     m_sortIcon->setImageFromFile(iconPath);

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -222,7 +222,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
             prev->setVisibility(brls::Visibility::INVISIBLE);
         }
         if (xIcon->getVisibility() != brls::Visibility::VISIBLE) {
-            xIcon->setImageFromFile("app0:resources/images/square_button.png");
+            xIcon->setImageFromFile(RESOURCE_PREFIX "images/square_button.png");
         }
         xIcon->setVisibility(brls::Visibility::VISIBLE);
         view->setCurrentFocusedIcon(xIcon);
@@ -450,24 +450,24 @@ void ChaptersDataSource::applyDownloadState(ChapterCell* cell, int dlState, int 
         cell->dlBtn->setBackgroundColor(nvgRGBA(52, 152, 219, 200));
     } else if (isLocallyDownloaded) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-        cell->dlIcon->setImageFromFile("app0:resources/icons/checkbox_checked.png");
+        cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/checkbox_checked.png");
         cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(46, 204, 113, 200));
     } else if (isLocallyQueued) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-        cell->dlIcon->setImageFromFile("app0:resources/icons/refresh.png");
+        cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/refresh.png");
         cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(241, 196, 15, 200));
     } else if (isLocallyFailed) {
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-        cell->dlIcon->setImageFromFile("app0:resources/icons/cross.png");
+        cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/cross.png");
         cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(231, 76, 60, 200));
     } else {
         // Default "not downloaded" state - show download arrow icon.
         // With RecyclerFrame only ~8 cells exist, so loading icons is cheap.
         cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-        cell->dlIcon->setImageFromFile("app0:resources/icons/download.png");
+        cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/download.png");
         cell->dlLabel->setVisibility(brls::Visibility::GONE);
         cell->dlBtn->setBackgroundColor(nvgRGBA(60, 60, 60, 200));
     }
@@ -1039,13 +1039,13 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     this->addView(m_categoryOverlay);
 
     // Load button icons immediately (avoids blank→loaded flash)
-    selectIcon->setImageFromFile("app0:resources/images/select_button.png");
-    rButtonIcon->setImageFromFile("app0:resources/images/r_button.png");
+    selectIcon->setImageFromFile(RESOURCE_PREFIX "images/select_button.png");
+    rButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/r_button.png");
     updateSortIcon();
-    yButtonIcon->setImageFromFile("app0:resources/images/triangle_button.png");
-    filterIcon->setImageFromFile("app0:resources/icons/filter-menu-outline.png");
-    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
-    menuIcon->setImageFromFile("app0:resources/icons/menu.png");
+    yButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/triangle_button.png");
+    filterIcon->setImageFromFile(RESOURCE_PREFIX "icons/filter-menu-outline.png");
+    startButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
+    menuIcon->setImageFromFile(RESOURCE_PREFIX "icons/menu.png");
 
     // Load full details
     loadDetails();
@@ -1692,22 +1692,22 @@ void MangaDetailView::refreshVisibleDownloadIcons() {
                 cell->dlBtn->invalidate();
             } else if (isDownloaded) {
                 cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-                cell->dlIcon->setImageFromFile("app0:resources/icons/checkbox_checked.png");
+                cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/checkbox_checked.png");
                 cell->dlLabel->setVisibility(brls::Visibility::GONE);
                 cell->dlBtn->setBackgroundColor(nvgRGBA(46, 204, 113, 200));
             } else if (isQueued) {
                 cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-                cell->dlIcon->setImageFromFile("app0:resources/icons/refresh.png");
+                cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/refresh.png");
                 cell->dlLabel->setVisibility(brls::Visibility::GONE);
                 cell->dlBtn->setBackgroundColor(nvgRGBA(241, 196, 15, 200));
             } else if (isFailed) {
                 cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-                cell->dlIcon->setImageFromFile("app0:resources/icons/cross.png");
+                cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/cross.png");
                 cell->dlLabel->setVisibility(brls::Visibility::GONE);
                 cell->dlBtn->setBackgroundColor(nvgRGBA(231, 76, 60, 200));
             } else {
                 cell->dlIcon->setVisibility(brls::Visibility::VISIBLE);
-                cell->dlIcon->setImageFromFile("app0:resources/icons/download.png");
+                cell->dlIcon->setImageFromFile(RESOURCE_PREFIX "icons/download.png");
                 cell->dlLabel->setVisibility(brls::Visibility::GONE);
                 cell->dlBtn->setBackgroundColor(nvgRGBA(60, 60, 60, 200));
             }
@@ -3566,8 +3566,8 @@ void MangaDetailView::updateSortIcon() {
     if (!m_sortIcon) return;
 
     std::string iconPath = m_sortDescending
-        ? "app0:resources/icons/sort-9-1.png"
-        : "app0:resources/icons/sort-1-9.png";
+        ? RESOURCE_PREFIX "icons/sort-9-1.png"
+        : RESOURCE_PREFIX "icons/sort-1-9.png";
 
     m_sortIcon->setImageFromFile(iconPath);
 }

--- a/src/view/media_item_cell.cpp
+++ b/src/view/media_item_cell.cpp
@@ -193,7 +193,7 @@ void MangaItemCell::updateDisplay() {
         if (showStar) {
             auto* star = ensureStarBadge();
             if (!m_starImageLoaded) {
-                star->setImageFromFile("app0:resources/icons/star.png");
+                star->setImageFromFile(RESOURCE_PREFIX "icons/star.png");
                 m_starImageLoaded = true;
             }
             star->setVisibility(brls::Visibility::VISIBLE);
@@ -292,7 +292,7 @@ void MangaItemCell::onFocusGained() {
     if (!m_showLibraryBadge) {
         auto* hint = ensureStartHintIcon();
         if (!m_startHintImageLoaded) {
-            hint->setImageFromFile("app0:resources/images/start_button.png");
+            hint->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
             m_startHintImageLoaded = true;
         }
         hint->setVisibility(brls::Visibility::VISIBLE);
@@ -617,7 +617,7 @@ void MangaItemCell::setShowLibraryBadge(bool show) {
     if (inLib) {
         auto* star = ensureStarBadge();
         if (!m_starImageLoaded) {
-            star->setImageFromFile("app0:resources/icons/star.png");
+            star->setImageFromFile(RESOURCE_PREFIX "icons/star.png");
             m_starImageLoaded = true;
         }
         star->setVisibility(brls::Visibility::VISIBLE);
@@ -636,7 +636,7 @@ void MangaItemCell::refreshLibraryBadge() {
     if (inLib) {
         auto* star = ensureStarBadge();
         if (!m_starImageLoaded) {
-            star->setImageFromFile("app0:resources/icons/star.png");
+            star->setImageFromFile(RESOURCE_PREFIX "icons/star.png");
             m_starImageLoaded = true;
         }
         star->setVisibility(brls::Visibility::VISIBLE);

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -53,7 +53,7 @@ SearchTab::SearchTab() {
     triangleHintIcon->setWidth(16);
     triangleHintIcon->setHeight(16);
     triangleHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    triangleHintIcon->setImageFromFile("app0:resources/images/triangle_button.png");
+    triangleHintIcon->setImageFromFile(RESOURCE_PREFIX "images/triangle_button.png");
     triangleHintIcon->setMarginBottom(2);
     m_filterBtnContainer->addView(triangleHintIcon);
 
@@ -68,7 +68,7 @@ SearchTab::SearchTab() {
     m_tagFilterIcon->setWidth(24);
     m_tagFilterIcon->setHeight(24);
     m_tagFilterIcon->setScalingType(brls::ImageScalingType::FIT);
-    m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
+    m_tagFilterIcon->setImageFromFile(RESOURCE_PREFIX "icons/tag.png");
     m_tagFilterBtn->addView(m_tagFilterIcon);
 
     m_tagFilterBtn->registerClickAction([this](brls::View* view) {
@@ -101,7 +101,7 @@ SearchTab::SearchTab() {
     selectButtonIcon->setWidth(48);
     selectButtonIcon->setHeight(16);
     selectButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    selectButtonIcon->setImageFromFile("app0:resources/images/select_button.png");
+    selectButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/select_button.png");
     selectButtonIcon->setMarginBottom(2);
     historyContainer->addView(selectButtonIcon);
 
@@ -116,7 +116,7 @@ SearchTab::SearchTab() {
     historyIcon->setWidth(24);
     historyIcon->setHeight(24);
     historyIcon->setScalingType(brls::ImageScalingType::FIT);
-    historyIcon->setImageFromFile("app0:resources/icons/history.png");
+    historyIcon->setImageFromFile(RESOURCE_PREFIX "icons/history.png");
     m_historyBtn->addView(historyIcon);
 
     m_historyBtn->registerClickAction([this](brls::View* view) {
@@ -148,7 +148,7 @@ SearchTab::SearchTab() {
     startButtonIcon->setWidth(64);
     startButtonIcon->setHeight(16);
     startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
     startButtonIcon->setMarginBottom(2);
     searchContainer->addView(startButtonIcon);
 
@@ -163,7 +163,7 @@ SearchTab::SearchTab() {
     searchIcon->setWidth(24);
     searchIcon->setHeight(24);
     searchIcon->setScalingType(brls::ImageScalingType::FIT);
-    searchIcon->setImageFromFile("app0:resources/icons/search.png");
+    searchIcon->setImageFromFile(RESOURCE_PREFIX "icons/search.png");
     m_globalSearchBtn->addView(searchIcon);
 
     m_globalSearchBtn->registerClickAction([this](brls::View* view) {
@@ -757,7 +757,7 @@ void SearchTab::showSources() {
     m_latestBtn->setVisibility(brls::Visibility::GONE);
     m_backBtn->setVisibility(brls::Visibility::GONE);
     // Restore filter icon on header button
-    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
+    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile(RESOURCE_PREFIX "icons/tag.png");
     m_tagFilterBtn->setBackgroundColor(Application::getInstance().getButtonColor());
     // Hide the filter button on the sources page (it does nothing here)
     m_filterBtnContainer->setVisibility(brls::Visibility::GONE);
@@ -2848,7 +2848,7 @@ void SearchTab::handleBackNavigation() {
                     m_latestBtn->setVisibility(source.supportsLatest ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
                     m_backBtn->setVisibility(brls::Visibility::VISIBLE);
                     // Restore filter icon on header button
-                    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile("app0:resources/icons/tag.png");
+                    if (m_tagFilterIcon) m_tagFilterIcon->setImageFromFile(RESOURCE_PREFIX "icons/tag.png");
 
                     // Restore search/history buttons and filter button for source browsing
                     m_buttonContainer->setVisibility(brls::Visibility::VISIBLE);

--- a/src/view/source_browse_tab.cpp
+++ b/src/view/source_browse_tab.cpp
@@ -87,7 +87,7 @@ SourceBrowseTab::SourceBrowseTab(const Source& source)
     startButtonIcon->setWidth(64);
     startButtonIcon->setHeight(16);
     startButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    startButtonIcon->setImageFromFile("app0:resources/images/start_button.png");
+    startButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
     startButtonIcon->setMarginBottom(2);
     searchContainer->addView(startButtonIcon);
 

--- a/src/view/tracking_search_view.cpp
+++ b/src/view/tracking_search_view.cpp
@@ -155,12 +155,12 @@ void TrackingSearchResultCell::loadCoverImage() {
 
     if (m_result.coverUrl.empty()) {
         // Set placeholder image for missing covers
-        m_coverImage->setImageFromFile("app0:resources/icons/book-open-page-variant.png");
+        m_coverImage->setImageFromFile(RESOURCE_PREFIX "icons/book-open-page-variant.png");
         return;
     }
 
     // Set loading placeholder while image loads
-    m_coverImage->setImageFromFile("app0:resources/icons/book-open-page-variant.png");
+    m_coverImage->setImageFromFile(RESOURCE_PREFIX "icons/book-open-page-variant.png");
 
     // Tracker cover URLs are external URLs (MAL, AniList CDN, etc.)
     // Proxy them through the Suwayomi server to avoid HTTPS/CORS issues on Vita


### PR DESCRIPTION
Hardens the CI: builds libromfs-generator before the Android CMake fallback, adds X11/DBus/libwebp dev bundles for deb/aur, aligns dispatch inputs and release gating with switchfin, and fixes a Windows mkdir and flatpak linker issue.

---
_Generated by [Claude Code](https://claude.ai/code)_