### PR TITLE
Fix Android build by removing unsupported Label padding call

### DIFF
--- a/src/activity/login_activity.cpp
+++ b/src/activity/login_activity.cpp
@@ -23,7 +23,6 @@ brls::Label* makeInteractiveLabel(const std::string& text) {
     label->setMarginBottom(15);
     label->setBackgroundColor(nvgRGBA(255, 255, 255, 18));
     label->setCornerRadius(6);
-    label->setPadding(12, 10, 12, 10);
     return label;
 }
 


### PR DESCRIPTION
Fix Android build by removing unsupported Label padding call

---
_Generated by [Claude Code](https://claude.ai/code)_