### PR TITLE
Fix browser tab focus stealing and crash on second page load

### DIFF
--- a/include/view/recycling_grid.hpp
+++ b/include/view/recycling_grid.hpp
@@ -96,6 +96,7 @@ private:
     std::function<bool()> m_onBackPressed;
     std::function<void()> m_onEndReached;
     bool m_endReachedFired = false;  // Prevent repeated firing until new data is loaded
+    bool m_isAppending = false;      // Guard: suppress end-reached during appendItems
     std::function<void(int count)> m_onSelectionChanged;
 
     // Pull-to-refresh state

--- a/include/view/search_tab.hpp
+++ b/include/view/search_tab.hpp
@@ -141,6 +141,9 @@ private:
     void handleBackNavigation();
     bool m_isNavigatingBack = false;  // Guard against double back-press
 
+    // Returns true if focus is currently inside this SearchTab's view hierarchy
+    bool hasFocusInside() const;
+
     // Data
     std::vector<Source> m_sources;
     std::vector<Manga> m_mangaList;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -112,6 +112,10 @@ void RecyclingGrid::setDataSource(const std::vector<Manga>& items) {
 void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
     if (newItems.empty()) return;
 
+    // Suppress end-reached callbacks during the append to prevent re-entrant
+    // calls into loadNextPage while we're rebuilding rows.
+    m_isAppending = true;
+
     int oldCellCount = static_cast<int>(m_cells.size());
     int oldRowCount = static_cast<int>(m_rows.size());
 
@@ -119,8 +123,6 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
     for (const auto& item : newItems) {
         m_items.push_back(item);
     }
-
-    m_endReachedFired = false;  // Allow end-reached to fire again
 
     int newTotalRows = (m_items.size() + m_columns - 1) / m_columns;
     m_totalRowsNeeded = newTotalRows;
@@ -170,6 +172,12 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
 
     // Create only the new rows
     createRowRange(startRow, newTotalRows);
+
+    // Allow end-reached to fire again now that all rows are built.
+    // Reset AFTER createRowRange so focus events during cell creation
+    // don't re-trigger loadNextPage while the grid is mid-construction.
+    m_isAppending = false;
+    m_endReachedFired = false;
 
     brls::Logger::info("RecyclingGrid: appendItems - added {} items, now {} total ({} rows)",
                         newItems.size(), m_items.size(), newTotalRows);
@@ -494,9 +502,11 @@ void RecyclingGrid::createRowRange(int startRow, int endRow) {
 
             cell->getFocusEvent()->subscribe([this, index](brls::View*) {
                 m_focusedIndex = index;
-                loadThumbnailsNearIndex(index);
+                if (!m_isAppending) {
+                    loadThumbnailsNearIndex(index);
+                }
 
-                if (m_onEndReached && !m_endReachedFired) {
+                if (m_onEndReached && !m_endReachedFired && !m_isAppending) {
                     int threshold = m_columns * 2;
                     if (index >= static_cast<int>(m_items.size()) - threshold) {
                         m_endReachedFired = true;

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -141,12 +141,24 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
         } else if (cellsInLastRow < m_columns) {
             // Partial last row - remove and rebuild it with new items
 
-            // Move focus away if it's on a cell in the partial row being removed
+            // Move focus to a cell in an EARLIER row before removing the
+            // partial row.  giveFocus(m_contentBox) is not safe because
+            // Box::getDefaultFocus() may return a cell in the partial row
+            // via the stale lastFocusedView pointer, and removeView does
+            // not clear lastFocusedView — leaving a dangling pointer.
             int partialStart = oldCellCount - cellsInLastRow;
+            bool needsFocusMove = false;
             for (int i = partialStart; i < oldCellCount; i++) {
                 if (m_cells[i] && m_cells[i]->isFocused()) {
-                    brls::Application::giveFocus(m_contentBox);
+                    needsFocusMove = true;
                     break;
+                }
+            }
+            if (needsFocusMove) {
+                if (partialStart > 0 && m_cells[0]) {
+                    brls::Application::giveFocus(m_cells[0]);
+                } else {
+                    brls::Application::giveFocus(this);
                 }
             }
 

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -550,6 +550,15 @@ brls::View* SearchTab::getNextFocus(brls::FocusDirection direction, brls::View* 
     return brls::Box::getNextFocus(direction, currentView);
 }
 
+bool SearchTab::hasFocusInside() const {
+    brls::View* cur = brls::Application::getCurrentFocus();
+    while (cur) {
+        if (cur == this) return true;
+        cur = cur->getParent();
+    }
+    return false;
+}
+
 void SearchTab::loadSources() {
     brls::Logger::debug("SearchTab: Loading sources");
     m_browseMode = BrowseMode::SOURCES;
@@ -586,8 +595,9 @@ void SearchTab::loadSources() {
                 if (!alive || !*alive) return;
                 hideLoadingIndicator();
                 m_resultsLabel->setText("App is offline - connect to a server to browse sources");
-                // Focus on history button so user can still navigate
-                brls::Application::giveFocus(m_historyBtn);
+                if (hasFocusInside()) {
+                    brls::Application::giveFocus(m_historyBtn);
+                }
             });
         }
     });
@@ -766,9 +776,13 @@ void SearchTab::showSources() {
     m_historyBtn->setFocusable(true);
     m_globalSearchBtn->setFocusable(true);
 
-    // CRITICAL: Move focus to a safe target before clearing any views.
-    // Focus may be on a grid cell or search result row that will be deleted.
-    brls::Application::giveFocus(m_historyBtn);
+    // Move focus to a safe target before clearing views that may hold focus.
+    // Only do this if focus is actually inside this tab — otherwise we'd steal
+    // focus from whichever tab the user is currently viewing.
+    bool weHaveFocus = hasFocusInside();
+    if (weHaveFocus) {
+        brls::Application::giveFocus(m_historyBtn);
+    }
 
     // Clear manga grid, results by source, and hide search results view
     m_mangaList.clear();
@@ -931,8 +945,8 @@ void SearchTab::showSources() {
         m_globalSearchBtn->setCustomNavigationRoute(brls::FocusDirection::DOWN, nullptr);
     }
 
-    // Transfer focus to first source row
-    if (firstSourceRow) {
+    // Transfer focus to first source row (only if we already have focus)
+    if (firstSourceRow && weHaveFocus) {
         brls::Application::giveFocus(firstSourceRow);
     }
 }


### PR DESCRIPTION
Fixes browser-tab focus stealing and a crash on the second page load, fixing the dangling pointer from the app side rather than via the borealis submodule.

---
_Generated by [Claude Code](https://claude.ai/code)_