### PR TITLE
Add SyncYomi settings section and update api.txt with sync API

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -1690,6 +1690,86 @@ mutation DeleteGlobalMetas($keys: [String!], $keyStartsWith: [String!]) {
 }
 
 # ============================================================================
+# SYNCYOMI
+# ============================================================================
+
+# SyncYomi Settings (part of server settings)
+# These are configured via the setSettings mutation and queried via settings query.
+#
+# Server Settings Fields:
+#   syncYomiEnabled: Boolean       # Enable/disable SyncYomi sync
+#   syncYomiHost: String           # SyncYomi server URL
+#   syncYomiApiKey: String         # API key for authentication
+#   syncDataManga: Boolean         # Sync manga data (default: true)
+#   syncDataChapters: Boolean      # Sync chapter data (default: true)
+#   syncDataTracking: Boolean      # Sync tracking data (default: true)
+#   syncDataHistory: Boolean       # Sync reading history (default: true)
+#   syncDataCategories: Boolean    # Sync categories (default: true)
+#   syncInterval: Duration         # Auto-sync interval (default: 0 = disabled)
+
+# Get SyncYomi Settings
+query GetSyncYomiSettings {
+    settings {
+        syncYomiEnabled
+        syncYomiHost
+        syncYomiApiKey
+        syncDataManga
+        syncDataChapters
+        syncDataTracking
+        syncDataHistory
+        syncDataCategories
+    }
+}
+
+# Update SyncYomi Settings
+mutation UpdateSyncYomiSettings {
+    setSettings(input: { settings: {
+        syncYomiEnabled: true,
+        syncYomiHost: "https://sync.example.com",
+        syncYomiApiKey: "your-api-key",
+        syncDataManga: true,
+        syncDataChapters: true,
+        syncDataTracking: true,
+        syncDataHistory: true,
+        syncDataCategories: true
+    }}) {
+        settings {
+            syncYomiEnabled
+        }
+    }
+}
+
+# Trigger Sync
+mutation StartSync {
+    startSync(input: {}) {
+        result                     # StartSyncResult: SUCCESS, SYNC_IN_PROGRESS, SYNC_DISABLED
+    }
+}
+
+# Get Last Sync Status
+query GetLastSyncStatus {
+    lastSyncStatus {
+        state                      # SyncState: STARTED, CREATING_BACKUP, DOWNLOADING,
+                                   #   MERGING, UPLOADING, RESTORING, SUCCESS, ERROR
+        startDate                  # Long timestamp
+        endDate                    # Long timestamp (null if still running)
+        backupRestoreId            # String (for RESTORING state)
+        errorMessage               # String (for ERROR state)
+    }
+}
+
+# Sync Status Subscription (WebSocket)
+subscription SyncStatusChanged {
+    syncStatusChanged {
+        state
+        startDate
+        endDate
+        backupRestoreId
+        errorMessage
+    }
+}
+
+# ============================================================================
 # BACKUP/RESTORE
 # ============================================================================
 

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -225,6 +225,16 @@ struct AppSettings {
     // Server image settings (applied once on first connection)
     bool serverImageSettingsApplied = false;
 
+    // SyncYomi Settings (server-side, configured via setSettings mutation)
+    bool syncYomiEnabled = false;
+    std::string syncYomiHost;
+    std::string syncYomiApiKey;
+    bool syncDataManga = true;
+    bool syncDataChapters = true;
+    bool syncDataTracking = true;
+    bool syncDataHistory = true;
+    bool syncDataCategories = true;
+
     // Per-manga reader settings (keyed by manga ID)
     // If a manga has custom settings, they override the defaults above
     std::map<int, MangaReaderSettings> mangaReaderSettings;

--- a/include/app/suwayomi_client.hpp
+++ b/include/app/suwayomi_client.hpp
@@ -617,6 +617,15 @@ public:
     // Apply server image settings (configure serveConversions to send only PNG/JPEG)
     bool applyServerImageSettings();
 
+    // SyncYomi settings (server-side)
+    bool fetchSyncYomiSettings(bool& enabled, std::string& host, std::string& apiKey,
+                                bool& dataManga, bool& dataChapters, bool& dataTracking,
+                                bool& dataHistory, bool& dataCategories);
+    bool updateSyncYomiSettings(bool enabled, const std::string& host, const std::string& apiKey,
+                                 bool dataManga, bool dataChapters, bool dataTracking,
+                                 bool dataHistory, bool dataCategories);
+    bool triggerSync(std::string& result);
+
     // Get update summary
     bool fetchUpdateSummary(int& pendingUpdates, int& runningJobs, bool& isUpdating);
 

--- a/include/view/settings_tab.hpp
+++ b/include/view/settings_tab.hpp
@@ -28,6 +28,7 @@ private:
     void createReaderSection();
     void createDownloadsSection();
     void createBrowseSection();
+    void createSyncYomiSection();
     void createBackupSection();
     void createStatisticsSection();
     void createAboutSection();

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1669,6 +1669,16 @@ bool Application::loadSettings() {
     m_settings.lastReadDate = extractInt64("lastReadDate");
     m_settings.totalReadingTime = extractInt64("totalReadingTime");
 
+    // Load SyncYomi settings
+    m_settings.syncYomiEnabled = extractBool("syncYomiEnabled", false);
+    m_settings.syncYomiHost = extractString("syncYomiHost");
+    m_settings.syncYomiApiKey = deobfuscate(extractString("syncYomiApiKey"));
+    m_settings.syncDataManga = extractBool("syncDataManga", true);
+    m_settings.syncDataChapters = extractBool("syncDataChapters", true);
+    m_settings.syncDataTracking = extractBool("syncDataTracking", true);
+    m_settings.syncDataHistory = extractBool("syncDataHistory", true);
+    m_settings.syncDataCategories = extractBool("syncDataCategories", true);
+
     // Load per-manga reader settings
     m_settings.mangaReaderSettings.clear();
     size_t mangaSettingsPos = content.find("\"mangaReaderSettings\"");
@@ -2009,6 +2019,16 @@ bool Application::saveSettings() {
     json += "  \"longestStreak\": " + std::to_string(m_settings.longestStreak) + ",\n";
     json += "  \"lastReadDate\": " + std::to_string(m_settings.lastReadDate) + ",\n";
     json += "  \"totalReadingTime\": " + std::to_string(m_settings.totalReadingTime) + ",\n";
+
+    // SyncYomi settings (cached locally from server)
+    json += "  \"syncYomiEnabled\": " + std::string(m_settings.syncYomiEnabled ? "true" : "false") + ",\n";
+    json += "  \"syncYomiHost\": \"" + m_settings.syncYomiHost + "\",\n";
+    json += "  \"syncYomiApiKey\": \"" + obfuscate(m_settings.syncYomiApiKey) + "\",\n";
+    json += "  \"syncDataManga\": " + std::string(m_settings.syncDataManga ? "true" : "false") + ",\n";
+    json += "  \"syncDataChapters\": " + std::string(m_settings.syncDataChapters ? "true" : "false") + ",\n";
+    json += "  \"syncDataTracking\": " + std::string(m_settings.syncDataTracking ? "true" : "false") + ",\n";
+    json += "  \"syncDataHistory\": " + std::string(m_settings.syncDataHistory ? "true" : "false") + ",\n";
+    json += "  \"syncDataCategories\": " + std::string(m_settings.syncDataCategories ? "true" : "false") + ",\n";
 
     // Per-manga reader settings
     json += "  \"mangaReaderSettings\": {";

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3088,6 +3088,130 @@ bool SuwayomiClient::removeExtensionRepo(const std::string& repoUrl) {
 }
 
 // ============================================================================
+// SyncYomi Settings
+// ============================================================================
+
+bool SuwayomiClient::fetchSyncYomiSettings(bool& enabled, std::string& host, std::string& apiKey,
+                                            bool& dataManga, bool& dataChapters, bool& dataTracking,
+                                            bool& dataHistory, bool& dataCategories) {
+    const char* query = R"(
+        query GetSyncYomiSettings {
+            settings {
+                syncYomiEnabled
+                syncYomiHost
+                syncYomiApiKey
+                syncDataManga
+                syncDataChapters
+                syncDataTracking
+                syncDataHistory
+                syncDataCategories
+            }
+        }
+    )";
+
+    std::string response = executeGraphQL(query, "");
+    if (response.empty()) return false;
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) return false;
+
+    std::string settings = extractJsonObject(data, "settings");
+    if (settings.empty()) return false;
+
+    enabled = extractJsonBool(settings, "syncYomiEnabled");
+    host = extractJsonValue(settings, "syncYomiHost");
+    apiKey = extractJsonValue(settings, "syncYomiApiKey");
+    dataManga = extractJsonBool(settings, "syncDataManga");
+    dataChapters = extractJsonBool(settings, "syncDataChapters");
+    dataTracking = extractJsonBool(settings, "syncDataTracking");
+    dataHistory = extractJsonBool(settings, "syncDataHistory");
+    dataCategories = extractJsonBool(settings, "syncDataCategories");
+
+    brls::Logger::debug("Fetched SyncYomi settings: enabled={}, host={}", enabled, host);
+    return true;
+}
+
+bool SuwayomiClient::updateSyncYomiSettings(bool enabled, const std::string& host, const std::string& apiKey,
+                                              bool dataManga, bool dataChapters, bool dataTracking,
+                                              bool dataHistory, bool dataCategories) {
+    const char* query = R"(
+        mutation SetSettings($input: SetSettingsInput!) {
+            setSettings(input: $input) {
+                settings {
+                    syncYomiEnabled
+                }
+            }
+        }
+    )";
+
+    std::string escapedHost;
+    for (char c : host) {
+        if (c == '"') escapedHost += "\\\"";
+        else if (c == '\\') escapedHost += "\\\\";
+        else escapedHost += c;
+    }
+
+    std::string escapedKey;
+    for (char c : apiKey) {
+        if (c == '"') escapedKey += "\\\"";
+        else if (c == '\\') escapedKey += "\\\\";
+        else escapedKey += c;
+    }
+
+    std::string variables = "{\"input\":{\"settings\":{"
+        "\"syncYomiEnabled\":" + std::string(enabled ? "true" : "false") + ","
+        "\"syncYomiHost\":\"" + escapedHost + "\","
+        "\"syncYomiApiKey\":\"" + escapedKey + "\","
+        "\"syncDataManga\":" + std::string(dataManga ? "true" : "false") + ","
+        "\"syncDataChapters\":" + std::string(dataChapters ? "true" : "false") + ","
+        "\"syncDataTracking\":" + std::string(dataTracking ? "true" : "false") + ","
+        "\"syncDataHistory\":" + std::string(dataHistory ? "true" : "false") + ","
+        "\"syncDataCategories\":" + std::string(dataCategories ? "true" : "false") +
+        "}}}";
+
+    std::string response = executeGraphQL(query, variables);
+    if (response.empty()) {
+        brls::Logger::error("Failed to update SyncYomi settings");
+        return false;
+    }
+
+    brls::Logger::info("SyncYomi settings updated: enabled={}, host={}", enabled, host);
+    return true;
+}
+
+bool SuwayomiClient::triggerSync(std::string& result) {
+    const char* query = R"(
+        mutation StartSync {
+            startSync(input: {}) {
+                result
+            }
+        }
+    )";
+
+    std::string response = executeGraphQL(query, "");
+    if (response.empty()) {
+        result = "FAILED";
+        return false;
+    }
+
+    std::string data = extractJsonObject(response, "data");
+    if (data.empty()) {
+        result = "FAILED";
+        return false;
+    }
+
+    std::string syncResult = extractJsonObject(data, "startSync");
+    if (syncResult.empty()) {
+        result = "FAILED";
+        return false;
+    }
+
+    result = extractJsonValue(syncResult, "result");
+    brls::Logger::info("Sync triggered: result={}", result);
+    return true;
+}
+
+// ============================================================================
 // Source Management
 // ============================================================================
 

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -57,6 +57,8 @@ SettingsTab::SettingsTab() {
     addSectionSeparator();
     createBrowseSection();
     addSectionSeparator();
+    createSyncYomiSection();
+    addSectionSeparator();
     createStatisticsSection();
     addSectionSeparator();
     createBackupSection();
@@ -1275,6 +1277,215 @@ void SettingsTab::createBrowseSection() {
             Application::getInstance().saveSettings();
         });
     m_contentBox->addView(searchHistorySelector);
