### PR TITLE
Change tapToNavigate setting to false

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -190,7 +190,7 @@ struct AppSettings {
     int64_t totalReadingTime = 0;     // Total reading time in seconds (estimated)
 
     // Download Settings
-    DownloadMode downloadMode = DownloadMode::SERVER_ONLY;  // Where to download chapters
+    DownloadMode downloadMode = DownloadMode::BOTH;  // Where to download chapters
     DownloadQuality downloadQuality = DownloadQuality::ORIGINAL;  // Image quality for local downloads
     bool autoDownloadChapters = false;
     bool deleteAfterRead = false;
@@ -199,7 +199,7 @@ struct AppSettings {
 
     // Source/Browse Settings
     std::set<std::string> enabledSourceLanguages;  // Empty = all languages, otherwise filter by these (e.g. "en", "multi")
-    bool showNsfwSources = false;
+    bool showNsfwSources = true;
 
     // Source Tags (user-assigned labels for filtering)
     std::map<std::string, std::set<std::string>> sourceTags;  // sourceId -> set of tag names

--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -148,7 +148,7 @@ struct AppSettings {
     int imageRotation = 0;  // 0, 90, 180, or 270 degrees
     bool keepScreenOn = true;
     bool showPageNumber = true;
-    bool tapToNavigate = true;
+    bool tapToNavigate = false;
     bool goToEndOnPrevChapter = true;  // When going back to prev chapter, land on last page instead of first
 
     // Webtoon Settings (also applies to vertical mode)

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -643,18 +643,9 @@ void ReaderActivity::onContentAvailable() {
                             completeSwipeAnimation(false);
                         }
                     } else {
-                        // Secondary axis swipe (fallback navigation)
-                        // Use logical inversion for correct page direction
-                        float crossDelta = useVerticalSwipe ? dx : dy;
-                        float logicalCross = invertDirection ? -crossDelta : crossDelta;
-
-                        if (std::abs(crossDelta) >= PAGE_TURN_THRESHOLD) {
-                            if (logicalCross > 0) {
-                                previousPage();
-                            } else {
-                                nextPage();
-                            }
-                        }
+                        // Cross-axis swipe — ignore in paged mode (only horizontal
+                        // swipes should turn pages). Vertical/webtoon modes already
+                        // use the primary axis for scrolling.
                         resetSwipeState();
                     }
 
@@ -921,15 +912,6 @@ void ReaderActivity::onContentAvailable() {
                             completeSwipeAnimation(false);
                         }
                     } else {
-                        float crossDelta = useVerticalSwipe ? dx : dy;
-                        float logicalCross = invertDirection ? -crossDelta : crossDelta;
-
-                        if (std::abs(crossDelta) >= PAGE_TURN_THRESHOLD) {
-                            if (logicalCross > 0)
-                                previousPage();
-                            else
-                                nextPage();
-                        }
                         resetSwipeState();
                     }
                     m_isPanning = false;
@@ -1020,9 +1002,6 @@ void ReaderActivity::onContentAvailable() {
                         } else {
                             m_settings.direction == ReaderDirection::RIGHT_TO_LEFT ? previousPage() : nextPage();
                         }
-                    } else if (std::abs(crossDelta) >= PAGE_TURN_THRESHOLD) {
-                        float logicalCross = invertDirection ? -crossDelta : crossDelta;
-                        logicalCross > 0 ? previousPage() : nextPage();
                     }
                 }
             }, brls::PanAxis::ANY));


### PR DESCRIPTION
Disables tap-to-navigate by default, removes cross-axis swipe page navigation in the reader, and sets the download mode to BOTH with NSFW sources enabled.

---
_Generated by [Claude Code](https://claude.ai/code)_