### PR TITLE
Add title text below covers in normal grid mode

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -49,6 +49,11 @@ public:
     bool hasBadge() const { return !m_badgeText.empty(); }
     void cacheBadgeBounds(NVGcontext* vg, float fontSize);
 
+    // Cached truncated title (precomputed once, drawn with nvgText not nvgTextBox)
+    const std::string& getCachedTitle() const { return m_cachedTitle; }
+    bool hasCachedTitle() const { return m_titleCached; }
+    void cacheTitleText(NVGcontext* vg, float fontSize, float maxWidth, int maxLines);
+
     void setPressed(bool pressed);
     bool isPressed() const { return m_pressed; }
 
@@ -74,6 +79,8 @@ private:
     std::string m_badgeText;
     float m_badgeTextW = 0;
     float m_badgeTextH = 0;
+    std::string m_cachedTitle;
+    bool m_titleCached = false;
     std::shared_ptr<bool> m_alive;
 };
 

--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -158,6 +158,11 @@ private:
     float m_badgeMargin = 6.0f;
     NVGcolor m_badgeColor = {};
 
+    // Cached title drawing state (computed once in setupGrid)
+    bool m_showTitles = false;
+    float m_titleFontSize = 10.0f;
+    float m_titleAreaHeight = 28.0f;
+
     // Alive flag for deferred callbacks (kept for any future brls::sync usage).
     std::shared_ptr<bool> m_alive;
     int m_totalRowsNeeded = 0;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -23,6 +23,7 @@ MangaItemCell::~MangaItemCell() {
 void MangaItemCell::setManga(const Manga& manga) {
     m_manga = manga;
     m_thumbnailLoaded = false;
+    m_titleCached = false;
     m_badgeText = (manga.unreadCount > 0) ? std::to_string(manga.unreadCount) : std::string();
     m_badgeTextW = 0;
     m_badgeTextH = 0;
@@ -31,7 +32,11 @@ void MangaItemCell::setManga(const Manga& manga) {
 void MangaItemCell::updateMangaData(const Manga& manga) {
     bool coverChanged = (m_manga.thumbnailUrl != manga.thumbnailUrl);
     bool unreadChanged = (m_manga.unreadCount != manga.unreadCount);
+    bool titleChanged = (m_manga.title != manga.title);
     m_manga = manga;
+    if (titleChanged) {
+        m_titleCached = false;
+    }
     if (coverChanged) {
         if (m_nvgCover != 0) {
             NVGcontext* vg = brls::Application::getNVGContext();
@@ -123,6 +128,41 @@ void MangaItemCell::unloadThumbnail() {
 
 void MangaItemCell::resetThumbnailLoadState() {
     m_thumbnailLoaded = false;
+}
+
+void MangaItemCell::cacheTitleText(NVGcontext* vg, float fontSize, float maxWidth, int maxLines) {
+    if (m_titleCached) return;
+    m_titleCached = true;
+
+    const std::string& title = m_manga.title;
+    if (title.empty()) {
+        m_cachedTitle.clear();
+        return;
+    }
+
+    nvgFontFace(vg, "regular");
+    nvgFontSize(vg, fontSize);
+    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+
+    // Measure how many characters fit on each line using NVG's row-break API
+    NVGtextRow rows[4];
+    int maxRows = (maxLines > 4) ? 4 : maxLines;
+    int nrows = nvgTextBreakLines(vg, title.c_str(), nullptr, maxWidth, rows, maxRows);
+
+    m_cachedTitle.clear();
+    for (int r = 0; r < nrows; r++) {
+        if (r > 0) m_cachedTitle += '\n';
+        if (r == maxRows - 1 && rows[r].end != (title.c_str() + title.size())) {
+            // Last visible line but more text remains — add ellipsis
+            m_cachedTitle.append(rows[r].start, rows[r].end);
+            // Trim trailing space before ellipsis
+            while (!m_cachedTitle.empty() && m_cachedTitle.back() == ' ')
+                m_cachedTitle.pop_back();
+            m_cachedTitle += "...";
+        } else {
+            m_cachedTitle.append(rows[r].start, rows[r].end);
+        }
+    }
 }
 
 void MangaItemCell::setPressed(bool pressed) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -627,7 +627,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
                               static_cast<int>(m_cells.size()));
 
         bool drawBadges = m_showUnreadBadge;
-        bool drawTitles = m_showTitles && !m_uploadsDeferred;
+        bool drawTitles = m_showTitles;
         float titleAreaH = m_showTitles ? m_titleAreaHeight : 0.0f;
         bool fontSet = false;
         bool titleFontSet = false;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -699,16 +699,26 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
                     nvgFontSize(vg, m_titleFontSize);
                     nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
                     titleFontSet = true;
+                    fontSet = false;
                 } else if (fontSet) {
                     nvgFontSize(vg, m_titleFontSize);
-                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+                    fontSet = false;
                 }
-                nvgFillColor(vg, nvgRGBA(255, 255, 255, 230));
-                float tx = cx + 2.0f;
-                float ty = cy + coverH + 2.0f;
-                float maxW = cw - 4.0f;
-                nvgTextBox(vg, tx, ty, maxW,
-                           cell->getManga().title.c_str(), nullptr);
+                cell->cacheTitleText(vg, m_titleFontSize, cw - 4.0f, 2);
+                const std::string& cached = cell->getCachedTitle();
+                if (!cached.empty()) {
+                    nvgFillColor(vg, nvgRGBA(255, 255, 255, 230));
+                    float ty = cy + coverH + 2.0f;
+                    float lineH = m_titleFontSize * 1.2f;
+                    size_t pos = 0;
+                    size_t nl = cached.find('\n');
+                    nvgText(vg, cx + 2.0f, ty, cached.c_str() + pos,
+                            (nl != std::string::npos) ? cached.c_str() + nl : nullptr);
+                    if (nl != std::string::npos) {
+                        nvgText(vg, cx + 2.0f, ty + lineH,
+                                cached.c_str() + nl + 1, nullptr);
+                    }
+                }
             }
         }
 

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -628,7 +628,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
 
         bool drawBadges = m_showUnreadBadge;
         bool drawTitles = m_showTitles && !m_uploadsDeferred;
-        float titleAreaH = m_titleAreaHeight;
+        float titleAreaH = m_showTitles ? m_titleAreaHeight : 0.0f;
         bool fontSet = false;
         bool titleFontSet = false;
 
@@ -642,7 +642,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             float ch = cell->getDrawH();
             if (cw <= 0 || ch <= 0) continue;
 
-            float coverH = drawTitles ? (ch - titleAreaH) : ch;
+            float coverH = ch - titleAreaH;
 
             int nvgImg = cell->getCoverImage();
             if (nvgImg != 0) {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -95,7 +95,6 @@ RecyclingGrid::~RecyclingGrid() {
     // so pending texture uploads can resume for any remaining views.
     if (m_uploadsDeferred) {
         ImageLoader::setDeferTextureUploads(false);
-        MangaItemCell::setTitlesEnabled(true);
     }
     if (m_startHintNvg != 0) {
         NVGcontext* vg = brls::Application::getNVGContext();
@@ -398,6 +397,11 @@ void RecyclingGrid::setupGrid() {
     m_badgeFontSize = (m_columns <= 4) ? 13.0f : (m_columns >= 8) ? 8.0f : 10.0f;
     m_badgeMargin = (m_columns <= 4) ? 8.0f : (m_columns >= 8) ? 4.0f : 6.0f;
 
+    // Cache title drawing parameters
+    m_showTitles = !m_compactMode && !m_listMode;
+    m_titleFontSize = (m_columns <= 4) ? 13.0f : (m_columns >= 8) ? 9.0f : 11.0f;
+    m_titleAreaHeight = (m_columns <= 4) ? 32.0f : (m_columns >= 8) ? 22.0f : 28.0f;
+
     if (m_items.empty()) {
         float setupMs = std::chrono::duration<float, std::milli>(
             std::chrono::steady_clock::now() - setupStart).count();
@@ -610,11 +614,10 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     brls::ScrollingFrame::draw(vg, x, y, width, height, style, ctx);
     PERF_END("grid_draw");
 
-    // Batched cover + badge draw: single pass over visible cells.
-    // Covers are drawn first, then badges on top, all in one loop to avoid
-    // iterating visible cells multiple times. Placeholder backgrounds are
-    // drawn for cells without a loaded cover (replaces per-cell drawBackground
-    // which was 4 NVG calls per cell per frame even when hidden by a cover).
+    // Batched cover + badge + title draw: single pass over visible cells.
+    // Covers fill the cover area (full cell in compact, top portion in normal).
+    // Titles are drawn below the cover area in normal mode.
+    // Badges are drawn on top of covers. All in one loop.
     if (m_cachedFirstVisible >= 0) {
         nvgSave(vg);
         nvgIntersectScissor(vg, x, y, width, height);
@@ -624,7 +627,10 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
                               static_cast<int>(m_cells.size()));
 
         bool drawBadges = m_showUnreadBadge;
+        bool drawTitles = m_showTitles && !m_uploadsDeferred;
+        float titleAreaH = m_titleAreaHeight;
         bool fontSet = false;
+        bool titleFontSet = false;
 
         for (int i = startIdx; i < endIdx; i++) {
             MangaItemCell* cell = m_cells[i];
@@ -636,27 +642,29 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             float ch = cell->getDrawH();
             if (cw <= 0 || ch <= 0) continue;
 
+            float coverH = drawTitles ? (ch - titleAreaH) : ch;
+
             int nvgImg = cell->getCoverImage();
             if (nvgImg != 0) {
                 float imgW = static_cast<float>(cell->getCoverWidth());
                 float imgH = static_cast<float>(cell->getCoverHeight());
                 if (imgW > 0 && imgH > 0) {
-                    float scale = std::max(cw / imgW, ch / imgH);
+                    float scale = std::max(cw / imgW, coverH / imgH);
                     float sw = imgW * scale;
                     float sh = imgH * scale;
                     float ox = cx + (cw - sw) * 0.5f;
-                    float oy = cy + (ch - sh) * 0.5f;
+                    float oy = cy + (coverH - sh) * 0.5f;
 
                     NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh,
                                                       0, nvgImg, 1.0f);
                     nvgBeginPath(vg);
-                    nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                    nvgRoundedRect(vg, cx, cy, cw, coverH, 4.0f);
                     nvgFillPaint(vg, paint);
                     nvgFill(vg);
                 }
             } else {
                 nvgBeginPath(vg);
-                nvgRoundedRect(vg, cx, cy, cw, ch, 4.0f);
+                nvgRoundedRect(vg, cx, cy, cw, coverH, 4.0f);
                 nvgFillColor(vg, nvgRGB(40, 40, 48));
                 nvgFill(vg);
             }
@@ -683,6 +691,24 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
 
                 nvgFillColor(vg, nvgRGB(255, 255, 255));
                 nvgText(vg, bx + padX, by + padY, cell->getBadgeText().c_str(), nullptr);
+            }
+
+            if (drawTitles) {
+                if (!titleFontSet) {
+                    nvgFontFace(vg, "regular");
+                    nvgFontSize(vg, m_titleFontSize);
+                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+                    titleFontSet = true;
+                } else if (fontSet) {
+                    nvgFontSize(vg, m_titleFontSize);
+                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+                }
+                nvgFillColor(vg, nvgRGBA(255, 255, 255, 230));
+                float tx = cx + 2.0f;
+                float ty = cy + coverH + 2.0f;
+                float maxW = cw - 4.0f;
+                nvgTextBox(vg, tx, ty, maxW,
+                           cell->getManga().title.c_str(), nullptr);
             }
         }
 
@@ -737,10 +763,6 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
         if (wantDefer != m_uploadsDeferred) {
             m_uploadsDeferred = wantDefer;
             ImageLoader::setDeferTextureUploads(wantDefer);
-            // Also skip the per-cell title nvgText calls during fast
-            // scroll — 2 lines × ~24 cells × ~0.3ms = ~14ms/frame
-            // which is the main source of grid_draw cost on Vita.
-            MangaItemCell::setTitlesEnabled(!wantDefer);
         }
     }
 
@@ -912,9 +934,11 @@ void RecyclingGrid::setGridSize(int columns) {
     if (m_listMode) {
         m_cellHeight = 80;  // Fixed height for list mode
     } else if (m_compactMode) {
-        m_cellHeight = static_cast<int>(m_cellWidth * 1.4);  // Taller for compact (cover only)
+        m_cellHeight = static_cast<int>(m_cellWidth * 1.4);
     } else {
-        m_cellHeight = static_cast<int>(m_cellWidth * 1.4);  // Normal height with 2-line title
+        // Normal mode: cover + title area below
+        int titleArea = (m_columns <= 4) ? 32 : (m_columns >= 8) ? 22 : 28;
+        m_cellHeight = static_cast<int>(m_cellWidth * 1.4) + titleArea;
     }
 
     brls::Logger::info("RecyclingGrid: Grid size set to {} columns, cell {}x{}",


### PR DESCRIPTION
Adds title text below covers in normal grid mode with cached text layout, keeps the cover area constant on scroll stop, and keeps titles visible during scroll.

---
_Generated by [Claude Code](https://claude.ai/code)_