### PR TITLE
Replace remaining hardcoded 960x544 screen values across codebase

### DIFF
--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -1496,8 +1496,8 @@ void ReaderActivity::loadPages() {
                 });
 
                 // Load all pages into the scroll view
-                // Use actual view width (internal rendering coords, ~1280) rather than
-                // physical screen width (960) to avoid coordinate system mismatch.
+                // Use actual view width (internal rendering coords) to avoid
+                // coordinate system mismatch.
                 float viewW = webtoonScroll->getWidth();
                 if (viewW <= 0) viewW = container ? container->getWidth() : brls::Application::contentWidth;
                 webtoonScroll->setPages(m_pages, viewW, m_currentPage);
@@ -2460,10 +2460,10 @@ void ReaderActivity::saveSettingsToApp() {
 int ReaderActivity::getTapZone(brls::Point position) const {
     // Map physical tap position to user's perceived left/center/right zone,
     // accounting for how the device is held at each rotation.
-    //   0°:   user's left = low X,  right = high X  (screen width 960)
-    //   90°:  user's left = low Y,  right = high Y  (screen height 544)
-    //   180°: user's left = high X, right = low X   (screen width 960, inverted)
-    //   270°: user's left = high Y, right = low Y   (screen height 544, inverted)
+    //   0°:   user's left = low X,  right = high X
+    //   90°:  user's left = low Y,  right = high Y
+    //   180°: user's left = high X, right = low X  (inverted)
+    //   270°: user's left = high Y, right = low Y  (inverted)
     float normalized;
     int rotation = static_cast<int>(m_settings.rotation);
     float screenW = brls::Application::contentWidth;
@@ -2565,8 +2565,8 @@ void ReaderActivity::showPageError(const std::string& message) {
     m_errorOverlay->setAxis(brls::Axis::COLUMN);
     m_errorOverlay->setJustifyContent(brls::JustifyContent::CENTER);
     m_errorOverlay->setAlignItems(brls::AlignItems::CENTER);
-    m_errorOverlay->setWidth(960);
-    m_errorOverlay->setHeight(544);
+    m_errorOverlay->setWidth(brls::Application::contentWidth);
+    m_errorOverlay->setHeight(brls::Application::contentHeight);
     m_errorOverlay->setPositionType(brls::PositionType::ABSOLUTE);
     m_errorOverlay->setPositionTop(0);
     m_errorOverlay->setPositionLeft(0);

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -421,8 +421,8 @@ LibrarySectionTab::LibrarySectionTab() {
     m_categoryOverlay->setAxis(brls::Axis::COLUMN);
     m_categoryOverlay->setJustifyContent(brls::JustifyContent::CENTER);
     m_categoryOverlay->setAlignItems(brls::AlignItems::CENTER);
-    m_categoryOverlay->setWidth(960);
-    m_categoryOverlay->setHeight(544);
+    m_categoryOverlay->setWidth(brls::Application::contentWidth);
+    m_categoryOverlay->setHeight(brls::Application::contentHeight);
     m_categoryOverlay->setPositionType(brls::PositionType::ABSOLUTE);
     m_categoryOverlay->setPositionTop(0);
     m_categoryOverlay->setPositionLeft(0);

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1053,8 +1053,8 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_categoryOverlay->setAxis(brls::Axis::COLUMN);
     m_categoryOverlay->setJustifyContent(brls::JustifyContent::CENTER);
     m_categoryOverlay->setAlignItems(brls::AlignItems::CENTER);
-    m_categoryOverlay->setWidth(960);
-    m_categoryOverlay->setHeight(544);
+    m_categoryOverlay->setWidth(brls::Application::contentWidth);
+    m_categoryOverlay->setHeight(brls::Application::contentHeight);
     m_categoryOverlay->setPositionType(brls::PositionType::ABSOLUTE);
     m_categoryOverlay->setPositionTop(0);
     m_categoryOverlay->setPositionLeft(0);

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -983,7 +983,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
     // Draw performance overlay on top (uses screen coordinates, ignores scroll)
     // Reset scissor so overlay draws over everything
     nvgResetScissor(vg);
-    perf.draw(vg, 960.0f, 544.0f);
+    perf.draw(vg, brls::Application::contentWidth, brls::Application::contentHeight);
 }
 
 void RecyclingGrid::loadThumbnailsForScrollPosition() {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -78,8 +78,8 @@ void WebtoonScrollView::setupGestures() {
                     m_lastTapPosition = status.position;
 
                     // Scale tap position from physical to view coords
-                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
-                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / brls::Application::contentWidth) : 1.0f;
+                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / brls::Application::contentHeight) : 1.0f;
                     float tapX = status.position.x * scaleX;
                     float tapY = status.position.y * scaleY;
 
@@ -123,8 +123,8 @@ void WebtoonScrollView::setupGestures() {
                 // Divide by zoom level since offset is in pre-scale space;
                 // without this, panning moves too fast at higher zoom levels.
                 if (m_isZoomed) {
-                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
-                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / brls::Application::contentWidth) : 1.0f;
+                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / brls::Application::contentHeight) : 1.0f;
                     m_zoomOffset.x += rawDx * scaleX / m_zoomLevel;
                     m_zoomOffset.y += rawDy * scaleY / m_zoomLevel;
                     m_touchLast = status.position;
@@ -144,8 +144,8 @@ void WebtoonScrollView::setupGestures() {
                 // position is in view coords (~1280x726). Scale for 1:1 tracking.
                 float scrollDelta = 0.0f;
                 int rotation = static_cast<int>(m_rotationDegrees);
-                float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
-                float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
+                float scaleY = (m_viewHeight > 0) ? (m_viewHeight / brls::Application::contentHeight) : 1.0f;
+                float scaleX = (m_viewWidth > 0) ? (m_viewWidth / brls::Application::contentWidth) : 1.0f;
 
                 if (rotation == 0) {
                     scrollDelta = rawDy * scaleY;
@@ -231,8 +231,8 @@ void WebtoonScrollView::setupGestures() {
                 // pinch can't accidentally trigger resetZoom
                 m_lastTapTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
                 // Convert physical pinch center to view coords
-                float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
-                float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                float scaleX = (m_viewWidth > 0) ? (m_viewWidth / brls::Application::contentWidth) : 1.0f;
+                float scaleY = (m_viewHeight > 0) ? (m_viewHeight / brls::Application::contentHeight) : 1.0f;
                 m_initialPinchCenter = {status.center.x * scaleX, status.center.y * scaleY};
                 m_scrollVelocity = 0.0f;
             } else if (status.state == brls::GestureState::STAY) {
@@ -241,8 +241,8 @@ void WebtoonScrollView::setupGestures() {
 
                 if (std::abs(newZoom - m_zoomLevel) > 0.01f) {
                     // Convert current pinch center to view coords
-                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / 960.0f) : 1.0f;
-                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / 544.0f) : 1.0f;
+                    float scaleX = (m_viewWidth > 0) ? (m_viewWidth / brls::Application::contentWidth) : 1.0f;
+                    float scaleY = (m_viewHeight > 0) ? (m_viewHeight / brls::Application::contentHeight) : 1.0f;
                     brls::Point currentCenter = {status.center.x * scaleX, status.center.y * scaleY};
 
                     // Focal-point zoom formula:
@@ -468,9 +468,9 @@ void WebtoonScrollView::setPages(const std::vector<Page>& pages, float screenWid
     m_viewWidth = screenWidth;
     // m_viewHeight will be updated from actual view dimensions in draw().
     // Use a reasonable default until then; the draw() dimensions (~726 internal)
-    // differ from the physical screen (544) due to borealis DPI scaling.
+    // differ from the physical screen due to borealis DPI scaling.
     if (m_viewHeight <= 0.0f) {
-        m_viewHeight = screenWidth * (544.0f / 960.0f);  // Maintain screen aspect ratio
+        m_viewHeight = screenWidth * (brls::Application::contentHeight / brls::Application::contentWidth);
     }
 
     // Calculate available width after padding
@@ -1605,7 +1605,7 @@ void WebtoonScrollView::draw(NVGcontext* vg, float x, float y, float width, floa
 
     // Draw perf overlay on top
     nvgResetScissor(vg);
-    PerfOverlay::getInstance().draw(vg, 960.0f, 544.0f);
+    PerfOverlay::getInstance().draw(vg, brls::Application::contentWidth, brls::Application::contentHeight);
 
     // Call onFrame for momentum updates
     onFrame();


### PR DESCRIPTION
Replace remaining hardcoded 960x544 screen values across codebase

Replaced all hardcoded Vita screen dimensions with dynamic
brls::Application::contentWidth/contentHeight in:
- webtoon_scroll_view.cpp: touch-to-view scaling, aspect ratio calc,
  perf overlay positioning (8 occurrences)
- recycling_grid.cpp: perf overlay positioning
- media_detail_view.cpp: category overlay dimensions
- library_section_tab.cpp: category overlay dimensions
- reader_activity.cpp: error overlay dimensions, stale comments

The only remaining 960 value is in downloads_manager.cpp which is an
image quality setting (max pixel width), not a screen dimension.

---
_Generated by [Claude Code](https://claude.ai/code)_