### PR TITLE
Drop mpv and FFmpeg from Linux build to fix SteamOS runtime error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,13 @@ if(PLATFORM_ANDROID)
 elseif(WIN32)
     set(APP_FFMPEG_LIBS mpv)
     set(APP_FFMPEG_LINK_BLOCK ${APP_FFMPEG_LIBS})
+elseif(UNIX AND NOT APPLE AND NOT PLATFORM_PS4)
+    # Linux/SteamOS: mpv is unused and FFmpeg is only for AVIF/HEIF (rare).
+    # Skip both to avoid runtime errors on distros with different FFmpeg
+    # versions (e.g. SteamOS ships FFmpeg 7.x, CI builds against 6.x).
+    set(APP_FFMPEG_LIBS)
+    set(APP_FFMPEG_LINK_BLOCK)
+    add_definitions(-DVITASUWAYOMI_NO_FFMPEG)
 else()
     set(APP_FFMPEG_LIBS
         mpv

--- a/src/utils/image_loader.cpp
+++ b/src/utils/image_loader.cpp
@@ -48,7 +48,7 @@
 #include "nanosvgrast.h"
 
 // FFmpeg for AVIF/HEIF decoding (libraries already linked)
-#if !defined(_WIN32) && defined(__has_include)
+#if !defined(_WIN32) && !defined(VITASUWAYOMI_NO_FFMPEG) && defined(__has_include)
 #if __has_include(<libavcodec/avcodec.h>) && __has_include(<libavformat/avformat.h>) && __has_include(<libavutil/imgutils.h>) && __has_include(<libswscale/swscale.h>)
 #define VITASUWAYOMI_HAS_FFMPEG 1
 extern "C" {


### PR DESCRIPTION
Drop mpv and FFmpeg from Linux build to fix SteamOS runtime error

mpv is unused in app code (only referenced in a Switch-specific borealis
file). FFmpeg is only used for AVIF/HEIF decoding which is rare for
manga sources. Linking them dynamically causes runtime errors on distros
with different FFmpeg versions (e.g. SteamOS has FFmpeg 7.x, CI builds
against 6.x with libavformat.so.60).

Skip both on Linux like Android already does. Added
VITASUWAYOMI_NO_FFMPEG define to suppress the __has_include guard in
image_loader.cpp so FFmpeg headers on CI don't cause link failures.

---
_Generated by [Claude Code](https://claude.ai/code)_