### PR TITLE
Use brls::Label title box in manga item cell

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -1,9 +1,7 @@
 /**
  * VitaSuwayomi - Manga Item Cell
  *
- * Focusable cell with cover image and a title overlay at the bottom.
- * Title is drawn directly via NanoVG to avoid per-cell brls::Label
- * frame() traversals on every scroll frame.
+ * Focusable cell with cover image and a title box at the bottom.
  */
 
 #pragma once
@@ -22,7 +20,7 @@ public:
 
     void setManga(const Manga& manga);
     void setMangaDeferred(const Manga& manga) { setManga(manga); }
-    void updateMangaData(const Manga& manga) { m_manga = manga; m_title = manga.title; }
+    void updateMangaData(const Manga& manga);
 
     void loadThumbnailIfNeeded();
     void unloadThumbnail();
@@ -46,9 +44,7 @@ public:
 
     static brls::View* create() { return new MangaItemCell(); }
 
-    // When false, draw() skips the per-cell title text. Used by
-    // RecyclingGrid to suppress title rendering during fast scrolls
-    // (each 2-line nvgText per cell across 24+ cells costs ~14ms on Vita).
+    // When false, hide title views during fast scrolling.
     static void setTitlesEnabled(bool enabled);
 
     void draw(NVGcontext* vg, float x, float y, float width, float height,
@@ -63,11 +59,9 @@ private:
 
     Manga m_manga;
     std::string m_title;
-    // Cached pre-wrapped title lines (up to 2) so draw() doesn't need to
-    // re-measure text per frame. Recomputed only when title or width changes.
-    std::string m_line1;
-    float m_wrappedForWidth = -1.0f;
     brls::Image* m_thumbnailImage = nullptr;
+    brls::Box* m_titleBox = nullptr;
+    brls::Label* m_titleLabel = nullptr;
     bool m_thumbnailLoaded = false;
     bool m_pressed = false;
     bool m_selected = false;

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -29,7 +29,7 @@ public:
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
-    void setCompactMode(bool compact) { m_showTitle = !compact; }
+    void setCompactMode(bool compact);
     void setListMode(bool) {}
     void setListRowSize(int) {}
     void setGridColumns(int) {}
@@ -56,6 +56,7 @@ protected:
 
 private:
     void loadThumbnail();
+    void syncTitleVisibility();
 
     Manga m_manga;
     std::string m_title;
@@ -66,6 +67,7 @@ private:
     bool m_pressed = false;
     bool m_selected = false;
     bool m_showTitle = true;
+    bool m_titleVisible = true;
 
     // Shared flag so in-flight ImageLoader callbacks skip writing to us
     // after this cell has been destroyed.

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -21,6 +21,14 @@ void MangaItemCell::setTitlesEnabled(bool enabled) {
     s_titlesEnabled = enabled;
 }
 
+void MangaItemCell::syncTitleVisibility() {
+    bool shouldShow = m_showTitle && s_titlesEnabled;
+    if (m_titleBox && m_titleVisible != shouldShow) {
+        m_titleVisible = shouldShow;
+        m_titleBox->setVisibility(shouldShow ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    }
+}
+
 static void loadLocalCoverToImage(brls::Image* image, const std::string& localPath) {
     if (localPath.empty() || !image) return;
 
@@ -88,7 +96,8 @@ MangaItemCell::MangaItemCell() {
     m_titleLabel->setFontSize(10);
     m_titleLabel->setTextColor(nvgRGBA(235, 235, 235, 255));
     m_titleBox->addView(m_titleLabel);
-    m_titleBox->setVisibility((m_showTitle && s_titlesEnabled) ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
+    m_titleVisible = !(m_showTitle && s_titlesEnabled);
+    syncTitleVisibility();
 }
 
 MangaItemCell::~MangaItemCell() {
@@ -112,6 +121,11 @@ void MangaItemCell::updateMangaData(const Manga& manga) {
     if (m_titleLabel) {
         m_titleLabel->setText(m_title);
     }
+}
+
+void MangaItemCell::setCompactMode(bool compact) {
+    m_showTitle = !compact;
+    syncTitleVisibility();
 }
 
 void MangaItemCell::loadThumbnailIfNeeded() {
@@ -165,10 +179,7 @@ void MangaItemCell::loadThumbnail() {
 
 void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
-    if (m_titleBox) {
-        m_titleBox->setVisibility((m_showTitle && s_titlesEnabled) ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
-    }
-
+    syncTitleVisibility();
     brls::Box::draw(vg, x, y, width, height, style, ctx);
 }
 

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -1,12 +1,11 @@
 /**
  * VitaSuwayomi - Manga Item Cell implementation
- * Minimal cell: rounded card with a cover image.
+ * Minimal cell: rounded card with a cover image and title label.
  */
 
 #include "view/manga_item_cell.hpp"
 #include "app/suwayomi_client.hpp"
 #include "utils/image_loader.hpp"
-#include <cmath>
 #include <fstream>
 #include <vector>
 
@@ -62,9 +61,7 @@ MangaItemCell::MangaItemCell() {
     this->setBackgroundColor(nvgRGB(40, 40, 48));
     this->setClipsToBounds(true);
 
-    // Cover fills the cell minus a 20px strip at the bottom for a single
-    // title line (drawn flat via NanoVG in draw()). Going to 1 line cuts
-    // per-frame text cost in half (~7ms saved on Vita at 24 visible cells).
+    // Cover fills the cell minus a 20px strip at the bottom for title.
     m_thumbnailImage = new brls::Image();
     m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
     m_thumbnailImage->setCornerRadius(4.0f);
@@ -74,6 +71,24 @@ MangaItemCell::MangaItemCell() {
     m_thumbnailImage->setPositionRight(0);
     m_thumbnailImage->setPositionBottom(20);
     this->addView(m_thumbnailImage);
+
+    m_titleBox = new brls::Box();
+    m_titleBox->setPositionType(brls::PositionType::ABSOLUTE);
+    m_titleBox->setPositionLeft(0);
+    m_titleBox->setPositionRight(0);
+    m_titleBox->setPositionBottom(0);
+    m_titleBox->setHeight(20);
+    m_titleBox->setPaddingLeft(5);
+    m_titleBox->setPaddingRight(5);
+    m_titleBox->setPaddingTop(4);
+    m_titleBox->setBackgroundColor(nvgRGBA(0, 0, 0, 160));
+    this->addView(m_titleBox);
+
+    m_titleLabel = new brls::Label();
+    m_titleLabel->setFontSize(10);
+    m_titleLabel->setTextColor(nvgRGBA(235, 235, 235, 255));
+    m_titleBox->addView(m_titleLabel);
+    m_titleBox->setVisibility((m_showTitle && s_titlesEnabled) ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
 }
 
 MangaItemCell::~MangaItemCell() {
@@ -85,9 +100,18 @@ MangaItemCell::~MangaItemCell() {
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
     m_title = manga.title;
-    m_line1.clear();
-    m_wrappedForWidth = -1.0f;
+    if (m_titleLabel) {
+        m_titleLabel->setText(m_title);
+    }
     m_thumbnailLoaded = false;
+}
+
+void MangaItemCell::updateMangaData(const Manga& manga) {
+    m_manga = manga;
+    m_title = manga.title;
+    if (m_titleLabel) {
+        m_titleLabel->setText(m_title);
+    }
 }
 
 void MangaItemCell::loadThumbnailIfNeeded() {
@@ -139,76 +163,13 @@ void MangaItemCell::loadThumbnail() {
     ImageLoader::loadAsync(url, nullptr, m_thumbnailImage, m_alive);
 }
 
-// Binary-search the largest byte prefix of `str` (len `len`) that fits
-// into `maxW` when measured through nvgTextBounds. Returns the byte
-// count.
-static int fitPrefix(NVGcontext* vg, const char* str, int len, float maxW) {
-    float bounds[4];
-    int lo = 0, hi = len, best = 0;
-    while (lo <= hi) {
-        int mid = (lo + hi) / 2;
-        nvgTextBounds(vg, 0, 0, str, str + mid, bounds);
-        float w = bounds[2] - bounds[0];
-        if (w <= maxW) {
-            best = mid;
-            lo = mid + 1;
-        } else {
-            hi = mid - 1;
-        }
-    }
-    return best;
-}
-
 void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
                          brls::Style style, brls::FrameContext* ctx) {
-    // Draw the cover image (child view)
-    brls::Box::draw(vg, x, y, width, height, style, ctx);
-
-    if (!m_showTitle || m_title.empty() || !s_titlesEnabled) return;
-
-    // --- Flat-rendered single-line title below the cover ---
-    // One line keeps text cost per cell to a single nvgText call; on
-    // Vita with 24 visible cells this is ~7ms/frame vs ~14ms for 2 lines.
-    constexpr float kPadSide = 5.0f;
-    constexpr float kFontSize = 10.0f;
-    constexpr float kTitleAreaH = 20.0f;  // matches thumbnail positionBottom
-    constexpr float kTitleTopPad = 4.0f;
-
-    float textW = width - kPadSide * 2.0f;
-
-    nvgFontFace(vg, "regular");
-    nvgFontSize(vg, kFontSize);
-
-    // Re-wrap only when cell width changed or title was reassigned.
-    if (m_wrappedForWidth < 0.0f || std::fabs(m_wrappedForWidth - width) > 0.5f) {
-        m_wrappedForWidth = width;
-        m_line1.clear();
-
-        float bounds[4];
-        const char* s = m_title.c_str();
-        int len = static_cast<int>(m_title.size());
-
-        nvgTextBounds(vg, 0, 0, s, s + len, bounds);
-        float fullW = bounds[2] - bounds[0];
-
-        if (fullW <= textW) {
-            m_line1 = m_title;
-        } else {
-            // Truncate with trailing ellipsis
-            nvgTextBounds(vg, 0, 0, "\xE2\x80\xA6", nullptr, bounds);
-            float ellipsisW = bounds[2] - bounds[0];
-            int fit = fitPrefix(vg, s, len, textW - ellipsisW);
-            while (fit > 0 && s[fit - 1] == ' ') fit--;
-            m_line1.assign(s, fit);
-            m_line1.append("\xE2\x80\xA6");
-        }
+    if (m_titleBox) {
+        m_titleBox->setVisibility((m_showTitle && s_titlesEnabled) ? brls::Visibility::VISIBLE : brls::Visibility::GONE);
     }
 
-    float titleY = y + height - kTitleAreaH + kTitleTopPad;
-
-    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-    nvgFillColor(vg, nvgRGBA(235, 235, 235, 255));
-    nvgText(vg, x + kPadSide, titleY, m_line1.c_str(), nullptr);
+    brls::Box::draw(vg, x, y, width, height, style, ctx);
 }
 
 void MangaItemCell::setPressed(bool pressed) {


### PR DESCRIPTION
Uses a `brls::Label` title box in the manga item cell and avoids per-frame title-box visibility resets.

---
_Generated by [Claude Code](https://claude.ai/code)_