### PR TITLE
Optimize grid draw: eliminate redundant NVG calls per cell per frame

### DIFF
--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -3671,12 +3671,29 @@ void LibrarySectionTab::updateMangaCellsIncrementally(const std::vector<Manga>& 
 
     brls::Logger::debug("LibrarySectionTab: Metadata changed, updating cells in place");
 
-    // Update the manga list and apply sort via sortMangaList(), which uses
-    // updateDataOrder() to properly handle thumbnail updates when manga
-    // change positions. Previously used updateCellData() here which preserved
-    // old thumbnails even when the sort order changed, causing cover mismatches.
-    m_mangaList = newManga;
-    sortMangaList();
+    // Update metadata on the existing sorted list without re-sorting.
+    // Re-sorting would shuffle cover positions every time the server returns
+    // slightly different metadata (unread counts, timestamps), causing a
+    // visible flicker as covers reload in new positions.
+    std::map<int, const Manga*> newById;
+    for (const auto& m : newManga) {
+        newById[m.id] = &m;
+    }
+    for (auto& m : m_mangaList) {
+        auto it = newById.find(m.id);
+        if (it != newById.end()) {
+            const Manga* updated = it->second;
+            m.unreadCount = updated->unreadCount;
+            m.lastReadAt = updated->lastReadAt;
+            m.latestChapterUploadDate = updated->latestChapterUploadDate;
+            m.chapterCount = updated->chapterCount;
+            m.downloadedCount = updated->downloadedCount;
+            m.thumbnailUrl = updated->thumbnailUrl;
+        }
+    }
+    if (m_contentGrid) {
+        m_contentGrid->updateCellData(m_mangaList);
+    }
 
     // Update cache
     m_cachedMangaList.clear();

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -1300,8 +1300,21 @@ void LibrarySectionTab::loadCategories() {
 
                 brls::Logger::info("LibrarySectionTab: Applied prefetched manga ({} items) from combined query",
                                   prefetchedManga.size());
+            } else if (selectedId == m_currentCategoryId && m_loaded) {
+                // Category already loaded and displayed — just refresh UI state
+                // (tabs may have been recreated, so update index/styles/scroll)
+                m_selectedCategoryIndex = 0;
+                for (size_t i = 0; i < m_categories.size(); i++) {
+                    if (m_categories[i].id == selectedId) {
+                        m_selectedCategoryIndex = static_cast<int>(i);
+                        break;
+                    }
+                }
+                updateCategoryButtonStyles();
+                scrollToCategoryIndex(m_selectedCategoryIndex);
+                brls::Logger::info("LibrarySectionTab: Category {} already loaded, skipping redundant reload", selectedId);
             } else {
-                // No prefetched manga or category changed - use normal selectCategory flow
+                // Different category or not yet loaded - use normal selectCategory flow
                 selectCategory(selectedId);
             }
 

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -8,7 +8,6 @@ MangaItemCell::MangaItemCell() {
     m_alive = std::make_shared<bool>(true);
     this->setFocusable(true);
     this->setCornerRadius(4.0f);
-    this->setBackgroundColor(nvgRGB(40, 40, 48));
 }
 
 MangaItemCell::~MangaItemCell() {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -623,7 +623,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         int endIdx = std::min(m_cachedLastVisible * m_columns,
                               static_cast<int>(m_cells.size()));
 
-        bool drawBadges = m_showUnreadBadge && !m_uploadsDeferred;
+        bool drawBadges = m_showUnreadBadge;
         bool fontSet = false;
 
         for (int i = startIdx; i < endIdx; i++) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -610,9 +610,11 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 
-    // Batched cover draw: render cover textures for visible cells.
-    // Uses each cell's stored draw coordinates (captured during Box::draw)
-    // to guarantee covers align exactly with cell backgrounds.
+    // Batched cover + badge draw: single pass over visible cells.
+    // Covers are drawn first, then badges on top, all in one loop to avoid
+    // iterating visible cells multiple times. Placeholder backgrounds are
+    // drawn for cells without a loaded cover (replaces per-cell drawBackground
+    // which was 4 NVG calls per cell per frame even when hidden by a cover).
     if (m_cachedFirstVisible >= 0) {
         nvgSave(vg);
         nvgIntersectScissor(vg, x, y, width, height);
@@ -621,11 +623,12 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         int endIdx = std::min(m_cachedLastVisible * m_columns,
                               static_cast<int>(m_cells.size()));
 
+        bool drawBadges = m_showUnreadBadge && !m_uploadsDeferred;
+        bool fontSet = false;
+
         for (int i = startIdx; i < endIdx; i++) {
             MangaItemCell* cell = m_cells[i];
             if (!cell) continue;
-            int nvgImg = cell->getCoverImage();
-            if (nvgImg == 0) continue;
 
             float cx = cell->getDrawX();
             float cy = cell->getDrawY();
@@ -633,62 +636,54 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             float ch = cell->getDrawH();
             if (cw <= 0 || ch <= 0) continue;
 
-            float imgW = static_cast<float>(cell->getCoverWidth());
-            float imgH = static_cast<float>(cell->getCoverHeight());
-            if (imgW <= 0 || imgH <= 0) continue;
+            int nvgImg = cell->getCoverImage();
+            if (nvgImg != 0) {
+                float imgW = static_cast<float>(cell->getCoverWidth());
+                float imgH = static_cast<float>(cell->getCoverHeight());
+                if (imgW > 0 && imgH > 0) {
+                    float scale = std::max(cw / imgW, ch / imgH);
+                    float sw = imgW * scale;
+                    float sh = imgH * scale;
+                    float ox = cx + (cw - sw) * 0.5f;
+                    float oy = cy + (ch - sh) * 0.5f;
 
-            float scale = std::max(cw / imgW, ch / imgH);
-            float sw = imgW * scale;
-            float sh = imgH * scale;
-            float ox = cx + (cw - sw) * 0.5f;
-            float oy = cy + (ch - sh) * 0.5f;
+                    NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
+                                                      0, nvgImg, 1.0f);
+                    nvgBeginPath(vg);
+                    nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                    nvgFillPaint(vg, paint);
+                    nvgFill(vg);
+                }
+            } else {
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                nvgFillColor(vg, nvgRGB(40, 40, 48));
+                nvgFill(vg);
+            }
 
-            NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
-                                              0, nvgImg, 1.0f);
-            nvgBeginPath(vg);
-            nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
-            nvgFillPaint(vg, paint);
-            nvgFill(vg);
-        }
+            if (drawBadges && cell->hasBadge()) {
+                if (!fontSet) {
+                    nvgFontFace(vg, "regular");
+                    nvgFontSize(vg, m_badgeFontSize);
+                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+                    fontSet = true;
+                }
+                cell->cacheBadgeBounds(vg, m_badgeFontSize);
+                float bx = cx + m_badgeMargin;
+                float by = cy + m_badgeMargin;
+                float tw = cell->getBadgeTextW();
+                float th = cell->getBadgeTextH();
+                static constexpr float padX = 4.0f;
+                static constexpr float padY = 2.0f;
 
-        nvgRestore(vg);
-    }
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
+                nvgFillColor(vg, m_badgeColor);
+                nvgFill(vg);
 
-    // Draw unread count badges on visible cells (after covers so they're on top)
-    if (m_cachedFirstVisible >= 0 && m_showUnreadBadge) {
-        int startIdx = m_cachedFirstVisible * m_columns;
-        int endIdx = std::min(m_cachedLastVisible * m_columns,
-                              static_cast<int>(m_cells.size()));
-
-        nvgSave(vg);
-        nvgIntersectScissor(vg, x, y, width, height);
-        nvgFontFace(vg, "regular");
-        nvgFontSize(vg, m_badgeFontSize);
-        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-
-        for (int i = startIdx; i < endIdx; i++) {
-            MangaItemCell* cell = m_cells[i];
-            if (!cell || !cell->hasBadge()) continue;
-
-            // Lazy-cache text bounds once per cell (not per frame)
-            cell->cacheBadgeBounds(vg, m_badgeFontSize);
-
-            float cx = cell->getDrawX();
-            float cy = cell->getDrawY();
-            float bx = cx + m_badgeMargin;
-            float by = cy + m_badgeMargin;
-            float tw = cell->getBadgeTextW();
-            float th = cell->getBadgeTextH();
-            static constexpr float padX = 4.0f;
-            static constexpr float padY = 2.0f;
-
-            nvgBeginPath(vg);
-            nvgRoundedRect(vg, bx, by, tw + padX * 2, th + padY * 2, 2.0f);
-            nvgFillColor(vg, m_badgeColor);
-            nvgFill(vg);
-
-            nvgFillColor(vg, nvgRGB(255, 255, 255));
-            nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
+                nvgFillColor(vg, nvgRGB(255, 255, 255));
+                nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
+            }
         }
 
         nvgRestore(vg);


### PR DESCRIPTION
Optimizes the grid draw (removing redundant per-cell NVG calls), keeps unread badges visible during scroll, and fixes duplicate category loads and cover flicker on load by not re-sorting on server refresh.

---
_Generated by [Claude Code](https://claude.ai/code)_