### PR TITLE
Fix save-version job: add workflows permission for pushing workflow changes

### DIFF
--- a/.github/workflows/build-multi-platform.yml
+++ b/.github/workflows/build-multi-platform.yml
@@ -101,6 +101,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
     permissions:
       contents: write
+      workflows: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fix save-version job: add workflows permission for pushing workflow changes

GitHub requires explicit `workflows: write` permission for a GitHub App
to push changes to workflow files.

---
_Generated by [Claude Code](https://claude.ai/code)_