### PR TITLE
Add unread count badge drawn above covers on grid cells

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -42,6 +42,13 @@ public:
     void setShowLibraryBadge(bool) {}
     void refreshLibraryBadge() {}
 
+    // Cached unread badge data (precomputed, not per-frame)
+    const std::string& getBadgeText() const { return m_badgeText; }
+    float getBadgeTextW() const { return m_badgeTextW; }
+    float getBadgeTextH() const { return m_badgeTextH; }
+    bool hasBadge() const { return !m_badgeText.empty(); }
+    void cacheBadgeBounds(NVGcontext* vg, float fontSize);
+
     void setPressed(bool pressed);
     bool isPressed() const { return m_pressed; }
 
@@ -64,6 +71,9 @@ private:
     bool m_compact = false;
     bool m_listMode = false;
     bool m_thumbnailLoaded = false;
+    std::string m_badgeText;
+    float m_badgeTextW = 0;
+    float m_badgeTextH = 0;
     std::shared_ptr<bool> m_alive;
 };
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -152,6 +152,12 @@ private:
     int m_startHintW = 0;
     int m_startHintH = 0;
 
+    // Cached unread badge drawing state (computed once in setupGrid, not per-frame)
+    bool m_showUnreadBadge = true;
+    float m_badgeFontSize = 10.0f;
+    float m_badgeMargin = 6.0f;
+    NVGcolor m_badgeColor = {};
+
     // Alive flag for deferred callbacks (kept for any future brls::sync usage).
     std::shared_ptr<bool> m_alive;
     int m_totalRowsNeeded = 0;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -24,10 +24,14 @@ MangaItemCell::~MangaItemCell() {
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
     m_thumbnailLoaded = false;
+    m_badgeText = (manga.unreadCount > 0) ? std::to_string(manga.unreadCount) : std::string();
+    m_badgeTextW = 0;
+    m_badgeTextH = 0;
 }
 
 void MangaItemCell::updateMangaData(const Manga& manga) {
     bool coverChanged = (m_manga.thumbnailUrl != manga.thumbnailUrl);
+    bool unreadChanged = (m_manga.unreadCount != manga.unreadCount);
     m_manga = manga;
     if (coverChanged) {
         if (m_nvgCover != 0) {
@@ -39,6 +43,22 @@ void MangaItemCell::updateMangaData(const Manga& manga) {
         }
         m_thumbnailLoaded = false;
     }
+    if (unreadChanged) {
+        m_badgeText = (manga.unreadCount > 0) ? std::to_string(manga.unreadCount) : std::string();
+        m_badgeTextW = 0;
+        m_badgeTextH = 0;
+    }
+}
+
+void MangaItemCell::cacheBadgeBounds(NVGcontext* vg, float fontSize) {
+    if (m_badgeTextW > 0 || m_badgeText.empty()) return;
+    nvgFontFace(vg, "regular");
+    nvgFontSize(vg, fontSize);
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+    float bb[4];
+    nvgTextBounds(vg, 0, 0, m_badgeText.c_str(), nullptr, bb);
+    m_badgeTextW = bb[2] - bb[0];
+    m_badgeTextH = bb[3] - bb[1];
 }
 
 void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float height,

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -8,7 +8,6 @@ MangaItemCell::MangaItemCell() {
     m_alive = std::make_shared<bool>(true);
     this->setFocusable(true);
     this->setCornerRadius(4.0f);
-    this->setBackgroundColor(nvgRGB(40, 40, 48));
 }
 
 MangaItemCell::~MangaItemCell() {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -392,6 +392,12 @@ void RecyclingGrid::setupGrid() {
     m_nextCoverLoadIdx = 0;
     m_allCoversQueued = false;
 
+    // Cache badge drawing parameters (avoids per-frame settings/color lookups)
+    m_showUnreadBadge = Application::getInstance().getSettings().showUnreadBadge;
+    m_badgeColor = Application::getInstance().getTealColor();
+    m_badgeFontSize = (m_columns <= 4) ? 13.0f : (m_columns >= 8) ? 8.0f : 10.0f;
+    m_badgeMargin = (m_columns <= 4) ? 8.0f : (m_columns >= 8) ? 4.0f : 6.0f;
+
     if (m_items.empty()) {
         float setupMs = std::chrono::duration<float, std::milli>(
             std::chrono::steady_clock::now() - setupStart).count();
@@ -649,48 +655,40 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     }
 
     // Draw unread count badges on visible cells (after covers so they're on top)
-    if (m_cachedFirstVisible >= 0 && Application::getInstance().getSettings().showUnreadBadge) {
+    if (m_cachedFirstVisible >= 0 && m_showUnreadBadge) {
         int startIdx = m_cachedFirstVisible * m_columns;
         int endIdx = std::min(m_cachedLastVisible * m_columns,
                               static_cast<int>(m_cells.size()));
 
         nvgSave(vg);
         nvgIntersectScissor(vg, x, y, width, height);
+        nvgFontFace(vg, "regular");
+        nvgFontSize(vg, m_badgeFontSize);
+        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
 
         for (int i = startIdx; i < endIdx; i++) {
             MangaItemCell* cell = m_cells[i];
-            if (!cell) continue;
-            int unread = cell->getManga().unreadCount;
-            if (unread <= 0) continue;
+            if (!cell || !cell->hasBadge()) continue;
+
+            // Lazy-cache text bounds once per cell (not per frame)
+            cell->cacheBadgeBounds(vg, m_badgeFontSize);
 
             float cx = cell->getDrawX();
             float cy = cell->getDrawY();
-            if (cx == 0 && cy == 0) continue;
-
-            std::string text = std::to_string(unread);
-            float fontSize = (m_columns <= 4) ? 13.0f : (m_columns >= 8) ? 8.0f : 10.0f;
-            float margin = (m_columns <= 4) ? 8.0f : (m_columns >= 8) ? 4.0f : 6.0f;
-            float padX = 4.0f;
-            float padY = 2.0f;
-
-            nvgFontFace(vg, "regular");
-            nvgFontSize(vg, fontSize);
-            nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-            float bb[4];
-            nvgTextBounds(vg, 0, 0, text.c_str(), nullptr, bb);
-            float tw = bb[2] - bb[0];
-            float th = bb[3] - bb[1];
-
-            float bx = cx + margin;
-            float by = cy + margin;
+            float bx = cx + m_badgeMargin;
+            float by = cy + m_badgeMargin;
+            float tw = cell->getBadgeTextW();
+            float th = cell->getBadgeTextH();
+            static constexpr float padX = 4.0f;
+            static constexpr float padY = 2.0f;
 
             nvgBeginPath(vg);
             nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
-            nvgFillColor(vg, Application::getInstance().getTealColor());
+            nvgFillColor(vg, m_badgeColor);
             nvgFill(vg);
 
             nvgFillColor(vg, nvgRGB(255, 255, 255));
-            nvgText(vg, bx + padX, by + padY, text.c_str(), nullptr);
+            nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
         }
 
         nvgRestore(vg);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -610,9 +610,11 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 
-    // Batched cover draw: render cover textures for visible cells.
-    // Uses each cell's stored draw coordinates (captured during Box::draw)
-    // to guarantee covers align exactly with cell backgrounds.
+    // Batched cover + badge draw: single pass over visible cells.
+    // Covers are drawn first, then badges on top, all in one loop to avoid
+    // iterating visible cells multiple times. Placeholder backgrounds are
+    // drawn for cells without a loaded cover (replaces per-cell drawBackground
+    // which was 4 NVG calls per cell per frame even when hidden by a cover).
     if (m_cachedFirstVisible >= 0) {
         nvgSave(vg);
         nvgIntersectScissor(vg, x, y, width, height);
@@ -621,11 +623,12 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         int endIdx = std::min(m_cachedLastVisible * m_columns,
                               static_cast<int>(m_cells.size()));
 
+        bool drawBadges = m_showUnreadBadge && !m_uploadsDeferred;
+        bool fontSet = false;
+
         for (int i = startIdx; i < endIdx; i++) {
             MangaItemCell* cell = m_cells[i];
             if (!cell) continue;
-            int nvgImg = cell->getCoverImage();
-            if (nvgImg == 0) continue;
 
             float cx = cell->getDrawX();
             float cy = cell->getDrawY();
@@ -633,62 +636,54 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             float ch = cell->getDrawH();
             if (cw <= 0 || ch <= 0) continue;
 
-            float imgW = static_cast<float>(cell->getCoverWidth());
-            float imgH = static_cast<float>(cell->getCoverHeight());
-            if (imgW <= 0 || imgH <= 0) continue;
+            int nvgImg = cell->getCoverImage();
+            if (nvgImg != 0) {
+                float imgW = static_cast<float>(cell->getCoverWidth());
+                float imgH = static_cast<float>(cell->getCoverHeight());
+                if (imgW > 0 && imgH > 0) {
+                    float scale = std::max(cw / imgW, ch / imgH);
+                    float sw = imgW * scale;
+                    float sh = imgH * scale;
+                    float ox = cx + (cw - sw) * 0.5f;
+                    float oy = cy + (ch - sh) * 0.5f;
 
-            float scale = std::max(cw / imgW, ch / imgH);
-            float sw = imgW * scale;
-            float sh = imgH * scale;
-            float ox = cx + (cw - sw) * 0.5f;
-            float oy = cy + (ch - sh) * 0.5f;
+                    NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
+                                                      0, nvgImg, 1.0f);
+                    nvgBeginPath(vg);
+                    nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                    nvgFillPaint(vg, paint);
+                    nvgFill(vg);
+                }
+            } else {
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                nvgFillColor(vg, nvgRGB(40, 40, 48));
+                nvgFill(vg);
+            }
 
-            NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
-                                              0, nvgImg, 1.0f);
-            nvgBeginPath(vg);
-            nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
-            nvgFillPaint(vg, paint);
-            nvgFill(vg);
-        }
+            if (drawBadges && cell->hasBadge()) {
+                if (!fontSet) {
+                    nvgFontFace(vg, "regular");
+                    nvgFontSize(vg, m_badgeFontSize);
+                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+                    fontSet = true;
+                }
+                cell->cacheBadgeBounds(vg, m_badgeFontSize);
+                float bx = cx + m_badgeMargin;
+                float by = cy + m_badgeMargin;
+                float tw = cell->getBadgeTextW();
+                float th = cell->getBadgeTextH();
+                static constexpr float padX = 4.0f;
+                static constexpr float padY = 2.0f;
 
-        nvgRestore(vg);
-    }
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
+                nvgFillColor(vg, m_badgeColor);
+                nvgFill(vg);
 
-    // Draw unread count badges on visible cells (after covers so they're on top)
-    if (m_cachedFirstVisible >= 0 && m_showUnreadBadge) {
-        int startIdx = m_cachedFirstVisible * m_columns;
-        int endIdx = std::min(m_cachedLastVisible * m_columns,
-                              static_cast<int>(m_cells.size()));
-
-        nvgSave(vg);
-        nvgIntersectScissor(vg, x, y, width, height);
-        nvgFontFace(vg, "regular");
-        nvgFontSize(vg, m_badgeFontSize);
-        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-
-        for (int i = startIdx; i < endIdx; i++) {
-            MangaItemCell* cell = m_cells[i];
-            if (!cell || !cell->hasBadge()) continue;
-
-            // Lazy-cache text bounds once per cell (not per frame)
-            cell->cacheBadgeBounds(vg, m_badgeFontSize);
-
-            float cx = cell->getDrawX();
-            float cy = cell->getDrawY();
-            float bx = cx + m_badgeMargin;
-            float by = cy + m_badgeMargin;
-            float tw = cell->getBadgeTextW();
-            float th = cell->getBadgeTextH();
-            static constexpr float padX = 4.0f;
-            static constexpr float padY = 2.0f;
-
-            nvgBeginPath(vg);
-            nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
-            nvgFillColor(vg, m_badgeColor);
-            nvgFill(vg);
-
-            nvgFillColor(vg, nvgRGB(255, 255, 255));
-            nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
+                nvgFillColor(vg, nvgRGB(255, 255, 255));
+                nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
+            }
         }
 
         nvgRestore(vg);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -648,6 +648,54 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         nvgRestore(vg);
     }
 
+    // Draw unread count badges on visible cells (after covers so they're on top)
+    if (m_cachedFirstVisible >= 0 && Application::getInstance().getSettings().showUnreadBadge) {
+        int startIdx = m_cachedFirstVisible * m_columns;
+        int endIdx = std::min(m_cachedLastVisible * m_columns,
+                              static_cast<int>(m_cells.size()));
+
+        nvgSave(vg);
+        nvgIntersectScissor(vg, x, y, width, height);
+
+        for (int i = startIdx; i < endIdx; i++) {
+            MangaItemCell* cell = m_cells[i];
+            if (!cell) continue;
+            int unread = cell->getManga().unreadCount;
+            if (unread <= 0) continue;
+
+            float cx = cell->getDrawX();
+            float cy = cell->getDrawY();
+            if (cx == 0 && cy == 0) continue;
+
+            std::string text = std::to_string(unread);
+            float fontSize = (m_columns <= 4) ? 13.0f : (m_columns >= 8) ? 8.0f : 10.0f;
+            float margin = (m_columns <= 4) ? 8.0f : (m_columns >= 8) ? 4.0f : 6.0f;
+            float padX = 4.0f;
+            float padY = 2.0f;
+
+            nvgFontFace(vg, "regular");
+            nvgFontSize(vg, fontSize);
+            nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+            float bb[4];
+            nvgTextBounds(vg, 0, 0, text.c_str(), nullptr, bb);
+            float tw = bb[2] - bb[0];
+            float th = bb[3] - bb[1];
+
+            float bx = cx + margin;
+            float by = cy + margin;
+
+            nvgBeginPath(vg);
+            nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
+            nvgFillColor(vg, Application::getInstance().getTealColor());
+            nvgFill(vg);
+
+            nvgFillColor(vg, nvgRGB(255, 255, 255));
+            nvgText(vg, bx + padX, by + padY, text.c_str(), nullptr);
+        }
+
+        nvgRestore(vg);
+    }
+
     // Draw start button hint on the focused cell (after covers so it's on top)
     if (m_focusedIndex >= 0 && m_focusedIndex < static_cast<int>(m_cells.size())) {
         MangaItemCell* focused = m_cells[m_focusedIndex];


### PR DESCRIPTION
Adds the unread-count badge above covers, caches its per-frame computations to fix the FPS drop, and eliminates redundant per-cell NVG calls in the grid draw.

---
_Generated by [Claude Code](https://claude.ai/code)_