### PR TITLE
Add mouse scroll wheel support in webtoon reading mode

### DIFF
--- a/include/app/application.hpp
+++ b/include/app/application.hpp
@@ -155,6 +155,7 @@ struct AppSettings {
     bool cropBorders = false;           // Auto-crop white/black borders from pages
     bool webtoonDetection = true;       // Auto-detect webtoon format (aspect ratio based)
     int webtoonSidePadding = 0;         // Side padding percentage (0-20%)
+    bool reverseMouseScroll = true;     // Reverse mouse scroll wheel direction in webtoon mode
 
     // Library Settings
     bool updateOnStart = false;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1387,6 +1387,7 @@ bool Application::loadSettings() {
     if (m_settings.webtoonSidePadding < 0 || m_settings.webtoonSidePadding > 20) {
         m_settings.webtoonSidePadding = 0;
     }
+    m_settings.reverseMouseScroll = extractBool("reverseMouseScroll", true);
 
     // Load library settings
     m_settings.updateOnStart = extractBool("updateOnStart", false);
@@ -1888,6 +1889,7 @@ bool Application::saveSettings() {
     json += "  \"cropBorders\": " + std::string(m_settings.cropBorders ? "true" : "false") + ",\n";
     json += "  \"webtoonDetection\": " + std::string(m_settings.webtoonDetection ? "true" : "false") + ",\n";
     json += "  \"webtoonSidePadding\": " + std::to_string(m_settings.webtoonSidePadding) + ",\n";
+    json += "  \"reverseMouseScroll\": " + std::string(m_settings.reverseMouseScroll ? "true" : "false") + ",\n";
 
     // Library settings
     json += "  \"updateOnStart\": " + std::string(m_settings.updateOnStart ? "true" : "false") + ",\n";

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -1102,6 +1102,14 @@ void SettingsTab::createReaderSection() {
             Application::getInstance().saveSettings();
         });
     m_contentBox->addView(paddingSelector);
+
+    // Reverse mouse scroll
+    auto* reverseScrollToggle = new brls::BooleanCell();
+    reverseScrollToggle->init("Reverse Mouse Scroll", settings.reverseMouseScroll, [&settings](bool value) {
+        settings.reverseMouseScroll = value;
+        Application::getInstance().saveSettings();
+    });
+    m_contentBox->addView(reverseScrollToggle);
 }
 
 void SettingsTab::createDownloadsSection() {

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -109,7 +109,7 @@ void WebtoonScrollView::setupGestures() {
 
             // Mouse scroll wheel: deltaOnly events with delta.y
             if (status.deltaOnly) {
-                float scrollDelta = -status.delta.y;
+                float scrollDelta = status.delta.y;
                 float totalContentSize = getTotalContentSize();
                 bool horizontal = isHorizontalLayout();
                 float viewSize = horizontal ? m_viewWidth : m_viewHeight;

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -102,10 +102,29 @@ void WebtoonScrollView::setupGestures() {
         }));
 
     // Pan gesture for scrolling (ANY axis to support rotated views)
-    this->addGestureRecognizer(new brls::PanGestureRecognizer(
+    this->addGestureRecognizer(new brls::ScrollGestureRecognizer(
         [this](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
             // Suppress scrolling while pinch-to-zoom is active
             if (m_isPinching) return;
+
+            // Mouse scroll wheel: deltaOnly events with delta.y
+            if (status.deltaOnly) {
+                float scrollDelta = -status.delta.y;
+                float totalContentSize = getTotalContentSize();
+                bool horizontal = isHorizontalLayout();
+                float viewSize = horizontal ? m_viewWidth : m_viewHeight;
+                float minScroll = -(totalContentSize - viewSize);
+                if (minScroll > 0.0f) minScroll = 0.0f;
+
+                m_scrollY = std::max(minScroll, std::min(0.0f, m_scrollY + scrollDelta));
+                m_scrollVelocity = 0.0f;
+
+                if (!m_userHasScrolled) m_userHasScrolled = true;
+
+                updateVisibleImages();
+                updateCurrentPage();
+                return;
+            }
 
             if (status.state == brls::GestureState::START) {
                 m_isTouching = true;

--- a/src/view/webtoon_scroll_view.cpp
+++ b/src/view/webtoon_scroll_view.cpp
@@ -109,7 +109,8 @@ void WebtoonScrollView::setupGestures() {
 
             // Mouse scroll wheel: deltaOnly events with delta.y
             if (status.deltaOnly) {
-                float scrollDelta = status.delta.y;
+                bool reverse = Application::getInstance().getSettings().reverseMouseScroll;
+                float scrollDelta = reverse ? status.delta.y : -status.delta.y;
                 float totalContentSize = getTotalContentSize();
                 bool horizontal = isHorizontalLayout();
                 float viewSize = horizontal ? m_viewWidth : m_viewHeight;


### PR DESCRIPTION
Adds mouse scroll-wheel support in webtoon reading mode with a reverse-direction setting (on by default).

---
_Generated by [Claude Code](https://claude.ai/code)_