### PR TITLE
Strip MangaItemCell to empty focusable box for FPS baseline

### DIFF
--- a/.github/workflows/update-borealis.yml
+++ b/.github/workflows/update-borealis.yml
@@ -1,0 +1,53 @@
+name: Update borealis submodule
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Update borealis to latest switchfin branch
+        run: |
+          cd lib/borealis
+          git fetch origin switchfin
+          git checkout origin/switchfin
+          cd ../..
+          echo "NEW_SHA=$(cd lib/borealis && git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "OLD_SHA=$(git diff --submodule=short lib/borealis | head -1 | grep -oP '[a-f0-9]{7}(?=\.\.)')" >> $GITHUB_ENV
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet lib/borealis; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Submodule already up to date"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Submodule updated to ${{ env.NEW_SHA }}"
+          fi
+
+      - name: Create pull request
+        if: steps.check.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update borealis submodule to switchfin (${{ env.NEW_SHA }})"
+          title: "Update borealis submodule to switchfin (${{ env.NEW_SHA }})"
+          body: |
+            Automated update of `lib/borealis` submodule to the latest commit on the [`switchfin`](https://github.com/dragonflylee/borealis/tree/switchfin) branch.
+
+            Previous: ${{ env.OLD_SHA }}
+            Updated: ${{ env.NEW_SHA }}
+          branch: auto/update-borealis
+          delete-branch: true

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -1,9 +1,6 @@
 /**
  * VitaSuwayomi - Manga Item Cell
- *
- * Focusable cell with cover image and a title overlay at the bottom.
- * Title is drawn directly via NanoVG to avoid per-cell brls::Label
- * frame() traversals on every scroll frame.
+ * Empty focusable box - rebuild base for FPS testing.
  */
 
 #pragma once
@@ -22,16 +19,16 @@ public:
 
     void setManga(const Manga& manga);
     void setMangaDeferred(const Manga& manga) { setManga(manga); }
-    void updateMangaData(const Manga& manga) { m_manga = manga; m_title = manga.title; }
+    void updateMangaData(const Manga& manga) { m_manga = manga; }
 
-    void loadThumbnailIfNeeded();
-    void unloadThumbnail();
-    void resetThumbnailLoadState() { m_thumbnailLoaded = false; }
+    void loadThumbnailIfNeeded() {}
+    void unloadThumbnail() {}
+    void resetThumbnailLoadState() {}
 
-    bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
+    bool isThumbnailLoaded() const { return false; }
     const Manga& getManga() const { return m_manga; }
 
-    void setCompactMode(bool compact) { m_showTitle = !compact; }
+    void setCompactMode(bool) {}
     void setListMode(bool) {}
     void setListRowSize(int) {}
     void setGridColumns(int) {}
@@ -41,41 +38,16 @@ public:
     void setPressed(bool pressed);
     bool isPressed() const { return m_pressed; }
 
-    void setSelected(bool selected) { m_selected = selected; }
-    bool isSelected() const { return m_selected; }
+    void setSelected(bool) {}
+    bool isSelected() const { return false; }
 
     static brls::View* create() { return new MangaItemCell(); }
 
-    // When false, draw() skips the per-cell title text. Used by
-    // RecyclingGrid to suppress title rendering during fast scrolls
-    // (each 2-line nvgText per cell across 24+ cells costs ~14ms on Vita).
-    static void setTitlesEnabled(bool enabled);
-
-    void draw(NVGcontext* vg, float x, float y, float width, float height,
-              brls::Style style, brls::FrameContext* ctx) override;
-
-protected:
-    void onFocusGained() override;
-    void onFocusLost() override;
+    static void setTitlesEnabled(bool) {}
 
 private:
-    void loadThumbnail();
-
     Manga m_manga;
-    std::string m_title;
-    // Cached pre-wrapped title lines (up to 2) so draw() doesn't need to
-    // re-measure text per frame. Recomputed only when title or width changes.
-    std::string m_line1;
-    std::string m_line2;
-    float m_wrappedForWidth = -1.0f;
-    brls::Image* m_thumbnailImage = nullptr;
-    bool m_thumbnailLoaded = false;
     bool m_pressed = false;
-    bool m_selected = false;
-    bool m_showTitle = true;
-
-    // Shared flag so in-flight ImageLoader callbacks skip writing to us
-    // after this cell has been destroyed.
     std::shared_ptr<bool> m_alive;
 };
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -1,6 +1,6 @@
 /**
  * VitaSuwayomi - Recycling Grid
- * Efficient grid view with lazy loading for displaying manga items
+ * Efficient grid view for displaying manga items
  */
 
 #pragma once
