### PR TITLE
ci: bundle MinGW runtime DLLs in Windows artifacts

### DIFF
--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -525,6 +525,30 @@ jobs:
             -DZLIB_USE_STATIC_LIBS=ON \
             -DUSE_SYSTEM_GLFW=ON
           cmake --build build
+      - name: Bundle runtime DLLs
+        run: |
+          EXE="build/VitaSuwayomi.exe"
+          DLL_DIR="${MINGW_PREFIX}/bin"
+          if [ ! -f "$EXE" ]; then
+            echo "Expected binary not found: $EXE"
+            exit 1
+          fi
+          if [ ! -d "$DLL_DIR" ]; then
+            echo "Expected DLL directory not found: $DLL_DIR"
+            exit 1
+          fi
+
+          mapfile -t dlls < <(objdump -p "$EXE" | awk '/DLL Name:/{print $3}' | sort -u)
+          for dll in "${dlls[@]}"; do
+            candidate="$DLL_DIR/$dll"
+            if [ -f "$candidate" ]; then
+              cp -f "$candidate" build/
+              echo "Bundled $dll"
+            fi
+          done
+
+          echo "DLLs bundled into build/:"
+          ls -1 build/*.dll
       - name: Upload Windows binary
         uses: actions/upload-artifact@v4
         with:
@@ -741,6 +765,30 @@ jobs:
         run: |
           cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON
           cmake --build build
+      - name: Bundle runtime DLLs
+        run: |
+          EXE="build/VitaSuwayomi.exe"
+          DLL_DIR="${MINGW_PREFIX}/bin"
+          if [ ! -f "$EXE" ]; then
+            echo "Expected binary not found: $EXE"
+            exit 1
+          fi
+          if [ ! -d "$DLL_DIR" ]; then
+            echo "Expected DLL directory not found: $DLL_DIR"
+            exit 1
+          fi
+
+          mapfile -t dlls < <(objdump -p "$EXE" | awk '/DLL Name:/{print $3}' | sort -u)
+          for dll in "${dlls[@]}"; do
+            candidate="$DLL_DIR/$dll"
+            if [ -f "$candidate" ]; then
+              cp -f "$candidate" build/
+              echo "Bundled $dll"
+            fi
+          done
+
+          echo "DLLs bundled into build/:"
+          ls -1 build/*.dll
       - name: Upload mingw artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -538,13 +538,29 @@ jobs:
             exit 1
           fi
 
-          mapfile -t dlls < <(objdump -p "$EXE" | awk '/DLL Name:/{print $3}' | sort -u)
-          for dll in "${dlls[@]}"; do
-            candidate="$DLL_DIR/$dll"
-            if [ -f "$candidate" ]; then
-              cp -f "$candidate" build/
-              echo "Bundled $dll"
-            fi
+          queue=("$EXE")
+          declare -A scanned
+          declare -A bundled
+          while [ ${#queue[@]} -gt 0 ]; do
+            current="${queue[0]}"
+            queue=("${queue[@]:1}")
+            scanned["$current"]=1
+
+            mapfile -t dlls < <(objdump -p "$current" | awk '/DLL Name:/{print $3}' | sort -u)
+            for dll in "${dlls[@]}"; do
+              candidate="$DLL_DIR/$dll"
+              target="build/$dll"
+              if [ -f "$candidate" ]; then
+                if [ -z "${bundled[$dll]+x}" ]; then
+                  cp -f "$candidate" "$target"
+                  bundled["$dll"]=1
+                  echo "Bundled $dll (from $(basename "$current"))"
+                fi
+                if [ -z "${scanned[$target]+x}" ]; then
+                  queue+=("$target")
+                fi
+              fi
+            done
           done
 
           echo "DLLs bundled into build/:"
@@ -778,13 +794,29 @@ jobs:
             exit 1
           fi
 
-          mapfile -t dlls < <(objdump -p "$EXE" | awk '/DLL Name:/{print $3}' | sort -u)
-          for dll in "${dlls[@]}"; do
-            candidate="$DLL_DIR/$dll"
-            if [ -f "$candidate" ]; then
-              cp -f "$candidate" build/
-              echo "Bundled $dll"
-            fi
+          queue=("$EXE")
+          declare -A scanned
+          declare -A bundled
+          while [ ${#queue[@]} -gt 0 ]; do
+            current="${queue[0]}"
+            queue=("${queue[@]:1}")
+            scanned["$current"]=1
+
+            mapfile -t dlls < <(objdump -p "$current" | awk '/DLL Name:/{print $3}' | sort -u)
+            for dll in "${dlls[@]}"; do
+              candidate="$DLL_DIR/$dll"
+              target="build/$dll"
+              if [ -f "$candidate" ]; then
+                if [ -z "${bundled[$dll]+x}" ]; then
+                  cp -f "$candidate" "$target"
+                  bundled["$dll"]=1
+                  echo "Bundled $dll (from $(basename "$current"))"
+                fi
+                if [ -z "${scanned[$target]+x}" ]; then
+                  queue+=("$target")
+                fi
+              fi
+            done
           done
 
           echo "DLLs bundled into build/:"


### PR DESCRIPTION
Bundles the MinGW runtime DLLs — including transitive dependencies — in the Windows CI artifacts.

---
_Generated by [Claude Code](https://claude.ai/code)_