### PR TITLE
Remove dead unloadThumbnail method and add crash diagnostic logging

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -17,7 +17,6 @@ public:
     void updateMangaData(const Manga& manga);
 
     void loadThumbnailIfNeeded();
-    void unloadThumbnail();
     void resetThumbnailLoadState();
 
     bool isThumbnailLoaded() const { return m_thumbnailLoaded; }

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -114,18 +114,6 @@ void MangaItemCell::loadThumbnailIfNeeded() {
         m_alive);
 }
 
-void MangaItemCell::unloadThumbnail() {
-    if (!m_thumbnailLoaded) return;
-    if (m_nvgCover != 0) {
-        NVGcontext* vg = brls::Application::getNVGContext();
-        if (vg) nvgDeleteImage(vg, m_nvgCover);
-        m_nvgCover = 0;
-        m_coverW = 0;
-        m_coverH = 0;
-    }
-    m_thumbnailLoaded = false;
-}
-
 void MangaItemCell::resetThumbnailLoadState() {
     m_thumbnailLoaded = false;
 }

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1039,6 +1039,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     this->addView(m_categoryOverlay);
 
     // Load button icons immediately (avoids blank→loaded flash)
+    brls::Logger::info("MangaDetailView: Loading icons...");
     selectIcon->setImageFromFile(RESOURCE_PREFIX "images/select_button.png");
     rButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/r_button.png");
     updateSortIcon();
@@ -1046,6 +1047,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     filterIcon->setImageFromFile(RESOURCE_PREFIX "icons/filter-menu-outline.png");
     startButtonIcon->setImageFromFile(RESOURCE_PREFIX "images/start_button.png");
     menuIcon->setImageFromFile(RESOURCE_PREFIX "icons/menu.png");
+    brls::Logger::info("MangaDetailView: Icons loaded, starting detail fetch...");
 
     // Load full details
     loadDetails();

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1008,7 +1008,11 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_chaptersRecycler->registerCell("chapter", ChapterCell::create);
 
     m_chaptersDataSource = new ChaptersDataSource(this);
-    m_chaptersRecycler->setDataSource(m_chaptersDataSource);
+    // Don't set data source here — RecyclerFrame::selectRowAt crashes with
+    // an out-of-bounds access when the data source has 0 rows during the
+    // first yoga layout pass. Data source is attached in populateChaptersList
+    // once chapters are available. We pass false to setDataSource later so
+    // it never tries to delete our data source object.
 
     recyclerContainer->addView(m_chaptersRecycler);
     rightPanel->addView(recyclerContainer);
@@ -1766,9 +1770,17 @@ void MangaDetailView::populateChaptersList() {
     }
     dlLock.unlock();
 
-    // RecyclerFrame handles everything: only visible rows are created.
-    // No incremental batch building needed - instant for any chapter count.
-    m_chaptersRecycler->reloadData();
+    // RecyclerFrame::selectRowAt crashes with an out-of-bounds access when
+    // the data source reports 0 rows. Avoid calling reloadData in that case.
+    if (m_sortedFilteredChapters.empty()) {
+        if (m_chaptersRecycler->getDataSource()) {
+            m_chaptersRecycler->setDataSource(nullptr, false);
+        }
+    } else if (!m_chaptersRecycler->getDataSource()) {
+        m_chaptersRecycler->setDataSource(m_chaptersDataSource, false);
+    } else {
+        m_chaptersRecycler->reloadData();
+    }
     setupChapterNavigation();
 
     brls::Logger::debug("MangaDetailView: Recycler loaded {} chapters (only visible rows created)",
@@ -4082,7 +4094,7 @@ MangaDetailView::~MangaDetailView() {
     dm.setChapterCompletionCallback(nullptr);
     Application::getInstance().setReaderResultCallback(nullptr);
 
-    // Note: m_chaptersDataSource is owned and deleted by m_chaptersRecycler
+    delete m_chaptersDataSource;
 }
 
 } // namespace vitasuwayomi


### PR DESCRIPTION
Removes the dead `unloadThumbnail` method and fixes a crash when opening a book caused by a RecyclerFrame out-of-bounds (0-row) access.

---
_Generated by [Claude Code](https://claude.ai/code)_