### PR TITLE
Fix Windows desktop packaging to include runtime DLLs

### DIFF
--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -742,12 +742,31 @@ jobs:
           cmake --build build
       - name: Collect runtime DLLs
         run: |
-          ldd build/VitaSuwayomi.exe | awk '/=>/ {print $3}' | while read -r dep; do
-            [ -f "$dep" ] || continue
-            case "$dep" in
-              /c/Windows/*) continue ;;
+          objdump -p build/VitaSuwayomi.exe | awk '/DLL Name:/{print $3}' | sort -u | while read -r dll; do
+            [ -n "$dll" ] || continue
+            case "$dll" in
+              api-ms-win-*|ext-ms-*|KERNEL32.dll|USER32.dll|GDI32.dll|WINMM.dll|IMM32.dll|OLE32.dll|OLEAUT32.dll|VERSION.dll|SHELL32.dll|ADVAPI32.dll|WS2_32.dll|bcrypt.dll|ntdll.dll)
+                continue
+                ;;
             esac
-            cp -n "$dep" build/
+
+            found=""
+            IFS=':' read -ra path_entries <<< "$PATH"
+            for dir in "${path_entries[@]}"; do
+              candidate="$dir/$dll"
+              if [ -f "$candidate" ]; then
+                case "$candidate" in
+                  /c/Windows/*) break ;;
+                esac
+                cp -n "$candidate" build/
+                found=1
+                break
+              fi
+            done
+
+            if [ -z "$found" ]; then
+              echo "warning: could not locate $dll in PATH"
+            fi
           done
       - name: Upload mingw artifact
         uses: actions/upload-artifact@v4
@@ -756,6 +775,7 @@ jobs:
           path: |
             build/VitaSuwayomi.exe
             build/*.dll
+            build/**/*.dll
             build/resources/
 
   # ───────────────────────────────────────────────

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -746,6 +746,7 @@ jobs:
           name: VitaSuwayomi-mingw-${{ matrix.arch }}-${{ github.run_number }}
           path: |
             build/VitaSuwayomi.exe
+            build/*.dll
             build/resources/
 
   # ───────────────────────────────────────────────

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -740,6 +740,15 @@ jobs:
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON
           cmake --build build
+      - name: Collect runtime DLLs
+        run: |
+          ldd build/VitaSuwayomi.exe | awk '/=>/ {print $3}' | while read -r dep; do
+            [ -f "$dep" ] || continue
+            case "$dep" in
+              /c/Windows/*) continue ;;
+            esac
+            cp -n "$dep" build/
+          done
       - name: Upload mingw artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,10 +396,10 @@ elseif(PLATFORM_DESKTOP)
     # This makes local runs and CI artifacts self-contained.
     if(WIN32)
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>
-                $<TARGET_FILE_DIR:${PROJECT_NAME}>
-            COMMAND_EXPAND_LISTS
+            COMMAND ${CMAKE_COMMAND}
+                -Ddlls="$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>"
+                -Ddest="$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_runtime_dlls.cmake"
             COMMENT "Copying runtime DLL dependencies for Windows build"
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ elseif(PLATFORM_DESKTOP)
     if(WIN32)
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND}
-                -Ddlls="$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>"
+                -Dexe="$<TARGET_FILE:${PROJECT_NAME}>"
                 -Ddest="$<TARGET_FILE_DIR:${PROJECT_NAME}>"
                 -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_runtime_dlls.cmake"
             COMMENT "Copying runtime DLL dependencies for Windows build"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,4 +391,16 @@ elseif(PLATFORM_DESKTOP)
             $<TARGET_FILE_DIR:${PROJECT_NAME}>/resources
         COMMENT "Copying resources for desktop build"
     )
+
+    # On Windows, also copy runtime DLL dependencies next to the executable.
+    # This makes local runs and CI artifacts self-contained.
+    if(WIN32)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>
+                $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            COMMAND_EXPAND_LISTS
+            COMMENT "Copying runtime DLL dependencies for Windows build"
+        )
+    endif()
 endif()

--- a/cmake/copy_runtime_dlls.cmake
+++ b/cmake/copy_runtime_dlls.cmake
@@ -1,13 +1,34 @@
-if(NOT DEFINED dlls OR "${dlls}" STREQUAL "")
-    message(STATUS "No runtime DLL dependencies detected for target")
-    return()
+if(NOT DEFINED exe OR "${exe}" STREQUAL "")
+    message(FATAL_ERROR "Executable path for runtime dependency scan is not set")
+endif()
+
+if(NOT EXISTS "${exe}")
+    message(FATAL_ERROR "Executable does not exist: ${exe}")
 endif()
 
 if(NOT DEFINED dest OR "${dest}" STREQUAL "")
     message(FATAL_ERROR "Destination directory for runtime DLL copy is not set")
 endif()
 
+file(GET_RUNTIME_DEPENDENCIES
+    EXECUTABLES "${exe}"
+    RESOLVED_DEPENDENCIES_VAR resolved_deps
+    UNRESOLVED_DEPENDENCIES_VAR unresolved_deps
+    PRE_EXCLUDE_REGEXES "api-ms-win-.*" "ext-ms-.*"
+    POST_EXCLUDE_REGEXES ".*/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/[Ss]ystem32/.*"
+    DIRECTORIES "$ENV{PATH}"
+)
+
+if(unresolved_deps)
+    message(STATUS "Unresolved runtime dependencies: ${unresolved_deps}")
+endif()
+
+if(NOT resolved_deps)
+    message(STATUS "No runtime DLL dependencies detected for target")
+    return()
+endif()
+
 execute_process(
-    COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${dlls} "${dest}"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${resolved_deps} "${dest}"
     COMMAND_ERROR_IS_FATAL ANY
 )

--- a/cmake/copy_runtime_dlls.cmake
+++ b/cmake/copy_runtime_dlls.cmake
@@ -1,0 +1,13 @@
+if(NOT DEFINED dlls OR "${dlls}" STREQUAL "")
+    message(STATUS "No runtime DLL dependencies detected for target")
+    return()
+endif()
+
+if(NOT DEFINED dest OR "${dest}" STREQUAL "")
+    message(FATAL_ERROR "Destination directory for runtime DLL copy is not set")
+endif()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${dlls} "${dest}"
+    COMMAND_ERROR_IS_FATAL ANY
+)


### PR DESCRIPTION
Fixes Windows desktop packaging to include the runtime DLLs, guarding the copy step when the list is empty and making DLL collection robust for both local and CI builds.

---
_Generated by [Claude Code](https://claude.ai/code)_