### PR TITLE
Restore title overlay on MangaItemCell

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -1,8 +1,9 @@
 /**
  * VitaSuwayomi - Manga Item Cell
  *
- * Minimal focusable cell with a cover image. No title/badge overlays —
- * just a rounded card that shows the manga cover.
+ * Focusable cell with cover image and a title overlay at the bottom.
+ * Title is drawn directly via NanoVG to avoid per-cell brls::Label
+ * frame() traversals on every scroll frame.
  */
 
 #pragma once
@@ -10,6 +11,7 @@
 #include <borealis.hpp>
 #include "app/suwayomi_client.hpp"
 #include <memory>
+#include <string>
 
 namespace vitasuwayomi {
 
@@ -20,7 +22,7 @@ public:
 
     void setManga(const Manga& manga);
     void setMangaDeferred(const Manga& manga) { setManga(manga); }
-    void updateMangaData(const Manga& manga) { m_manga = manga; }
+    void updateMangaData(const Manga& manga) { m_manga = manga; m_title = manga.title; }
 
     void loadThumbnailIfNeeded();
     void unloadThumbnail();
@@ -29,7 +31,7 @@ public:
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
-    void setCompactMode(bool) {}
+    void setCompactMode(bool compact) { m_showTitle = !compact; }
     void setListMode(bool) {}
     void setListRowSize(int) {}
     void setGridColumns(int) {}
@@ -44,6 +46,9 @@ public:
 
     static brls::View* create() { return new MangaItemCell(); }
 
+    void draw(NVGcontext* vg, float x, float y, float width, float height,
+              brls::Style style, brls::FrameContext* ctx) override;
+
 protected:
     void onFocusGained() override;
     void onFocusLost() override;
@@ -52,10 +57,12 @@ private:
     void loadThumbnail();
 
     Manga m_manga;
+    std::string m_title;
     brls::Image* m_thumbnailImage = nullptr;
     bool m_thumbnailLoaded = false;
     bool m_pressed = false;
     bool m_selected = false;
+    bool m_showTitle = true;
 
     // Shared flag so in-flight ImageLoader callbacks skip writing to us
     // after this cell has been destroyed.

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -74,6 +74,7 @@ MangaItemCell::~MangaItemCell() {
 
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
+    m_title = manga.title;
     m_thumbnailLoaded = false;
 }
 
@@ -124,6 +125,42 @@ void MangaItemCell::loadThumbnail() {
     }
 
     ImageLoader::loadAsync(url, nullptr, m_thumbnailImage, m_alive);
+}
+
+void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
+                         brls::Style style, brls::FrameContext* ctx) {
+    // Draw the cover image (child view)
+    brls::Box::draw(vg, x, y, width, height, style, ctx);
+
+    if (!m_showTitle || m_title.empty()) return;
+
+    // --- Flat-rendered title overlay ---
+    // Drawn directly via NanoVG instead of a brls::Label child so we don't
+    // pay per-cell frame() overhead each draw.
+    constexpr float kPadSide = 5.0f;
+    constexpr float kPadV = 4.0f;
+    constexpr float kFontSize = 13.0f;
+    constexpr float kOverlayH = 22.0f;
+
+    float overlayY = y + height - kOverlayH;
+
+    // Semi-transparent dark overlay for text legibility
+    nvgBeginPath(vg);
+    nvgRect(vg, x, overlayY, width, kOverlayH);
+    nvgFillColor(vg, nvgRGBA(0, 0, 0, 170));
+    nvgFill(vg);
+
+    nvgFontFace(vg, "regular");
+    nvgFontSize(vg, kFontSize);
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+    nvgFillColor(vg, nvgRGBA(255, 255, 255, 235));
+
+    // Clip so long titles truncate cleanly to the cell width
+    nvgSave(vg);
+    nvgIntersectScissor(vg, x + kPadSide, overlayY, width - kPadSide * 2.0f, kOverlayH);
+    nvgText(vg, x + kPadSide, overlayY + kOverlayH * 0.5f - kPadV * 0.25f,
+            m_title.c_str(), nullptr);
+    nvgRestore(vg);
 }
 
 void MangaItemCell::setPressed(bool pressed) {


### PR DESCRIPTION
Restore title overlay on MangaItemCell

Adds a single-line title strip at the bottom of each cover, drawn
directly via NanoVG in the cell's draw() override (not as a
brls::Label child), so per-cell frame() overhead stays flat.

A ~22px dark translucent bar sits above the cover's bottom edge with
the manga title at 13pt white text, scissor-clipped so long titles
truncate cleanly to the cell width without per-frame word wrapping.
setCompactMode(true) hides the overlay for cover-only layouts.

---
_Generated by [Claude Code](https://claude.ai/code)_