@@ -84,11 +84,7 @@ public:
 
 private:
     void setupGrid();
-    void createRowRange(int startRow, int endRow);  // Create empty row skeletons [startRow, endRow)
-    // Populate up to `budget` remaining cells in `row`. Returns number of
-    // cells actually created this call. Default budget -1 = populate
-    // the entire row in one call.
-    int populateRow(int row, int budget = -1);
+    void createRowRange(int startRow, int endRow);
     void updateVisibleCells();
     void loadThumbnailsForScrollPosition();  // Scroll-position-based thumbnail loading
     void onItemClicked(int index);
@@ -114,10 +110,8 @@ private:
 
     brls::Box* m_contentBox = nullptr;
     std::vector<brls::Box*> m_rows;
-    std::vector<MangaItemCell*> m_cells;  // sparse: nullptr slots for rows not yet populated
-    std::vector<bool> m_rowPopulated;       // parallel to m_rows (true when count == row's cell count)
-    std::vector<int> m_rowPopulatedCount;   // parallel to m_rows (number of cells populated so far)
-    std::vector<int> m_rowHeights;          // parallel to m_rows (list mode varies per row)
+    std::vector<MangaItemCell*> m_cells;
+    std::vector<int> m_rowHeights;
 
     int m_columns = 6;
     int m_cellWidth = 140;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -1,78 +1,17 @@
 /**
  * VitaSuwayomi - Manga Item Cell implementation
- * Minimal cell: rounded card with a cover image.
+ * Empty focusable box - rebuild base for FPS testing.
  */
 
 #include "view/manga_item_cell.hpp"
