### PR TITLE
Add cover image support to MangaItemCell

### DIFF
--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -24,6 +24,7 @@ class ImageLoader {
 public:
     using LoadCallback = std::function<void(brls::Image*)>;
     using RotatableLoadCallback = std::function<void(RotatableImage*)>;
+    using CoverReadyCallback = std::function<void(int nvgImage, int w, int h)>;
 
     // Set authentication credentials for image loading
     static void setAuthCredentials(const std::string& username, const std::string& password);
@@ -39,6 +40,13 @@ public:
     static std::string getAuthPassword();
     static std::string getAccessToken();
     static std::string getSessionCookie();
+
+    // Load cover image: worker thread decodes to RGBA, main thread does GPU
+    // upload only via nvgCreateImageRGBA (no TGA double-decode). Callback
+    // receives the NVG image handle + dimensions. Not affected by scroll
+    // deferral so covers load continuously.
+    static void loadCoverAsync(const std::string& url, CoverReadyCallback callback,
+                               std::shared_ptr<bool> alive);
 
     // Load image asynchronously from URL (with thumbnail downscaling) - for brls::Image
     static void loadAsync(const std::string& url, LoadCallback callback, brls::Image* target);
@@ -99,6 +107,7 @@ private:
         brls::Image* target;
         bool fullSize;  // true = no downscaling
         std::shared_ptr<bool> alive;  // If set and *alive==false, skip (owner destroyed)
+        CoverReadyCallback coverCallback;  // If set, use cover mode (RGBA direct upload)
     };
 
     // Pending load request for RotatableImage
@@ -173,6 +182,23 @@ private:
                                    std::shared_ptr<bool> alive = nullptr);
     // Process a batch of pending texture uploads (called on main thread)
     static void processPendingTextures();
+
+    // Cover upload queue: carries pre-decoded RGBA from worker thread.
+    // Main thread only does nvgCreateImageRGBA (pure GPU upload, no decode).
+    // Not affected by s_deferTextureUploads so covers load during scroll.
+    struct PendingCoverUpload {
+        std::vector<uint8_t> rgbaData;
+        int width = 0;
+        int height = 0;
+        CoverReadyCallback callback;
+        std::shared_ptr<bool> alive;
+    };
+    static std::queue<PendingCoverUpload> s_pendingCovers;
+    static std::mutex s_pendingCoverMutex;
+    static std::atomic<bool> s_pendingCoverScheduled;
+    static void queueCoverUpload(std::vector<uint8_t> rgbaData, int w, int h,
+                                  CoverReadyCallback callback, std::shared_ptr<bool> alive);
+    static void processPendingCovers();
 
     // Batched texture upload queue for RotatableImage (webtoon/manga reader pages).
     // Same concept as PendingTextureUpdate but for full-size reader images.

--- a/include/utils/image_loader.hpp
+++ b/include/utils/image_loader.hpp
@@ -166,7 +166,7 @@ private:
     static std::mutex s_pendingMutex;
     static std::atomic<bool> s_pendingScheduled;
     static std::atomic<bool> s_deferTextureUploads;
