### PR TITLE
Fix chapter list breaking when server returns no genres/tags

### DIFF
--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -210,6 +210,10 @@ private:
     // Track first appearance to avoid duplicate chapter loading
     bool m_firstAppearance = true;
 
+    // Tracks whether we've already attempted a detail fetch (prevents infinite
+    // re-fetching when the server/source genuinely has no genres/tags)
+    bool m_detailsFetched = false;
+
     // Description expand/collapse
     bool m_descriptionExpanded = false;
     std::string m_fullDescription;

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -2019,7 +2019,7 @@ bool SuwayomiClient::fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, st
     // If manga is not initialized (missing genre/status/chapters), the server hasn't
     // scraped the source yet. Trigger fetchManga + fetchChapters mutations to initialize,
     // then re-query both manga details and chapters.
-    bool needsRefresh = (chapters.empty() || manga.genre.empty() || manga.status == MangaStatus::UNKNOWN)
+    bool needsRefresh = (chapters.empty() || !manga.initialized)
                         && manga.id > 0;
     if (needsRefresh) {
         brls::Logger::info("GraphQL combined: manga {} needs refresh (chapters={}, genres={}, status={})",

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -833,8 +833,6 @@ MangaDetailView::MangaDetailView(const Manga& manga)
             genreLabel->setMarginRight(12);
             m_genreBox->addView(genreLabel);
         }
-    } else {
-        m_genreBox->setVisibility(brls::Visibility::GONE);
     }
     rightPanel->addView(m_genreBox);
 
@@ -1240,8 +1238,10 @@ void MangaDetailView::loadDetails() {
         }
     }
 
-    // Fetch full details when description, genre, or status are missing (common for non-library books from browse/search)
-    bool needsDetailFetch = m_manga.description.empty() || m_manga.genre.empty() || m_manga.status == MangaStatus::UNKNOWN;
+    // Fetch full details when description, genre, or status are missing (common for non-library books from browse/search).
+    // m_detailsFetched prevents infinite re-fetching when the source genuinely has no genres/tags.
+    bool needsDetailFetch = !m_detailsFetched &&
+        (m_manga.description.empty() || m_manga.genre.empty() || m_manga.status == MangaStatus::UNKNOWN);
     if (needsDetailFetch && Application::getInstance().isConnected()) {
         // Use combined query to fetch manga details + chapters in one request
         brls::Logger::info("MangaDetailView: Using combined query for details + chapters");
@@ -1314,6 +1314,8 @@ void MangaDetailView::loadDetails() {
                 brls::sync([this, updatedManga, chapters, chaptersToDownload, aliveWeak]() {
                     auto alive = aliveWeak.lock();
                     if (!alive || !*alive) return;
+
+                    m_detailsFetched = true;
 
                     // Apply manga details
                     bool needsUpdate = false;
@@ -1417,6 +1419,7 @@ void MangaDetailView::loadDetails() {
                 brls::sync([this, aliveWeak]() {
                     auto alive = aliveWeak.lock();
                     if (!alive || !*alive) return;
+                    m_detailsFetched = true;
                     loadChapters();
                 });
 


### PR DESCRIPTION
Fix chapter list breaking when server returns no genres/tags

Three fixes applied on top of latest main:

1. Keep genreBox in layout when empty (no GONE) — setting it to GONE
   was disrupting the flexbox layout and preventing chapters from
   rendering properly.

2. Add m_detailsFetched flag to prevent infinite re-fetching — the
   detail fetch now only runs once per view. If the source has no
   genres, we accept that and move on instead of re-fetching forever.

3. Use manga.initialized instead of genre.empty() in the client's
   needsRefresh check — prevents the expensive refreshMangaGraphQL
   re-scrape mutation for manga that are already initialized but
   simply have no tags.

---
_Generated by [Claude Code](https://claude.ai/code)_