+}
+
+void SettingsTab::createSyncYomiSection() {
+    Application& app = Application::getInstance();
+    AppSettings& settings = app.getSettings();
+
+    auto* header = new brls::Header();
+    header->setTitle("SyncYomi");
+    m_contentBox->addView(header);
+
+    auto* descLabel = new brls::Label();
+    descLabel->setText("Sync library data with a SyncYomi server");
+    descLabel->setFontSize(14);
+    descLabel->setMarginLeft(16);
+    descLabel->setMarginBottom(8);
+    descLabel->setTextColor(Application::getInstance().getSubtitleColor());
+    m_contentBox->addView(descLabel);
+
+    // Fetch current server-side settings
+    auto alive = m_alive;
+    vitasuwayomi::asyncRun([alive]() {
+        SuwayomiClient& client = SuwayomiClient::getInstance();
+        AppSettings& s = Application::getInstance().getSettings();
+
+        bool enabled = false;
+        std::string host, apiKey;
+        bool dataManga = true, dataChapters = true, dataTracking = true;
+        bool dataHistory = true, dataCategories = true;
+
+        if (client.fetchSyncYomiSettings(enabled, host, apiKey,
+                dataManga, dataChapters, dataTracking, dataHistory, dataCategories)) {
+            s.syncYomiEnabled = enabled;
+            s.syncYomiHost = host;
+            s.syncYomiApiKey = apiKey;
+            s.syncDataManga = dataManga;
+            s.syncDataChapters = dataChapters;
+            s.syncDataTracking = dataTracking;
+            s.syncDataHistory = dataHistory;
+            s.syncDataCategories = dataCategories;
+        }
+    });
+
+    // Enable/disable toggle
+    auto* enableToggle = new brls::BooleanCell();
+    enableToggle->init("Enable SyncYomi", settings.syncYomiEnabled, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncYomiEnabled = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                value, s.syncYomiHost, s.syncYomiApiKey,
+                s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
+                s.syncDataHistory, s.syncDataCategories);
+        });
+    });
+    m_contentBox->addView(enableToggle);
+
+    // Host URL
+    auto* hostCell = new brls::DetailCell();
+    hostCell->setText("SyncYomi Host");
+    hostCell->setDetailText(settings.syncYomiHost.empty() ? "Not configured" : settings.syncYomiHost);
+    hostCell->registerClickAction([this, hostCell, alive](brls::View* view) {
+        showUrlInputDialog("SyncYomi Host URL", "https://sync.example.com",
+            Application::getInstance().getSettings().syncYomiHost,
+            [hostCell, alive](const std::string& newUrl) {
+                if (!*alive) return;
+                AppSettings& s = Application::getInstance().getSettings();
+                s.syncYomiHost = newUrl;
+                brls::sync([hostCell, newUrl]() {
+                    hostCell->setDetailText(newUrl.empty() ? "Not configured" : newUrl);
+                });
+                SuwayomiClient::getInstance().updateSyncYomiSettings(
+                    s.syncYomiEnabled, newUrl, s.syncYomiApiKey,
+                    s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
+                    s.syncDataHistory, s.syncDataCategories);
+            });
+        return true;
+    });
+    m_contentBox->addView(hostCell);
+
+    // API Key
+    auto* apiKeyCell = new brls::DetailCell();
+    apiKeyCell->setText("API Key");
+    apiKeyCell->setDetailText(settings.syncYomiApiKey.empty() ? "Not set" : "••••••••");
+    apiKeyCell->registerClickAction([this, apiKeyCell, alive](brls::View* view) {
+        showUrlInputDialog("SyncYomi API Key", "Enter API key",
+            Application::getInstance().getSettings().syncYomiApiKey,
+            [apiKeyCell, alive](const std::string& newKey) {
+                if (!*alive) return;
+                AppSettings& s = Application::getInstance().getSettings();
+                s.syncYomiApiKey = newKey;
+                brls::sync([apiKeyCell, newKey]() {
+                    apiKeyCell->setDetailText(newKey.empty() ? "Not set" : "••••••••");
+                });
+                SuwayomiClient::getInstance().updateSyncYomiSettings(
+                    s.syncYomiEnabled, s.syncYomiHost, newKey,
+                    s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
+                    s.syncDataHistory, s.syncDataCategories);
+            });
+        return true;
+    });
+    m_contentBox->addView(apiKeyCell);
+
+    // Data sync toggles
+    auto* syncMangaToggle = new brls::BooleanCell();
+    syncMangaToggle->init("Sync Manga", settings.syncDataManga, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncDataManga = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                s.syncYomiEnabled, s.syncYomiHost, s.syncYomiApiKey,
+                value, s.syncDataChapters, s.syncDataTracking,
+                s.syncDataHistory, s.syncDataCategories);
+        });
+    });
+    m_contentBox->addView(syncMangaToggle);
+
+    auto* syncChaptersToggle = new brls::BooleanCell();
+    syncChaptersToggle->init("Sync Chapters", settings.syncDataChapters, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncDataChapters = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                s.syncYomiEnabled, s.syncYomiHost, s.syncYomiApiKey,
+                s.syncDataManga, value, s.syncDataTracking,
+                s.syncDataHistory, s.syncDataCategories);
+        });
+    });
+    m_contentBox->addView(syncChaptersToggle);
+
+    auto* syncTrackingToggle = new brls::BooleanCell();
+    syncTrackingToggle->init("Sync Tracking", settings.syncDataTracking, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncDataTracking = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                s.syncYomiEnabled, s.syncYomiHost, s.syncYomiApiKey,
+                s.syncDataManga, s.syncDataChapters, value,
+                s.syncDataHistory, s.syncDataCategories);
+        });
+    });
+    m_contentBox->addView(syncTrackingToggle);
+
+    auto* syncHistoryToggle = new brls::BooleanCell();
+    syncHistoryToggle->init("Sync History", settings.syncDataHistory, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncDataHistory = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                s.syncYomiEnabled, s.syncYomiHost, s.syncYomiApiKey,
+                s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
+                value, s.syncDataCategories);
+        });
+    });
+    m_contentBox->addView(syncHistoryToggle);
+
+    auto* syncCategoriesToggle = new brls::BooleanCell();
+    syncCategoriesToggle->init("Sync Categories", settings.syncDataCategories, [alive](bool value) {
+        if (!*alive) return;
+        AppSettings& s = Application::getInstance().getSettings();
+        s.syncDataCategories = value;
+        vitasuwayomi::asyncRun([value]() {
+            AppSettings& s = Application::getInstance().getSettings();
+            SuwayomiClient::getInstance().updateSyncYomiSettings(
+                s.syncYomiEnabled, s.syncYomiHost, s.syncYomiApiKey,
+                s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
+                s.syncDataHistory, value);
+        });
+    });
+    m_contentBox->addView(syncCategoriesToggle);
+
+    // Trigger sync button
+    auto* syncNowCell = new brls::DetailCell();
+    syncNowCell->setText("Sync Now");
+    syncNowCell->setDetailText("Trigger SyncYomi sync");
+    syncNowCell->registerClickAction([alive](brls::View* view) {
+        if (!Application::getInstance().isConnected()) {
+            brls::Application::notify("Not connected to server");
+            return true;
+        }
+        brls::Application::notify("Starting sync...");
+        vitasuwayomi::asyncRun([alive]() {
+            std::string result;
+            SuwayomiClient::getInstance().triggerSync(result);
+            brls::sync([result, alive]() {
+                if (!*alive) return;
+                if (result == "SUCCESS") {
+                    brls::Application::notify("Sync started successfully");
+                } else if (result == "SYNC_IN_PROGRESS") {
+                    brls::Application::notify("Sync already in progress");
+                } else if (result == "SYNC_DISABLED") {
+                    brls::Application::notify("SyncYomi is not enabled");
+                } else {
+                    brls::Application::notify("Sync failed: " + result);
+                }
+            });
+        });
+        return true;
+    });
+    m_contentBox->addView(syncNowCell);
 }
 
 void SettingsTab::updateLanguageFilterCellText() {

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1362,21 +1362,23 @@ void SettingsTab::createSyncYomiSection() {
     auto* apiKeyCell = new brls::DetailCell();
     apiKeyCell->setText("API Key");
     apiKeyCell->setDetailText(settings.syncYomiApiKey.empty() ? "Not set" : "••••••••");
-    apiKeyCell->registerClickAction([this, apiKeyCell, alive](brls::View* view) {
-        showUrlInputDialog("SyncYomi API Key", "Enter API key",
-            Application::getInstance().getSettings().syncYomiApiKey,
-            [apiKeyCell, alive](const std::string& newKey) {
-                if (!*alive) return;
+    apiKeyCell->registerClickAction([apiKeyCell, alive](brls::View* view) {
+        std::string currentKey = Application::getInstance().getSettings().syncYomiApiKey;
+        brls::Application::getImeManager()->openForText([apiKeyCell, alive](std::string text) {
+            if (!*alive) return;
+            AppSettings& s = Application::getInstance().getSettings();
+            s.syncYomiApiKey = text;
+            brls::sync([apiKeyCell, text]() {
+                apiKeyCell->setDetailText(text.empty() ? "Not set" : "••••••••");
+            });
+            vitasuwayomi::asyncRun([text]() {
                 AppSettings& s = Application::getInstance().getSettings();
-                s.syncYomiApiKey = newKey;
-                brls::sync([apiKeyCell, newKey]() {
-                    apiKeyCell->setDetailText(newKey.empty() ? "Not set" : "••••••••");
-                });
                 SuwayomiClient::getInstance().updateSyncYomiSettings(
-                    s.syncYomiEnabled, s.syncYomiHost, newKey,
+                    s.syncYomiEnabled, s.syncYomiHost, text,
                     s.syncDataManga, s.syncDataChapters, s.syncDataTracking,
                     s.syncDataHistory, s.syncDataCategories);
             });
+        }, "Enter API Key", "", 256, currentKey, 0);
         return true;
     });
     m_contentBox->addView(apiKeyCell);


### PR DESCRIPTION
Adds a SyncYomi settings section, updates api.txt with the sync API, and fixes the SyncYomi API-key input to use plain text instead of URL validation.

---
_Generated by [Claude Code](https://claude.ai/code)_