-    static constexpr int MAX_TEXTURES_PER_FRAME = 2;  // Limit GPU uploads per frame (reduced from 6 - each upload stalls Vita GPU for ~15-20ms)
+    static constexpr int MAX_TEXTURES_PER_FRAME = 1;  // Limit GPU uploads per frame (each upload stalls Vita GPU for ~15-20ms)
 
     // Queue a texture for batched upload on the main thread
     static void queueTextureUpdate(const std::vector<uint8_t>& data, brls::Image* target, LoadCallback callback,

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -23,9 +23,17 @@ public:
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
+    void draw(NVGcontext* vg, float x, float y, float width, float height,
+              brls::Style style, brls::FrameContext* ctx) override;
+
     int getCoverImage() const { return m_nvgCover; }
     int getCoverWidth() const { return m_coverW; }
     int getCoverHeight() const { return m_coverH; }
+
+    float getDrawX() const { return m_drawX; }
+    float getDrawY() const { return m_drawY; }
+    float getDrawW() const { return m_drawW; }
+    float getDrawH() const { return m_drawH; }
 
     void setCompactMode(bool compact) { m_compact = compact; }
     void setListMode(bool list) { m_listMode = list; }
@@ -48,6 +56,10 @@ private:
     int m_nvgCover = 0;
     int m_coverW = 0;
     int m_coverH = 0;
+    float m_drawX = 0;
+    float m_drawY = 0;
+    float m_drawW = 0;
+    float m_drawH = 0;
     bool m_pressed = false;
     bool m_compact = false;
     bool m_listMode = false;

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -1,8 +1,3 @@
-/**
- * VitaSuwayomi - Manga Item Cell
- * Empty focusable box - rebuild base for FPS testing.
- */
-
 #pragma once
 
 #include <borealis.hpp>
@@ -19,17 +14,17 @@ public:
 
     void setManga(const Manga& manga);
     void setMangaDeferred(const Manga& manga) { setManga(manga); }
-    void updateMangaData(const Manga& manga) { m_manga = manga; }
+    void updateMangaData(const Manga& manga);
 
-    void loadThumbnailIfNeeded() {}
-    void unloadThumbnail() {}
-    void resetThumbnailLoadState() {}
+    void loadThumbnailIfNeeded();
+    void unloadThumbnail();
+    void resetThumbnailLoadState();
 
-    bool isThumbnailLoaded() const { return false; }
+    bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
-    void setCompactMode(bool) {}
-    void setListMode(bool) {}
+    void setCompactMode(bool compact) { m_compact = compact; }
+    void setListMode(bool list) { m_listMode = list; }
     void setListRowSize(int) {}
     void setGridColumns(int) {}
     void setShowLibraryBadge(bool) {}
@@ -42,12 +37,15 @@ public:
     bool isSelected() const { return false; }
 
     static brls::View* create() { return new MangaItemCell(); }
-
     static void setTitlesEnabled(bool) {}
 
 private:
     Manga m_manga;
+    brls::Image* m_coverImage = nullptr;
     bool m_pressed = false;
+    bool m_compact = false;
+    bool m_listMode = false;
+    bool m_thumbnailLoaded = false;
     std::shared_ptr<bool> m_alive;
 };
 

--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -23,6 +23,10 @@ public:
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }
     const Manga& getManga() const { return m_manga; }
 
+    int getCoverImage() const { return m_nvgCover; }
+    int getCoverWidth() const { return m_coverW; }
+    int getCoverHeight() const { return m_coverH; }
+
     void setCompactMode(bool compact) { m_compact = compact; }
     void setListMode(bool list) { m_listMode = list; }
     void setListRowSize(int) {}
@@ -41,7 +45,9 @@ public:
 
 private:
     Manga m_manga;
-    brls::Image* m_coverImage = nullptr;
+    int m_nvgCover = 0;
+    int m_coverW = 0;
+    int m_coverH = 0;
     bool m_pressed = false;
     bool m_compact = false;
     bool m_listMode = false;

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -97,6 +97,11 @@ std::mutex ImageLoader::s_pendingMutex;
 std::atomic<bool> ImageLoader::s_pendingScheduled{false};
 std::atomic<bool> ImageLoader::s_deferTextureUploads{false};
 
+// Cover upload queue (pre-decoded RGBA, GPU upload only on main thread)
+std::queue<ImageLoader::PendingCoverUpload> ImageLoader::s_pendingCovers;
+std::mutex ImageLoader::s_pendingCoverMutex;
+std::atomic<bool> ImageLoader::s_pendingCoverScheduled{false};
+
 // Batched texture upload queue (reader pages / RotatableImage)
 std::queue<ImageLoader::PendingRotatableTextureUpdate> ImageLoader::s_pendingRotatableTextures;
 std::mutex ImageLoader::s_pendingRotatableMutex;
@@ -2191,6 +2196,99 @@ void ImageLoader::processPendingTextures() {
     }
 }
 
