### PR TITLE
Fix chapter list not loading when manga has no genres/tags

### DIFF
--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2019,7 +2019,7 @@ bool SuwayomiClient::fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, st
     // If manga is not initialized (missing genre/status/chapters), the server hasn't
     // scraped the source yet. Trigger fetchManga + fetchChapters mutations to initialize,
     // then re-query both manga details and chapters.
-    bool needsRefresh = (chapters.empty() || manga.genre.empty() || manga.status == MangaStatus::UNKNOWN)
+    bool needsRefresh = (chapters.empty() || !manga.initialized)
                         && manga.id > 0;
     if (needsRefresh) {
         brls::Logger::info("GraphQL combined: manga {} needs refresh (chapters={}, genres={}, status={})",

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1240,8 +1240,9 @@ void MangaDetailView::loadDetails() {
         }
     }
 
-    // Fetch full details when description, genre, or status are missing (common for non-library books from browse/search)
-    bool needsDetailFetch = m_manga.description.empty() || m_manga.genre.empty() || m_manga.status == MangaStatus::UNKNOWN;
+    // Fetch full details when description or status are missing (common for non-library books from browse/search)
+    // Don't check genre.empty() — some manga legitimately have no genres/tags on the server
+    bool needsDetailFetch = m_manga.description.empty() || m_manga.status == MangaStatus::UNKNOWN;
     if (needsDetailFetch && Application::getInstance().isConnected()) {
         // Use combined query to fetch manga details + chapters in one request
         brls::Logger::info("MangaDetailView: Using combined query for details + chapters");
@@ -1454,7 +1455,7 @@ void MangaDetailView::loadDetails() {
             }
         });
     } else {
-        // All details (description, genre, status) already available - just load chapters
+        // All details already available - just load chapters
         loadChapters();
     }
 }


### PR DESCRIPTION
Fixes the chapter list not loading when a manga has no genres/tags, updating and then reverting a borealis submodule ref.

---
_Generated by [Claude Code](https://claude.ai/code)_