### PR TITLE
Fix search covers not loading and distribute result limit across sources

### DIFF
--- a/include/view/manga_item_cell.hpp
+++ b/include/view/manga_item_cell.hpp
@@ -34,6 +34,7 @@ public:
     float getDrawW() const { return m_drawW; }
     float getDrawH() const { return m_drawH; }
 
+    void setSelfDrawCover(bool v) { m_selfDrawCover = v; }
     void setCompactMode(bool compact) { m_compact = compact; }
     void setListMode(bool list) { m_listMode = list; }
     void setListRowSize(int) {}
@@ -74,6 +75,7 @@ private:
     bool m_pressed = false;
     bool m_compact = false;
     bool m_listMode = false;
+    bool m_selfDrawCover = false;
     bool m_thumbnailLoaded = false;
     std::string m_badgeText;
     float m_badgeTextW = 0;

--- a/src/view/manga_item_cell.cpp
+++ b/src/view/manga_item_cell.cpp
@@ -72,6 +72,32 @@ void MangaItemCell::draw(NVGcontext* vg, float x, float y, float width, float he
     m_drawW = width;
     m_drawH = height;
     brls::Box::draw(vg, x, y, width, height, style, ctx);
+
+    if (m_selfDrawCover && width > 0 && height > 0) {
+        if (m_nvgCover != 0) {
+            float imgW = static_cast<float>(m_coverW);
+            float imgH = static_cast<float>(m_coverH);
+            if (imgW > 0 && imgH > 0) {
+                float scaleW = width / imgW, scaleH = height / imgH;
+                float scale = (scaleW > scaleH) ? scaleW : scaleH;
+                float sw = imgW * scale;
+                float sh = imgH * scale;
+                float ox = x + (width - sw) * 0.5f;
+                float oy = y + (height - sh) * 0.5f;
+
+                NVGpaint paint = nvgImagePattern(vg, ox, oy, sw, sh, 0, m_nvgCover, 1.0f);
+                nvgBeginPath(vg);
+                nvgRoundedRect(vg, x, y, width, height, 4.0f);
+                nvgFillPaint(vg, paint);
+                nvgFill(vg);
+            }
+        } else {
+            nvgBeginPath(vg);
+            nvgRoundedRect(vg, x, y, width, height, 4.0f);
+            nvgFillColor(vg, nvgRGB(40, 40, 48));
+            nvgFill(vg);
+        }
+    }
 }
 
 void MangaItemCell::loadThumbnailIfNeeded() {

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -2436,6 +2436,8 @@ void SearchTab::performSearch(const std::string& query) {
         int failedSources = 0;
         int searchedSources = 0;
 
+        int maxPerSource = std::max(5, 200 / static_cast<int>(sourcesToSearch.size()));
+
         // Search each filtered source
         for (const auto& source : sourcesToSearch) {
             std::vector<Manga> results;
@@ -2448,19 +2450,15 @@ void SearchTab::performSearch(const std::string& query) {
                     for (auto& manga : results) {
                         manga.sourceName = source.name;
                     }
+                    if (static_cast<int>(results.size()) > maxPerSource) {
+                        results.resize(maxPerSource);
+                    }
                     resultsBySource[source.name] = results;
                     totalResults += results.size();
                 }
             } else {
                 failedSources++;
                 brls::Logger::warning("SearchTab: Search failed for source '{}'", source.name);
-            }
-
-            // Limit to prevent too many requests on constrained hardware
-            if (totalResults >= 100) {
-                brls::Logger::info("SearchTab: Hit 100-result limit after {} of {} sources",
-                                   searchedSources, sourcesToSearch.size());
-                break;
             }
         }
 
@@ -2476,7 +2474,7 @@ void SearchTab::performSearch(const std::string& query) {
         }
 
         int totalSourceCount = static_cast<int>(sourcesToSearch.size());
-        bool wasTruncated = (totalResults >= 100 && searchedSources < totalSourceCount);
+        bool wasTruncated = false;
 
         brls::sync([this, allResults, resultsBySource, failedSources, searchedSources,
                      totalSourceCount, wasTruncated, gen, aliveWeak]() {
@@ -2704,6 +2702,7 @@ brls::View* SearchTab::createSourceRow(const std::string& sourceName, const std:
         }
         cell->setGridColumns(columns);
         cell->setManga(manga[i]);
+        cell->loadThumbnailIfNeeded();
         cell->setWidth(cellWidth);
         cell->setHeight(cellHeight);
         cell->setMarginRight(10);

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -928,6 +928,11 @@ void SearchTab::showSources() {
     m_contentGrid->setVisibility(brls::Visibility::GONE);
     m_sourceScrollView->setVisibility(brls::Visibility::VISIBLE);
 
+    // The library tab's RecyclingGrid may have left s_deferTextureUploads=true
+    // (set during scroll and never cleared when the tab became invisible).
+    // Clear it so source icon texture uploads can proceed.
+    ImageLoader::setDeferTextureUploads(false);
+
     // Add scroll view if not already added
     if (m_sourceScrollView->getParent() == nullptr) {
         m_mainContent->addView(m_sourceScrollView);
@@ -2636,6 +2641,9 @@ void SearchTab::populateSearchResultsBySource() {
         }
     }
 
+    // Clear deferred texture uploads so search result covers can load
+    ImageLoader::setDeferTextureUploads(false);
+
     // Show search results view, hide others
     if (m_sourceScrollView) {
         m_sourceScrollView->setVisibility(brls::Visibility::GONE);
@@ -2694,6 +2702,7 @@ brls::View* SearchTab::createSourceRow(const std::string& sourceName, const std:
     // Create manga cells for each result
     for (size_t i = 0; i < manga.size(); i++) {
         auto* cell = new MangaItemCell();
+        cell->setSelfDrawCover(true);
         cell->setShowLibraryBadge(true);  // Show star for library items in search results
         if (compactMode) {
             cell->setCompactMode(true);


### PR DESCRIPTION
Fixes global-search covers not loading and distributes the result limit across sources, and fixes browser-tab source icons not rendering.

---
_Generated by [Claude Code](https://claude.ai/code)_