-#include "app/suwayomi_client.hpp"
-#include "utils/image_loader.hpp"
-#include <cmath>
-#include <fstream>
-#include <vector>
-
-#ifdef __vita__
-#include <psp2/io/fcntl.h>
-#endif
 
 namespace vitasuwayomi {
 
-static bool s_titlesEnabled = true;
-
-void MangaItemCell::setTitlesEnabled(bool enabled) {
-    s_titlesEnabled = enabled;
-}
-
-static void loadLocalCoverToImage(brls::Image* image, const std::string& localPath) {
-    if (localPath.empty() || !image) return;
-
-#ifdef __vita__
-    SceUID fd = sceIoOpen(localPath.c_str(), SCE_O_RDONLY, 0);
-    if (fd >= 0) {
-        SceOff size = sceIoLseek(fd, 0, SCE_SEEK_END);
-        sceIoLseek(fd, 0, SCE_SEEK_SET);
-        if (size > 0 && size < 10 * 1024 * 1024) {
-            std::vector<uint8_t> data(size);
-            if (sceIoRead(fd, data.data(), size) == size) {
-                image->setImageFromMem(data.data(), data.size());
-            }
-        }
-        sceIoClose(fd);
-    }
-#else
-    std::ifstream file(localPath, std::ios::binary | std::ios::ate);
-    if (file.is_open()) {
-        std::streamsize size = file.tellg();
-        file.seekg(0, std::ios::beg);
-        if (size > 0 && size < 10 * 1024 * 1024) {
-            std::vector<uint8_t> data(size);
-            if (file.read(reinterpret_cast<char*>(data.data()), size)) {
-                image->setImageFromMem(data.data(), data.size());
-            }
-        }
-        file.close();
-    }
-#endif
-}
-
 MangaItemCell::MangaItemCell() {
     m_alive = std::make_shared<bool>(true);
-
     this->setFocusable(true);
     this->setCornerRadius(4.0f);
     this->setBackgroundColor(nvgRGB(40, 40, 48));
-    this->setClipsToBounds(true);
-
-    // Cover fills the cell minus a 36px strip at the bottom for the
-    // 2-line title area (drawn flat via NanoVG in draw()).
-    m_thumbnailImage = new brls::Image();
-    m_thumbnailImage->setScalingType(brls::ImageScalingType::FILL);
-    m_thumbnailImage->setCornerRadius(4.0f);
-    m_thumbnailImage->setPositionType(brls::PositionType::ABSOLUTE);
-    m_thumbnailImage->setPositionTop(0);
-    m_thumbnailImage->setPositionLeft(0);
-    m_thumbnailImage->setPositionRight(0);
-    m_thumbnailImage->setPositionBottom(36);
-    this->addView(m_thumbnailImage);
 }
 
 MangaItemCell::~MangaItemCell() {
@@ -83,174 +22,10 @@ MangaItemCell::~MangaItemCell() {
 
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
-    m_title = manga.title;
-    m_line1.clear();
-    m_line2.clear();
-    m_wrappedForWidth = -1.0f;
-    m_thumbnailLoaded = false;
-}
-
-void MangaItemCell::loadThumbnailIfNeeded() {
-    if (!m_thumbnailLoaded && m_manga.id > 0) {
-        loadThumbnail();
-    }
-}
-
-void MangaItemCell::unloadThumbnail() {
-    if (!m_thumbnailLoaded || !m_thumbnailImage) return;
-
-    static const unsigned char s_clearPixel[] = {
-        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 1, 0, 32, 0,
-        0, 0, 0, 0
-    };
-    m_thumbnailImage->setImageFromMem(s_clearPixel, sizeof(s_clearPixel));
-    m_thumbnailLoaded = false;
-}
-
-void MangaItemCell::loadThumbnail() {
-    if (!m_thumbnailImage || m_thumbnailLoaded) return;
-    m_thumbnailLoaded = true;
-
-    if (!m_manga.thumbnailUrl.empty() && m_manga.thumbnailUrl.find("ux0:") == 0) {
-        loadLocalCoverToImage(m_thumbnailImage, m_manga.thumbnailUrl);
-        return;
-    }
-
-    if (m_manga.id <= 0) return;
-
-    SuwayomiClient& client = SuwayomiClient::getInstance();
-    std::string url;
-
-    if (!m_manga.thumbnailUrl.empty()) {
-        if (m_manga.thumbnailUrl[0] == '/') {
-            url = client.getServerUrl();
-            while (!url.empty() && url.back() == '/') url.pop_back();
-            url += m_manga.thumbnailUrl;
-        } else if (m_manga.thumbnailUrl.find("http") == 0) {
-            url = m_manga.thumbnailUrl;
-        } else {
-            url = client.getMangaThumbnailUrl(m_manga.id);
-        }
-    } else {
-        url = client.getMangaThumbnailUrl(m_manga.id);
-    }
-
-    ImageLoader::loadAsync(url, nullptr, m_thumbnailImage, m_alive);
-}
-
-// Binary-search the largest byte prefix of `str` (len `len`) that fits
-// into `maxW` when measured through nvgTextBounds. Returns the byte
-// count.
-static int fitPrefix(NVGcontext* vg, const char* str, int len, float maxW) {
-    float bounds[4];
-    int lo = 0, hi = len, best = 0;
-    while (lo <= hi) {
-        int mid = (lo + hi) / 2;
-        nvgTextBounds(vg, 0, 0, str, str + mid, bounds);
-        float w = bounds[2] - bounds[0];
-        if (w <= maxW) {
-            best = mid;
-            lo = mid + 1;
-        } else {
-            hi = mid - 1;
-        }
-    }
-    return best;
-}
-
-void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
-                         brls::Style style, brls::FrameContext* ctx) {
-    // Draw the cover image (child view)
-    brls::Box::draw(vg, x, y, width, height, style, ctx);
-
-    if (!m_showTitle || m_title.empty() || !s_titlesEnabled) return;
-
-    // --- Flat-rendered title below the cover (2 lines) ---
-    // Cached line splits so the draw path is just 2 nvgText calls per
-    // cell with no per-frame measurement.
-    constexpr float kPadSide = 5.0f;
-    constexpr float kFontSize = 12.0f;
-    constexpr float kLineH = 16.0f;
-    constexpr float kTitleAreaH = 36.0f;  // matches thumbnail positionBottom
-    constexpr float kTitleTopPad = 2.0f;
-
-    float textW = width - kPadSide * 2.0f;
-
-    nvgFontFace(vg, "regular");
-    nvgFontSize(vg, kFontSize);
-
-    // Re-wrap only when cell width changed or title was reassigned.
-    if (m_wrappedForWidth < 0.0f || std::fabs(m_wrappedForWidth - width) > 0.5f) {
-        m_wrappedForWidth = width;
-        m_line1.clear();
-        m_line2.clear();
-
-        float bounds[4];
-        const char* s = m_title.c_str();
-        int len = static_cast<int>(m_title.size());
-
-        nvgTextBounds(vg, 0, 0, s, s + len, bounds);
-        float fullW = bounds[2] - bounds[0];
-
-        if (fullW <= textW) {
-            // Fits on one line
-            m_line1 = m_title;
-        } else {
-            // Find a word break inside the first-line fit range
-            int fit1 = fitPrefix(vg, s, len, textW);
-            int breakAt = fit1;
-            for (int i = fit1; i > 0; i--) {
-                if (s[i] == ' ') { breakAt = i; break; }
-            }
-            if (breakAt <= 0) breakAt = fit1;
-            m_line1.assign(s, breakAt);
-
-            int line2Start = breakAt;
-            while (line2Start < len && s[line2Start] == ' ') line2Start++;
-
-            int rest = len - line2Start;
-            const char* s2 = s + line2Start;
-            nvgTextBounds(vg, 0, 0, s2, s2 + rest, bounds);
-            float remW = bounds[2] - bounds[0];
-
-            if (remW <= textW) {
-                m_line2.assign(s2, rest);
-            } else {
-                // Truncate line 2 with ellipsis
-                nvgTextBounds(vg, 0, 0, "\xE2\x80\xA6", nullptr, bounds);
-                float ellipsisW = bounds[2] - bounds[0];
-                int fit2 = fitPrefix(vg, s2, rest, textW - ellipsisW);
-                while (fit2 > 0 && s2[fit2 - 1] == ' ') fit2--;
-                m_line2.assign(s2, fit2);
-                m_line2.append("\xE2\x80\xA6");
-            }
-        }
-    }
-
-    float titleY = y + height - kTitleAreaH + kTitleTopPad;
-
-    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-    nvgFillColor(vg, nvgRGBA(235, 235, 235, 255));
-    nvgText(vg, x + kPadSide, titleY, m_line1.c_str(), nullptr);
-    if (!m_line2.empty()) {
-        nvgText(vg, x + kPadSide, titleY + kLineH, m_line2.c_str(), nullptr);
-    }
 }
 
 void MangaItemCell::setPressed(bool pressed) {
     m_pressed = pressed;
-    this->setBackgroundColor(pressed ? nvgRGB(90, 90, 110) : nvgRGB(60, 60, 70));
-}
-
-void MangaItemCell::onFocusGained() {
-    brls::Box::onFocusGained();
-    this->setBackgroundColor(nvgRGB(100, 120, 160));
-}
-
-void MangaItemCell::onFocusLost() {
-    brls::Box::onFocusLost();
-    this->setBackgroundColor(m_pressed ? nvgRGB(90, 90, 110) : nvgRGB(60, 60, 70));
 }
 
 } // namespace vitasuwayomi

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -1,6 +1,7 @@
 /**
  * VitaSuwayomi - Recycling Grid implementation
- * Uses lazy loading to prevent UI freezes on large libraries
+ * Rows are fully populated at creation time to avoid per-cell yoga layout
+ * recalculations during scroll. Visibility culling hides off-screen rows.
  */
 
 #include "view/recycling_grid.hpp"