+void ImageLoader::loadCoverAsync(const std::string& url, CoverReadyCallback callback,
+                                  std::shared_ptr<bool> alive) {
+    if (url.empty()) return;
+
+    // Memory cache: decode TGA→RGBA here (fast, <0.5ms for 120px thumbnails),
+    // then queue the RGBA for GPU upload on the next frame.
+    {
+        std::vector<uint8_t> cachedData;
+        if (cacheGet(url, cachedData)) {
+            int w, h, c;
+            uint8_t* rgba = stbi_load_from_memory(cachedData.data(),
+                static_cast<int>(cachedData.size()), &w, &h, &c, 4);
+            if (rgba) {
+                std::vector<uint8_t> rgbaVec(rgba, rgba + w * h * 4);
+                stbi_image_free(rgba);
+                queueCoverUpload(std::move(rgbaVec), w, h, std::move(callback), std::move(alive));
+            }
+            return;
+        }
+    }
+
+    // Queue for worker thread (disk cache / network download + decode)
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        LoadRequest req;
+        req.url = url;
+        req.callback = nullptr;
+        req.target = nullptr;
+        req.fullSize = true;
+        req.alive = alive;
+        req.coverCallback = std::move(callback);
+        s_loadQueue.push(std::move(req));
+    }
+    s_queueCV.notify_one();
+    ensureWorkersStarted();
+}
+
+void ImageLoader::queueCoverUpload(std::vector<uint8_t> rgbaData, int w, int h,
+                                    CoverReadyCallback callback, std::shared_ptr<bool> alive) {
+    {
+        std::lock_guard<std::mutex> lock(s_pendingCoverMutex);
+        PendingCoverUpload upload;
+        upload.rgbaData = std::move(rgbaData);
+        upload.width = w;
+        upload.height = h;
+        upload.callback = std::move(callback);
+        upload.alive = std::move(alive);
+        s_pendingCovers.push(std::move(upload));
+    }
+    bool expected = false;
+    if (s_pendingCoverScheduled.compare_exchange_strong(expected, true)) {
+        brls::sync([]() { processPendingCovers(); });
+    }
+}
+
+void ImageLoader::processPendingCovers() {
+    s_pendingCoverScheduled = false;
+
+    NVGcontext* vg = brls::Application::getNVGContext();
+    if (!vg) return;
+
+    PendingCoverUpload upload;
+    {
+        std::lock_guard<std::mutex> lock(s_pendingCoverMutex);
+        if (s_pendingCovers.empty()) return;
+        upload = std::move(s_pendingCovers.front());
+        s_pendingCovers.pop();
+    }
+
+    if (upload.alive && !*upload.alive) {
+        // Cell destroyed — skip, but reschedule for remaining items
+    } else if (!upload.rgbaData.empty() && upload.width > 0 && upload.height > 0) {
+        int nvgImg = nvgCreateImageRGBA(vg, upload.width, upload.height,
+                                         0, upload.rgbaData.data());
+        if (nvgImg != 0 && upload.callback) {
+            upload.callback(nvgImg, upload.width, upload.height);
+        }
+    }
+
+    // Reschedule if more pending
+    bool morePending;
+    {
+        std::lock_guard<std::mutex> lock(s_pendingCoverMutex);
+        morePending = !s_pendingCovers.empty();
+    }
+    if (morePending) {
+        bool expected = false;
+        if (s_pendingCoverScheduled.compare_exchange_strong(expected, true)) {
+            brls::sync([]() { processPendingCovers(); });
+        }
+    }
+}
+
 void ImageLoader::queueRotatableTextureUpdate(const std::vector<uint8_t>& data, RotatableImage* target,
                                                RotatableLoadCallback callback, std::shared_ptr<bool> alive) {
     {
@@ -2340,9 +2438,16 @@ void ImageLoader::executeLoad(const LoadRequest& request) {
                     cachePut(url, diskData);
                     // Re-check alive after disk I/O
                     if (alive && !*alive) return;
-                    // Queue for batched texture upload (prevents main thread freeze
-                    // when 50+ covers load from disk cache simultaneously)
-                    if (target) {
+                    if (request.coverCallback) {
+                        int w, h, c;
+                        uint8_t* rgba = stbi_load_from_memory(diskData.data(),
+                            static_cast<int>(diskData.size()), &w, &h, &c, 4);
+                        if (rgba) {
+                            std::vector<uint8_t> rgbaVec(rgba, rgba + w * h * 4);
+                            stbi_image_free(rgba);
+                            queueCoverUpload(std::move(rgbaVec), w, h, request.coverCallback, alive);
+                        }
+                    } else if (target) {
                         queueTextureUpdate(diskData, target, callback, alive);
                     }
                     return;
@@ -2591,11 +2696,20 @@ void ImageLoader::executeLoad(const LoadRequest& request) {
     // and crashes on setImageFromMem().
     if (alive && !*alive) return;
 
-    // Queue for batched texture upload on main thread
-    if (target) {
+    // Cover mode: decode TGA→RGBA on this worker thread, queue pure GPU upload
+    if (request.coverCallback) {
+        int w, h, c;
+        uint8_t* rgba = stbi_load_from_memory(imageData.data(),
+            static_cast<int>(imageData.size()), &w, &h, &c, 4);
+        if (rgba) {
+            std::vector<uint8_t> rgbaVec(rgba, rgba + w * h * 4);
+            stbi_image_free(rgba);
+            queueCoverUpload(std::move(rgbaVec), w, h, request.coverCallback, alive);
+        }
+    } else if (target) {
         queueTextureUpdate(imageData, target, callback, alive);
     }
-    brls::Logger::info("ImageLoader: Queued texture for {}", url);
+    brls::Logger::debug("ImageLoader: Queued texture for {}", url);
 }
 
 void ImageLoader::ensureWorkersStarted() {

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -2257,22 +2257,25 @@ void ImageLoader::processPendingCovers() {
     NVGcontext* vg = brls::Application::getNVGContext();
     if (!vg) return;
 
-    PendingCoverUpload upload;
-    {
-        std::lock_guard<std::mutex> lock(s_pendingCoverMutex);
-        if (s_pendingCovers.empty()) return;
-        upload = std::move(s_pendingCovers.front());
-        s_pendingCovers.pop();
-    }
+    int uploaded = 0;
+    while (uploaded < 2) {
+        PendingCoverUpload upload;
+        {
+            std::lock_guard<std::mutex> lock(s_pendingCoverMutex);
+            if (s_pendingCovers.empty()) return;
+            upload = std::move(s_pendingCovers.front());
+            s_pendingCovers.pop();
+        }
 
-    if (upload.alive && !*upload.alive) {
-        // Cell destroyed — skip, but reschedule for remaining items
-    } else if (!upload.rgbaData.empty() && upload.width > 0 && upload.height > 0) {
+        if (upload.alive && !*upload.alive) continue;
+        if (upload.rgbaData.empty() || upload.width <= 0 || upload.height <= 0) continue;
+
         int nvgImg = nvgCreateImageRGBA(vg, upload.width, upload.height,
                                          0, upload.rgbaData.data());
         if (nvgImg != 0 && upload.callback) {
             upload.callback(nvgImg, upload.width, upload.height);
         }
+        uploaded++;
     }
 
     // Reschedule if more pending

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -84,7 +84,7 @@ std::set<std::string> ImageLoader::s_pendingFullSizeUrls;
 std::mutex ImageLoader::s_queueMutex;
 std::condition_variable ImageLoader::s_queueCV;
 int ImageLoader::s_maxConcurrentLoads = 3;  // Worker thread count - kept low for PS Vita memory limits
-int ImageLoader::s_maxThumbnailSize = 180;  // Smaller thumbnails for speed
+int ImageLoader::s_maxThumbnailSize = 120;  // Match grid cell width to minimize GPU upload cost
 
 // Worker thread pool
 std::vector<std::thread> ImageLoader::s_workers;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -12,7 +12,7 @@ MangaItemCell::MangaItemCell() {
     this->setClipsToBounds(true);
 
     m_coverImage = new brls::Image();
-    m_coverImage->setScalingType(brls::ImageScalingType::FILL);
+    m_coverImage->setScalingType(brls::ImageScalingType::FIT);
     m_coverImage->setCornerRadius(4.0f);
     m_coverImage->setWidthPercentage(100.0f);
     m_coverImage->setHeightPercentage(100.0f);

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -9,19 +9,15 @@ MangaItemCell::MangaItemCell() {
     this->setFocusable(true);
     this->setCornerRadius(4.0f);
     this->setBackgroundColor(nvgRGB(40, 40, 48));
-    this->setClipsToBounds(true);
-
-    m_coverImage = new brls::Image();
-    m_coverImage->setScalingType(brls::ImageScalingType::FILL);
-    m_coverImage->setCornerRadius(4.0f);
-    m_coverImage->setWidthPercentage(100.0f);
-    m_coverImage->setHeightPercentage(100.0f);
-    this->addView(m_coverImage);
 }
 
 MangaItemCell::~MangaItemCell() {
     if (m_alive) {
         *m_alive = false;
+    }
+    if (m_nvgCover != 0) {
+        NVGcontext* vg = brls::Application::getNVGContext();
+        if (vg) nvgDeleteImage(vg, m_nvgCover);
     }
 }
 
@@ -34,12 +30,19 @@ void MangaItemCell::updateMangaData(const Manga& manga) {
     bool coverChanged = (m_manga.thumbnailUrl != manga.thumbnailUrl);
     m_manga = manga;
     if (coverChanged) {
+        if (m_nvgCover != 0) {
+            NVGcontext* vg = brls::Application::getNVGContext();
+            if (vg) nvgDeleteImage(vg, m_nvgCover);
+            m_nvgCover = 0;
+            m_coverW = 0;
+            m_coverH = 0;
+        }
         m_thumbnailLoaded = false;
     }
 }
 
 void MangaItemCell::loadThumbnailIfNeeded() {
-    if (m_thumbnailLoaded || !m_coverImage) return;
+    if (m_thumbnailLoaded) return;
     if (m_manga.id <= 0 && m_manga.thumbnailUrl.empty()) return;
     m_thumbnailLoaded = true;
 
@@ -60,18 +63,33 @@ void MangaItemCell::loadThumbnailIfNeeded() {
         url = client.getMangaThumbnailUrl(m_manga.id);
     }
 
-    ImageLoader::loadAsync(url, nullptr, m_coverImage, m_alive);
+    std::weak_ptr<bool> weakAlive(m_alive);
+    MangaItemCell* self = this;
+
+    ImageLoader::loadCoverAsync(url,
+        [self, weakAlive](int nvgImg, int w, int h) {
+            auto alive = weakAlive.lock();
+            if (!alive || !*alive) {
+                NVGcontext* vg = brls::Application::getNVGContext();
+                if (vg && nvgImg != 0) nvgDeleteImage(vg, nvgImg);
+                return;
+            }
+            self->m_nvgCover = nvgImg;
+            self->m_coverW = w;
+            self->m_coverH = h;
+        },
+        m_alive);
 }
 
 void MangaItemCell::unloadThumbnail() {
-    if (!m_thumbnailLoaded || !m_coverImage) return;
-
-    static const unsigned char s_clearPixel[] = {
-        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 1, 0, 32, 0,
-        0, 0, 0, 0
-    };
-    m_coverImage->setImageFromMem(s_clearPixel, sizeof(s_clearPixel));
+    if (!m_thumbnailLoaded) return;
+    if (m_nvgCover != 0) {
+        NVGcontext* vg = brls::Application::getNVGContext();
+        if (vg) nvgDeleteImage(vg, m_nvgCover);
+        m_nvgCover = 0;
+        m_coverW = 0;
+        m_coverH = 0;
+    }
     m_thumbnailLoaded = false;
 }
 

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -1,9 +1,6 @@
-/**
- * VitaSuwayomi - Manga Item Cell implementation
- * Empty focusable box - rebuild base for FPS testing.
- */
-
 #include "view/manga_item_cell.hpp"
+#include "utils/image_loader.hpp"
+#include "app/suwayomi_client.hpp"
 
 namespace vitasuwayomi {
 
@@ -12,6 +9,14 @@ MangaItemCell::MangaItemCell() {
     this->setFocusable(true);
     this->setCornerRadius(4.0f);
     this->setBackgroundColor(nvgRGB(40, 40, 48));
+    this->setClipsToBounds(true);
+
+    m_coverImage = new brls::Image();
+    m_coverImage->setScalingType(brls::ImageScalingType::FILL);
+    m_coverImage->setCornerRadius(4.0f);
+    m_coverImage->setWidthPercentage(100.0f);
+    m_coverImage->setHeightPercentage(100.0f);
+    this->addView(m_coverImage);
 }
 
 MangaItemCell::~MangaItemCell() {
@@ -22,6 +27,56 @@ MangaItemCell::~MangaItemCell() {
 
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
+    m_thumbnailLoaded = false;
+}
+
+void MangaItemCell::updateMangaData(const Manga& manga) {
+    bool coverChanged = (m_manga.thumbnailUrl != manga.thumbnailUrl);
+    m_manga = manga;
+    if (coverChanged) {
+        m_thumbnailLoaded = false;
+    }
+}
+
+void MangaItemCell::loadThumbnailIfNeeded() {
+    if (m_thumbnailLoaded || !m_coverImage) return;
+    if (m_manga.id <= 0 && m_manga.thumbnailUrl.empty()) return;
+    m_thumbnailLoaded = true;
+
+    SuwayomiClient& client = SuwayomiClient::getInstance();
+    std::string url;
+
+    if (!m_manga.thumbnailUrl.empty()) {
+        if (m_manga.thumbnailUrl[0] == '/') {
+            url = client.getServerUrl();
+            while (!url.empty() && url.back() == '/') url.pop_back();
+            url += m_manga.thumbnailUrl;
+        } else if (m_manga.thumbnailUrl.find("http") == 0) {
+            url = m_manga.thumbnailUrl;
+        } else {
+            url = client.getMangaThumbnailUrl(m_manga.id);
+        }
+    } else {
+        url = client.getMangaThumbnailUrl(m_manga.id);
+    }
+
+    ImageLoader::loadAsync(url, nullptr, m_coverImage, m_alive);
+}
+
+void MangaItemCell::unloadThumbnail() {
+    if (!m_thumbnailLoaded || !m_coverImage) return;
+
+    static const unsigned char s_clearPixel[] = {
+        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 1, 0, 32, 0,
+        0, 0, 0, 0
+    };
+    m_coverImage->setImageFromMem(s_clearPixel, sizeof(s_clearPixel));
+    m_thumbnailLoaded = false;
+}
+
+void MangaItemCell::resetThumbnailLoadState() {
+    m_thumbnailLoaded = false;
 }
 
 void MangaItemCell::setPressed(bool pressed) {

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -41,6 +41,15 @@ void MangaItemCell::updateMangaData(const Manga& manga) {
     }
 }
 
+void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,
+                         brls::Style style, brls::FrameContext* ctx) {
+    m_drawX = x;
+    m_drawY = y;
+    m_drawW = width;
+    m_drawH = height;
+    brls::Box::draw(vg, x, y, width, height, style, ctx);
+}
+
 void MangaItemCell::loadThumbnailIfNeeded() {
     if (m_thumbnailLoaded) return;
     if (m_manga.id <= 0 && m_manga.thumbnailUrl.empty()) return;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -12,7 +12,7 @@ MangaItemCell::MangaItemCell() {
     this->setClipsToBounds(true);
 
     m_coverImage = new brls::Image();
-    m_coverImage->setScalingType(brls::ImageScalingType::FIT);
+    m_coverImage->setScalingType(brls::ImageScalingType::FILL);
     m_coverImage->setCornerRadius(4.0f);
     m_coverImage->setWidthPercentage(100.0f);
     m_coverImage->setHeightPercentage(100.0f);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -642,17 +642,20 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     // Batched cover draw: render cover textures for visible cells.
     // Covers are NVG image handles managed directly on cells (no brls::Image
     // child views), drawn here as textured quads via nvgImagePattern.
-    if (m_cachedFirstVisible >= 0) {
+    // Screen coords: grid(x,y) + contentBox offset + scroll + row + cell.
+    if (m_cachedFirstVisible >= 0 && m_contentBox) {
         float scrollY = this->getContentOffsetY();
-        float pad = 10.0f;
-        float baseX = x + pad;
-        float baseY = y + pad - scrollY;
+        float cbX = x + m_contentBox->getX();
+        float cbY = y + m_contentBox->getY() - scrollY;
 
         for (int r = m_cachedFirstVisible; r < m_cachedLastVisible; r++) {
             if (r < 0 || r >= static_cast<int>(m_rows.size())) continue;
-            int rh = (r < static_cast<int>(m_rowHeights.size()))
-                         ? m_rowHeights[r] : m_cellHeight;
-            float rowY = baseY + m_rows[r]->getY();
+            brls::Box* row = m_rows[r];
+            if (!row || row->getVisibility() != brls::Visibility::VISIBLE) continue;
+
+            float rowScreenX = cbX + row->getX();
+            float rowScreenY = cbY + row->getY();
+
             int startIdx = r * m_columns;
             int endIdx = std::min(startIdx + m_columns,
                                   static_cast<int>(m_cells.size()));
@@ -663,26 +666,25 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
                 int nvgImg = cell->getCoverImage();
                 if (nvgImg == 0) continue;
 
-                int col = i - startIdx;
-                float cx = baseX + col * (m_cellWidth + m_cellMargin);
-                float cw = static_cast<float>(m_cellWidth);
-                float ch = static_cast<float>(rh);
+                float cx = rowScreenX + cell->getX();
+                float cy = rowScreenY + cell->getY();
+                float cw = cell->getWidth();
+                float ch = cell->getHeight();
 
                 float imgW = static_cast<float>(cell->getCoverWidth());
                 float imgH = static_cast<float>(cell->getCoverHeight());
                 if (imgW <= 0 || imgH <= 0) continue;
 
-                // FILL scaling: scale to cover entire cell, center-crop
                 float scale = std::max(cw / imgW, ch / imgH);
                 float sw = imgW * scale;
                 float sh = imgH * scale;
                 float ox = cx + (cw - sw) * 0.5f;
-                float oy = rowY + (ch - sh) * 0.5f;
+                float oy = cy + (ch - sh) * 0.5f;
 
                 NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
                                                   0, nvgImg, 1.0f);
                 nvgBeginPath(vg);
-                nvgRoundedRect(vg, cx, rowY, cw, ch, 4.0f);
+                nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
                 nvgFillPaint(vg, paint);
                 nvgFill(vg);
             }

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -640,23 +640,21 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 
-    // Pause ImageLoader GPU texture uploads while the user is actively
-    // scrolling fast. Each upload (setImageFromMem) costs ~15-20ms on Vita
-    // and stalls the frame. Holding them off until scroll settles keeps
-    // scrolling smooth; queued textures flush as soon as velocity drops.
+    // Pause ImageLoader GPU texture uploads while the user is scrolling.
+    // Each upload (setImageFromMem) costs ~15-20ms on Vita and stalls the
+    // frame. Defer ALL uploads until scroll has fully stopped for several
+    // frames so scrolling stays at 60 FPS.
     {
         float curY = this->getContentOffsetY();
         float frameDelta = std::abs(curY - m_prevScrollY);
         m_prevScrollY = curY;
-        float rowHeight = static_cast<float>(m_cellHeight + m_rowMargin);
-        // "Fast scroll" = moving more than ~1/3 of a row per frame
-        bool movingFast = frameDelta > rowHeight * 0.33f;
-        if (movingFast) {
+        bool scrolling = frameDelta > 0.5f;
+        if (scrolling) {
             m_scrollSettledFrames = 0;
         } else {
             m_scrollSettledFrames++;
         }
-        bool wantDefer = movingFast || m_scrollSettledFrames < 3;
+        bool wantDefer = scrolling || m_scrollSettledFrames < 6;
         if (wantDefer != m_uploadsDeferred) {
             m_uploadsDeferred = wantDefer;
             ImageLoader::setDeferTextureUploads(wantDefer);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -636,11 +636,60 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     }
 
     PERF_BEGIN("grid_draw");
-    // Call parent draw - now only visible rows are rendered
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 
-    // Pause ImageLoader GPU texture uploads while the user is scrolling.
+    // Batched cover draw: render cover textures for visible cells.
+    // Covers are NVG image handles managed directly on cells (no brls::Image
+    // child views), drawn here as textured quads via nvgImagePattern.
+    if (m_cachedFirstVisible >= 0) {
+        float scrollY = this->getContentOffsetY();
+        float pad = 10.0f;
+        float baseX = x + pad;
+        float baseY = y + pad - scrollY;
+
+        for (int r = m_cachedFirstVisible; r < m_cachedLastVisible; r++) {
+            if (r < 0 || r >= static_cast<int>(m_rows.size())) continue;
+            int rh = (r < static_cast<int>(m_rowHeights.size()))
+                         ? m_rowHeights[r] : m_cellHeight;
+            float rowY = baseY + m_rows[r]->getY();
+            int startIdx = r * m_columns;
+            int endIdx = std::min(startIdx + m_columns,
+                                  static_cast<int>(m_cells.size()));
+
+            for (int i = startIdx; i < endIdx; i++) {
+                MangaItemCell* cell = m_cells[i];
+                if (!cell) continue;
+                int nvgImg = cell->getCoverImage();
+                if (nvgImg == 0) continue;
+
+                int col = i - startIdx;
+                float cx = baseX + col * (m_cellWidth + m_cellMargin);
+                float cw = static_cast<float>(m_cellWidth);
+                float ch = static_cast<float>(rh);
+
+                float imgW = static_cast<float>(cell->getCoverWidth());
+                float imgH = static_cast<float>(cell->getCoverHeight());
+                if (imgW <= 0 || imgH <= 0) continue;
+
+                // FILL scaling: scale to cover entire cell, center-crop
+                float scale = std::max(cw / imgW, ch / imgH);
+                float sw = imgW * scale;
+                float sh = imgH * scale;
+                float ox = cx + (cw - sw) * 0.5f;
+                float oy = rowY + (ch - sh) * 0.5f;
+
+                NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
+                                                  0, nvgImg, 1.0f);
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, cx, rowY, cw, ch, 4.0f);
+                nvgFillPaint(vg, paint);
+                nvgFill(vg);
+            }
+        }
+    }
+
+    // Pause ImageLoader GPU texture uploads (brls::Image path only) while scrolling.
     // Each upload (setImageFromMem) costs ~15-20ms on Vita and stalls the
     // frame. Defer ALL uploads until scroll has fully stopped for several
     // frames so scrolling stays at 60 FPS.

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -640,55 +640,47 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     PERF_END("grid_draw");
 
     // Batched cover draw: render cover textures for visible cells.
-    // Covers are NVG image handles managed directly on cells (no brls::Image
-    // child views), drawn here as textured quads via nvgImagePattern.
-    // Screen coords: grid(x,y) + contentBox offset + scroll + row + cell.
-    if (m_cachedFirstVisible >= 0 && m_contentBox) {
-        float scrollY = this->getContentOffsetY();
-        float cbX = x + m_contentBox->getX();
-        float cbY = y + m_contentBox->getY() - scrollY;
+    // Uses each cell's stored draw coordinates (captured during Box::draw)
+    // to guarantee covers align exactly with cell backgrounds.
+    if (m_cachedFirstVisible >= 0) {
+        nvgSave(vg);
+        nvgIntersectScissor(vg, x, y, width, height);
 
-        for (int r = m_cachedFirstVisible; r < m_cachedLastVisible; r++) {
-            if (r < 0 || r >= static_cast<int>(m_rows.size())) continue;
-            brls::Box* row = m_rows[r];
-            if (!row || row->getVisibility() != brls::Visibility::VISIBLE) continue;
+        int startIdx = m_cachedFirstVisible * m_columns;
+        int endIdx = std::min(m_cachedLastVisible * m_columns,
+                              static_cast<int>(m_cells.size()));
 
-            float rowScreenX = cbX + row->getX();
-            float rowScreenY = cbY + row->getY();
+        for (int i = startIdx; i < endIdx; i++) {
+            MangaItemCell* cell = m_cells[i];
+            if (!cell) continue;
+            int nvgImg = cell->getCoverImage();
+            if (nvgImg == 0) continue;
 
-            int startIdx = r * m_columns;
-            int endIdx = std::min(startIdx + m_columns,
-                                  static_cast<int>(m_cells.size()));
+            float cx = cell->getDrawX();
+            float cy = cell->getDrawY();
+            float cw = cell->getDrawW();
+            float ch = cell->getDrawH();
+            if (cw <= 0 || ch <= 0) continue;
 
-            for (int i = startIdx; i < endIdx; i++) {
-                MangaItemCell* cell = m_cells[i];
-                if (!cell) continue;
-                int nvgImg = cell->getCoverImage();
-                if (nvgImg == 0) continue;
+            float imgW = static_cast<float>(cell->getCoverWidth());
+            float imgH = static_cast<float>(cell->getCoverHeight());
+            if (imgW <= 0 || imgH <= 0) continue;
 
-                float cx = rowScreenX + cell->getX();
-                float cy = rowScreenY + cell->getY();
-                float cw = cell->getWidth();
-                float ch = cell->getHeight();
+            float scale = std::max(cw / imgW, ch / imgH);
+            float sw = imgW * scale;
+            float sh = imgH * scale;
+            float ox = cx + (cw - sw) * 0.5f;
+            float oy = cy + (ch - sh) * 0.5f;
 
-                float imgW = static_cast<float>(cell->getCoverWidth());
-                float imgH = static_cast<float>(cell->getCoverHeight());
-                if (imgW <= 0 || imgH <= 0) continue;
-
-                float scale = std::max(cw / imgW, ch / imgH);
-                float sw = imgW * scale;
-                float sh = imgH * scale;
-                float ox = cx + (cw - sw) * 0.5f;
-                float oy = cy + (ch - sh) * 0.5f;
-
-                NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
-                                                  0, nvgImg, 1.0f);
-                nvgBeginPath(vg);
-                nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
-                nvgFillPaint(vg, paint);
-                nvgFill(vg);
-            }
+            NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
+                                              0, nvgImg, 1.0f);
+            nvgBeginPath(vg);
+            nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+            nvgFillPaint(vg, paint);
+            nvgFill(vg);
         }
+
+        nvgRestore(vg);
     }
 
     // Pause ImageLoader GPU texture uploads (brls::Image path only) while scrolling.


### PR DESCRIPTION
Adds cover-image support to MangaItemCell and works through the resulting scroll-FPS and cover issues — scaling, corruption, a double-decode-eliminating direct RGBA upload pipeline, and correct positioning using cell draw coordinates.

---
_Generated by [Claude Code](https://claude.ai/code)_