### PR TITLE
ci: build Windows artifacts with GLES2 backend

### DIFF
--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -524,7 +524,7 @@ jobs:
             -DWIN32_TERMINAL=OFF \
             -DZLIB_USE_STATIC_LIBS=ON \
             -DUSE_SYSTEM_GLFW=ON \
-            -DUSE_GLES2=ON
+            -DUSE_D3D11=ON
           cmake --build build
       - name: Bundle runtime DLLs
         run: |
@@ -780,7 +780,7 @@ jobs:
           pacman -U --noconfirm *.pkg.tar.zst
       - name: Build
         run: |
-          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON -DUSE_GLES2=ON
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON -DUSE_D3D11=ON
           cmake --build build
       - name: Bundle runtime DLLs
         run: |

--- a/.github/workflows/build-multi-platform(1).yml
+++ b/.github/workflows/build-multi-platform(1).yml
@@ -523,8 +523,49 @@ jobs:
             -DPLATFORM_DESKTOP=ON \
             -DWIN32_TERMINAL=OFF \
             -DZLIB_USE_STATIC_LIBS=ON \
-            -DUSE_SYSTEM_GLFW=ON
+            -DUSE_SYSTEM_GLFW=ON \
+            -DUSE_GLES2=ON
           cmake --build build
+      - name: Bundle runtime DLLs
+        run: |
+          EXE="build/VitaSuwayomi.exe"
+          DLL_DIR="${MINGW_PREFIX}/bin"
+          if [ ! -f "$EXE" ]; then
+            echo "Expected binary not found: $EXE"
+            exit 1
+          fi
+          if [ ! -d "$DLL_DIR" ]; then
+            echo "Expected DLL directory not found: $DLL_DIR"
+            exit 1
+          fi
+
+          queue=("$EXE")
+          declare -A scanned
+          declare -A bundled
+          while [ ${#queue[@]} -gt 0 ]; do
+            current="${queue[0]}"
+            queue=("${queue[@]:1}")
+            scanned["$current"]=1
+
+            mapfile -t dlls < <(objdump -p "$current" | awk '/DLL Name:/{print $3}' | sort -u)
+            for dll in "${dlls[@]}"; do
+              candidate="$DLL_DIR/$dll"
+              target="build/$dll"
+              if [ -f "$candidate" ]; then
+                if [ -z "${bundled[$dll]+x}" ]; then
+                  cp -f "$candidate" "$target"
+                  bundled["$dll"]=1
+                  echo "Bundled $dll (from $(basename "$current"))"
+                fi
+                if [ -z "${scanned[$target]+x}" ]; then
+                  queue+=("$target")
+                fi
+              fi
+            done
+          done
+
+          echo "DLLs bundled into build/:"
+          ls -1 build/*.dll
       - name: Upload Windows binary
         uses: actions/upload-artifact@v4
         with:
@@ -739,8 +780,48 @@ jobs:
           pacman -U --noconfirm *.pkg.tar.zst
       - name: Build
         run: |
-          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON
+          cmake -B build -G Ninja -DPLATFORM_DESKTOP=ON -DUSE_SYSTEM_GLFW=ON -DUSE_GLES2=ON
           cmake --build build
+      - name: Bundle runtime DLLs
+        run: |
+          EXE="build/VitaSuwayomi.exe"
+          DLL_DIR="${MINGW_PREFIX}/bin"
+          if [ ! -f "$EXE" ]; then
+            echo "Expected binary not found: $EXE"
+            exit 1
+          fi
+          if [ ! -d "$DLL_DIR" ]; then
+            echo "Expected DLL directory not found: $DLL_DIR"
+            exit 1
+          fi
+
+          queue=("$EXE")
+          declare -A scanned
+          declare -A bundled
+          while [ ${#queue[@]} -gt 0 ]; do
+            current="${queue[0]}"
+            queue=("${queue[@]:1}")
+            scanned["$current"]=1
+
+            mapfile -t dlls < <(objdump -p "$current" | awk '/DLL Name:/{print $3}' | sort -u)
+            for dll in "${dlls[@]}"; do
+              candidate="$DLL_DIR/$dll"
+              target="build/$dll"
+              if [ -f "$candidate" ]; then
+                if [ -z "${bundled[$dll]+x}" ]; then
+                  cp -f "$candidate" "$target"
+                  bundled["$dll"]=1
+                  echo "Bundled $dll (from $(basename "$current"))"
+                fi
+                if [ -z "${scanned[$target]+x}" ]; then
+                  queue+=("$target")
+                fi
+              fi
+            done
+          done
+
+          echo "DLLs bundled into build/:"
+          ls -1 build/*.dll
       - name: Upload mingw artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Switches the Windows CI artifacts to the D3D11 backend (after trying GLES2).

---
_Generated by [Claude Code](https://claude.ai/code)_