@@ -152,8 +153,6 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
             // Remove last row view (deletes the row box and its children)
             brls::Box* lastRow = m_rows.back();
             m_rows.pop_back();
-            if (!m_rowPopulated.empty()) m_rowPopulated.pop_back();
-            if (!m_rowPopulatedCount.empty()) m_rowPopulatedCount.pop_back();
             if (!m_rowHeights.empty()) m_rowHeights.pop_back();
             m_contentBox->removeView(lastRow);
 
@@ -348,8 +347,6 @@ void RecyclingGrid::clearViews() {
     m_items.clear();
     m_rows.clear();
     m_cells.clear();
-    m_rowPopulated.clear();
-    m_rowPopulatedCount.clear();
     m_rowHeights.clear();
     if (m_contentBox) {
         m_contentBox->clearViews();
@@ -379,8 +376,6 @@ void RecyclingGrid::setupGrid() {
     m_contentBox->clearViews();
     m_rows.clear();
     m_cells.clear();
-    m_rowPopulated.clear();
-    m_rowPopulatedCount.clear();
     m_rowHeights.clear();
     auto clearEnd = std::chrono::steady_clock::now();
     float clearMs = std::chrono::duration<float, std::milli>(clearEnd - clearStart).count();
@@ -399,91 +394,47 @@ void RecyclingGrid::setupGrid() {
 
     m_totalRowsNeeded = (m_items.size() + m_columns - 1) / m_columns;
 
-    // Lazy row population: create all row skeletons (empty boxes with the
-    // correct height) up front, then populate only the rows that are
-    // initially visible. The draw-path culler will populate additional rows
-    // as the user scrolls. This trades a small one-time O(n) skeleton cost
-    // for avoiding the N successive frame drops of the old incremental
-    // per-row build.
-    brls::Logger::info("RecyclingGrid: Building {} row skeletons for {} items",
+    brls::Logger::info("RecyclingGrid: Building {} rows for {} items",
                         m_totalRowsNeeded, m_items.size());
 
-    auto skeletonStart = std::chrono::steady_clock::now();
+    auto buildStart = std::chrono::steady_clock::now();
     createRowRange(0, m_totalRowsNeeded);
-    float skeletonMs = std::chrono::duration<float, std::milli>(
-        std::chrono::steady_clock::now() - skeletonStart).count();
-
-    int initialPopulate = std::min(3, m_totalRowsNeeded);
-    auto populateStart = std::chrono::steady_clock::now();
-    for (int row = 0; row < initialPopulate; row++) {
-        populateRow(row);
-    }
-    float populateMs = std::chrono::duration<float, std::milli>(
-        std::chrono::steady_clock::now() - populateStart).count();
+    float buildMs = std::chrono::duration<float, std::milli>(
+        std::chrono::steady_clock::now() - buildStart).count();
 
     float setupMs = std::chrono::duration<float, std::milli>(
         std::chrono::steady_clock::now() - setupStart).count();
-    brls::Logger::info("RecyclingGrid: setupGrid took {:.1f}ms (clear {:.1f}ms of {} cells, skeletons {:.1f}ms for {} rows, populate {:.1f}ms for {} rows)",
-                       setupMs, clearMs, oldCellCount, skeletonMs, m_totalRowsNeeded, populateMs, initialPopulate);
+    brls::Logger::info("RecyclingGrid: setupGrid took {:.1f}ms (clear {:.1f}ms of {} cells, build {:.1f}ms for {} rows)",
+                       setupMs, clearMs, oldCellCount, buildMs, m_totalRowsNeeded);
 }
 
 void RecyclingGrid::createRowRange(int startRow, int endRow) {
-    // Create only empty row skeletons here — no cells. Cells are created
-    // lazily by populateRow() when a row first becomes visible. Every row's
-    // m_items slots are pre-allocated in m_cells as nullptrs so index-based
-    // access stays valid across the grid's lifetime.
-
     for (int row = startRow; row < endRow; row++) {
         auto* rowBox = new brls::Box();
         rowBox->setAxis(brls::Axis::ROW);
         rowBox->setJustifyContent(brls::JustifyContent::FLEX_START);
         rowBox->setMarginBottom(m_rowMargin);
 
-        // Determine the item range this row will hold
         int startIdx = row * m_columns;
         int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
 
-        // For list mode, auto-adapt row height based on title width
         int rowHeight = m_cellHeight;
         if (m_listMode) {
             int maxWidthUnits = 0;
             for (int i = startIdx; i < endIdx; i++) {
-                // Estimate visual width in "width units" (1 unit ≈ 1 Latin char width).
-                // CJK / wide characters (multi-byte UTF-8) count as 2 units since
-                // they render roughly twice as wide as Latin characters.
                 const std::string& title = m_items[i].title;
                 int widthUnits = 0;
                 for (size_t j = 0; j < title.size(); ) {
                     unsigned char c = static_cast<unsigned char>(title[j]);
-                    if (c < 0x80) {
-                        // ASCII: 1 byte, 1 width unit
-                        widthUnits += 1;
-                        j += 1;
-                    } else if (c < 0xC0) {
-                        // Continuation byte (shouldn't appear here), skip
-                        j += 1;
-                    } else if (c < 0xE0) {
-                        // 2-byte sequence (Latin extended, etc): 1 width unit
-                        widthUnits += 1;
-                        j += 2;
-                    } else if (c < 0xF0) {
-                        // 3-byte sequence (CJK, Japanese, Korean, etc): 2 width units
-                        widthUnits += 2;
-                        j += 3;
-                    } else {
-                        // 4-byte sequence (emoji, etc): 2 width units
-                        widthUnits += 2;
-                        j += 4;
-                    }
+                    if (c < 0x80)      { widthUnits += 1; j += 1; }
+                    else if (c < 0xC0) { j += 1; }
+                    else if (c < 0xE0) { widthUnits += 1; j += 2; }
+                    else if (c < 0xF0) { widthUnits += 2; j += 3; }
+                    else               { widthUnits += 2; j += 4; }
                 }
-                if (widthUnits > maxWidthUnits) {
-                    maxWidthUnits = widthUnits;
-                }
+                if (widthUnits > maxWidthUnits) maxWidthUnits = widthUnits;
             }
-            // At font 14 on the Vita (900px cell, ~32px padding), roughly 108
-            // Latin-width characters fit per line.
-            int charsPerLine = 100;  // Slightly conservative
-            int lines = (maxWidthUnits + charsPerLine - 1) / charsPerLine;
+            int lines = (maxWidthUnits + 99) / 100;
             if (lines < 1) lines = 1;
             if (lines > 3) lines = 3;
             rowHeight = 40 + (lines * 20);
@@ -493,111 +444,59 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
 
         rowBox->setHeight(rowHeight);
 
-        // Reserve cell slots for this row; they are filled in populateRow().
+        // Create all cells for this row BEFORE attaching to contentBox.
+        // This batches yoga layout: 1 invalidation per row instead of per cell.
         for (int i = startIdx; i < endIdx; i++) {
-            (void)i;
-            m_cells.push_back(nullptr);
-        }
+            auto* cell = new MangaItemCell();
+            cell->setWidth(m_cellWidth);
+            cell->setHeight(rowHeight);
+            cell->setMarginRight(m_cellMargin);
 
-        // All non-visible rows start INVISIBLE; the draw-path culler will
-        // show them (and populate them) once they enter the viewport.
-        if (m_cachedLastVisible >= 0 &&
-            (row < m_cachedFirstVisible || row >= m_cachedLastVisible)) {
-            rowBox->setVisibility(brls::Visibility::INVISIBLE);
+            if (m_listMode) cell->setListMode(true);
+            else if (m_compactMode) cell->setCompactMode(true);
+
+            cell->setGridColumns(m_columns);
+            if (m_showLibraryBadge) cell->setShowLibraryBadge(true);
+
+            cell->setManga(m_items[i]);
+
+            int index = i;
+            cell->registerClickAction([this, cell, index](brls::View*) {
+                if (m_longPressTriggered) {
+                    m_longPressTriggered = false;
+                    return true;
+                }
+                if (!cell->isFocused()) {
+                    brls::Application::giveFocus(cell);
+                }
+                onItemClicked(index);
+                return true;
+            });
+            cell->addGestureRecognizer(new brls::TapGestureRecognizer(cell));
+
+            cell->getFocusEvent()->subscribe([this, index](brls::View*) {
+                m_focusedIndex = index;
+                loadThumbnailsNearIndex(index);
+
+                if (m_onEndReached && !m_endReachedFired) {
+                    int threshold = m_columns * 2;
+                    if (index >= static_cast<int>(m_items.size()) - threshold) {
+                        m_endReachedFired = true;
+                        m_onEndReached();
+                    }
+                }
+            });
+
+            rowBox->addView(cell);
+            m_cells.push_back(cell);
         }
 
         m_contentBox->addView(rowBox);
         m_rows.push_back(rowBox);
-        m_rowPopulated.push_back(false);
-        m_rowPopulatedCount.push_back(0);
         m_rowHeights.push_back(rowHeight);
     }
 }
 
-int RecyclingGrid::populateRow(int row, int budget) {
-    if (row < 0 || row >= static_cast<int>(m_rows.size())) return 0;
-    if (m_rowPopulated[row]) return 0;
-
-    brls::Box* rowBox = m_rows[row];
-    int startIdx = row * m_columns;
-    int endIdx = std::min(startIdx + m_columns, (int)m_items.size());
-    int rowHeight = (row < static_cast<int>(m_rowHeights.size()))
-                        ? m_rowHeights[row]
-                        : m_cellHeight;
-
-    int alreadyDone = (row < static_cast<int>(m_rowPopulatedCount.size()))
-                          ? m_rowPopulatedCount[row] : 0;
-    int firstToMake = startIdx + alreadyDone;
-    int lastToMake = endIdx;
-    if (budget > 0) {
-        lastToMake = std::min(lastToMake, firstToMake + budget);
-    }
-
-    int madeThisCall = 0;
-    for (int i = firstToMake; i < lastToMake; i++) {
-        auto* cell = new MangaItemCell();
-        cell->setWidth(m_cellWidth);
-        cell->setHeight(rowHeight);
-        cell->setMarginRight(m_cellMargin);
-
-        if (m_listMode) {
-            cell->setListMode(true);
-        } else if (m_compactMode) {
-            cell->setCompactMode(true);
-        }
-
-        cell->setGridColumns(m_columns);
-
-        if (m_showLibraryBadge) {
-            cell->setShowLibraryBadge(true);
-        }
-
-        cell->setManga(m_items[i]);
-
-        int index = i;
-        cell->registerClickAction([this, cell, index](brls::View* view) {
-            if (m_longPressTriggered) {
-                m_longPressTriggered = false;
-                return true;
-            }
-            if (!cell->isFocused()) {
-                brls::Application::giveFocus(cell);
-            }
-            onItemClicked(index);
-            return true;
-        });
-        cell->addGestureRecognizer(new brls::TapGestureRecognizer(cell));
-
-        cell->getFocusEvent()->subscribe([this, index](brls::View*) {
-            m_focusedIndex = index;
-            loadThumbnailsNearIndex(index);
-
-            if (m_onEndReached && !m_endReachedFired) {
-                int threshold = m_columns * 2;
-                if (index >= static_cast<int>(m_items.size()) - threshold) {
-                    m_endReachedFired = true;
-                    m_onEndReached();
-                }
-            }
-        });
-
-        rowBox->addView(cell);
-        m_cells[i] = cell;
-        madeThisCall++;
-    }
-
-    if (row < static_cast<int>(m_rowPopulatedCount.size())) {
-        m_rowPopulatedCount[row] = alreadyDone + madeThisCall;
-        if (startIdx + m_rowPopulatedCount[row] >= endIdx) {
-            m_rowPopulated[row] = true;
-        }
-    }
-    return madeThisCall;
-}
-
-// buildNextRowBatch() removed: rows are now populated lazily by the
-// draw-path culler as they enter the viewport, so there is no
-// incremental per-row scheduling loop to keep running in the background.
 
 void RecyclingGrid::loadThumbnailsNearIndex(int index) {
     if (m_cells.empty() || m_columns <= 0) return;
@@ -734,22 +633,6 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             m_cachedLastVisible = lastVisible;
         }
 
-        // Populate a small number of cells per frame as rows enter the
-        // visible range. A single cell creation costs ~7ms on the Vita
-        // (new MangaItemCell + Image + addView triggering yoga layout),
-        // so budgeting 2 cells/frame keeps the extra work to ~14ms and
-        // leaves room for the rest of the frame. Rows may stay partially
-        // populated for a few frames during fast scroll; the empty slots
-        // render as the rowBox background until filled.
-        int cellBudget = 2;
-        for (int i = firstVisible; i < lastVisible && cellBudget > 0; i++) {
-            if (i >= 0 && i < static_cast<int>(m_rowPopulated.size())
-                && !m_rowPopulated[i]) {
-                int made = populateRow(i, cellBudget);
-                cellBudget -= made;
-                if (made == 0) break;  // safety against infinite loop
-            }
-        }
     }
 
     PERF_BEGIN("grid_draw");
@@ -1046,9 +929,6 @@ brls::View* RecyclingGrid::getFirstCell() const {
     if (m_cells.empty()) {
         return nullptr;
     }
-    // With lazy row population, m_cells[0] might be nullptr briefly (only
-    // during the setupGrid window before populateRow(0) runs). Returning the
-    // first non-null cell keeps the existing contract for callers.
     for (auto* c : m_cells) {
         if (c) return c;
     }
@@ -1066,13 +946,6 @@ void RecyclingGrid::focusIndex(int index) {
             }
         }
         return;
-    }
-
-    // If the target row hasn't been populated yet (user asked to focus a cell
-    // that's off-screen), populate it now so the focus target exists.
-    int row = index / m_columns;
-    if (row >= 0 && row < static_cast<int>(m_rowPopulated.size()) && !m_rowPopulated[row]) {
-        populateRow(row);
     }
 
     if (m_cells[index]) {


### PR DESCRIPTION
Strips MangaItemCell to an empty focusable box to establish an FPS baseline, adds a workflow to update the borealis submodule to the switchfin branch, and removes lazy row population that dropped scroll FPS.

---
_Generated by [Claude Code](https://claude.ai/code)_