### PR TITLE
Fix button icon hints showing wrong buttons on Switch

### DIFF
--- a/include/utils/button_icons.hpp
+++ b/include/utils/button_icons.hpp
@@ -25,6 +25,20 @@
   #define BUTTON_IMG(name) RESOURCE_PREFIX BUTTON_ICON_DIR name
 #endif
 
+// Platform-aware icon names for face buttons.
+// Image file names use PlayStation position conventions (square = left,
+// triangle = top), but borealis BUTTON_X / BUTTON_Y map to different
+// physical positions per platform:
+//   PSV/Desktop: BUTTON_X = Square (left), BUTTON_Y = Triangle (top)
+//   Switch:      BUTTON_X = X (top),       BUTTON_Y = Y (left)
+#if defined(__SWITCH__) || defined(SWITCH)
+  #define BUTTON_X_ICON "triangle_button.png"
+  #define BUTTON_Y_ICON "square_button.png"
+#else
+  #define BUTTON_X_ICON "square_button.png"
+  #define BUTTON_Y_ICON "triangle_button.png"
+#endif
+
 inline void setButtonIcon(brls::Image* img, const char* path) {
 #ifndef HIDE_BUTTON_HINTS
     img->setImageFromFile(path);

--- a/src/activity/reader_activity.cpp
+++ b/src/activity/reader_activity.cpp
@@ -2635,7 +2635,10 @@ void ReaderActivity::showPageError(const std::string& message) {
             asyncRun([mangaId, chapterId, mangaTitle, chapterName, downloadMode]() {
                 if (downloadMode == DownloadMode::LOCAL_ONLY || downloadMode == DownloadMode::BOTH) {
                     DownloadsManager& dm = DownloadsManager::getInstance();
-                    dm.queueChapterDownload(mangaId, chapterId, chapterId, mangaTitle, chapterName, 0.0f);
+                    dm.init();
+                    if (dm.queueChapterDownload(mangaId, chapterId, chapterId, mangaTitle, chapterName, 0.0f)) {
+                        dm.startDownloads();
+                    }
                 }
                 if (downloadMode == DownloadMode::SERVER_ONLY || downloadMode == DownloadMode::BOTH) {
                     SuwayomiClient& client = SuwayomiClient::getInstance();

--- a/src/app/downloads_manager.cpp
+++ b/src/app/downloads_manager.cpp
@@ -299,8 +299,9 @@ void DownloadsManager::startDownloads() {
 
     brls::Logger::info("DownloadsManager: Starting downloads");
 
-    // Run downloads in background thread
-    std::thread([this]() {
+    // Run downloads in background thread (must use platform::launchThread for
+    // the larger stack that curl+mbedTLS requires on Switch)
+    platform::launchThread([this]() {
         m_downloadThreadActive.store(true);
         while (m_downloading.load()) {
             DownloadedChapter* nextChapter = nullptr;
@@ -353,7 +354,7 @@ void DownloadsManager::startDownloads() {
             downloadChapter(mangaId, *nextChapter);
         }
         m_downloadThreadActive.store(false);
-    }).detach();
+    });
 }
 
 void DownloadsManager::pauseDownloads() {

--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -1093,7 +1093,7 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
     xButtonIcon->setWidth(24);
     xButtonIcon->setHeight(24);
     xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(xButtonIcon, BUTTON_IMG("square_button.png"));
+    setButtonIcon(xButtonIcon, BUTTON_IMG(BUTTON_X_ICON));
     xButtonIcon->setMarginLeft(8);
     xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
     outXButtonIcon = xButtonIcon;
@@ -1500,7 +1500,7 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
     xButtonIcon->setWidth(24);
     xButtonIcon->setHeight(24);
     xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(xButtonIcon, BUTTON_IMG("square_button.png"));
+    setButtonIcon(xButtonIcon, BUTTON_IMG(BUTTON_X_ICON));
     xButtonIcon->setMarginLeft(8);
     xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
     outXButtonIcon = xButtonIcon;

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -756,7 +756,7 @@ ExtensionsTab::ExtensionsTab() {
     triangleButtonIcon->setWidth(16);
     triangleButtonIcon->setHeight(16);
     triangleButtonIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(triangleButtonIcon, BUTTON_IMG("triangle_button.png"));
+    setButtonIcon(triangleButtonIcon, BUTTON_IMG(BUTTON_Y_ICON));
     triangleButtonIcon->setMarginBottom(2);
     refreshContainer->addView(triangleButtonIcon);
 

--- a/src/view/history_tab.cpp
+++ b/src/view/history_tab.cpp
@@ -47,7 +47,7 @@ HistoryTab::HistoryTab() {
     triangleIcon->setWidth(16);
     triangleIcon->setHeight(16);
     triangleIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(triangleIcon, BUTTON_IMG("triangle_button.png"));
+    setButtonIcon(triangleIcon, BUTTON_IMG(BUTTON_Y_ICON));
     triangleIcon->setMarginBottom(2);
     refreshContainer->addView(triangleIcon);
 

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -157,7 +157,7 @@ LibrarySectionTab::LibrarySectionTab() {
     sortHintIcon->setWidth(16);
     sortHintIcon->setHeight(16);
     sortHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(sortHintIcon, BUTTON_IMG("triangle_button.png"));
+    setButtonIcon(sortHintIcon, BUTTON_IMG(BUTTON_Y_ICON));
     sortHintIcon->setMarginBottom(2);
     sortContainer->addView(sortHintIcon);
 
@@ -242,7 +242,7 @@ LibrarySectionTab::LibrarySectionTab() {
     groupHintIcon->setWidth(16);
     groupHintIcon->setHeight(16);
     groupHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(groupHintIcon, BUTTON_IMG("square_button.png"));
+    setButtonIcon(groupHintIcon, BUTTON_IMG(BUTTON_X_ICON));
     groupHintIcon->setMarginBottom(2);
     groupContainer->addView(groupHintIcon);
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -1281,6 +1281,7 @@ void MangaDetailView::loadDetails() {
                 std::vector<int> chaptersToDownload;
                 if (autoDownload) {
                     DownloadsManager& localMgr = DownloadsManager::getInstance();
+                    localMgr.init();
                     for (const auto& ch : chapters) {
                         if (!ch.read && !ch.downloaded &&
                             !localMgr.isChapterDownloaded(combinedMangaId, ch.index)) {
@@ -1565,6 +1566,7 @@ void MangaDetailView::loadChapters() {
 
             if (autoDownload) {
                 DownloadsManager& localMgr = DownloadsManager::getInstance();
+                localMgr.init();
                 // Find unread chapters that are not yet downloaded
                 for (const auto& ch : chapters) {
                     if (!ch.read && !ch.downloaded &&
@@ -3947,6 +3949,7 @@ void MangaDetailView::downloadSelected() {
     asyncRun([mangaId, mangaTitle, chapterIds, localChapterPairs, downloadMode]() {
         SuwayomiClient& client = SuwayomiClient::getInstance();
         DownloadsManager& localMgr = DownloadsManager::getInstance();
+        localMgr.init();
 
         bool serverSuccess = true;
         bool localSuccess = true;

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -110,7 +110,7 @@ ChapterCell::ChapterCell() {
     xButtonIcon->setHeight(24);
     xButtonIcon->setScalingType(brls::ImageScalingType::FIT);
     xButtonIcon->setMarginLeft(8);
-    setButtonIcon(xButtonIcon, BUTTON_IMG("square_button.png"));
+    setButtonIcon(xButtonIcon, BUTTON_IMG(BUTTON_X_ICON));
     xButtonIcon->setVisibility(brls::Visibility::INVISIBLE);
     statusBox->addView(xButtonIcon);
 
@@ -1074,7 +1074,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     setButtonIcon(selectIcon, BUTTON_IMG("select_button.png"));
     setButtonIcon(rButtonIcon, BUTTON_IMG("r_button.png"));
     updateSortIcon();
-    setButtonIcon(yButtonIcon, BUTTON_IMG("triangle_button.png"));
+    setButtonIcon(yButtonIcon, BUTTON_IMG(BUTTON_Y_ICON));
     filterIcon->setImageFromFile(RESOURCE_PREFIX "icons/filter-menu-outline.png");
     setButtonIcon(startButtonIcon, BUTTON_IMG("start_button.png"));
     menuIcon->setImageFromFile(RESOURCE_PREFIX "icons/menu.png");

--- a/src/view/search_tab.cpp
+++ b/src/view/search_tab.cpp
@@ -78,7 +78,7 @@ SearchTab::SearchTab() {
     triangleHintIcon->setWidth(16);
     triangleHintIcon->setHeight(16);
     triangleHintIcon->setScalingType(brls::ImageScalingType::FIT);
-    setButtonIcon(triangleHintIcon, BUTTON_IMG("triangle_button.png"));
+    setButtonIcon(triangleHintIcon, BUTTON_IMG(BUTTON_Y_ICON));
     triangleHintIcon->setMarginBottom(2);
     m_filterBtnContainer->addView(triangleHintIcon);
 

--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -15,7 +15,6 @@
 #include <chrono>
 #include <ctime>
 #include <sstream>
-#include <thread>
 
 #include "platform/platform.hpp"
 
@@ -1934,7 +1933,7 @@ void SettingsTab::updateServerLabel() {
 void SettingsTab::runNetworkTest() {
     brls::Application::notify("Running network test...");
 
-    std::thread([this]() {
+    platform::launchThread([this]() {
         std::string results;
 
         // --- WiFi Check ---
@@ -2059,7 +2058,7 @@ void SettingsTab::runNetworkTest() {
             dialog->addButton("Close", []() {});
             dialog->open();
         });
-    }).detach();
+    });
 }
 
 void SettingsTab::showCategoryManagementDialog() {


### PR DESCRIPTION
Fixes button-icon hints showing the wrong buttons on Switch, a missing `DownloadsManager::init()` before local downloads, and a Switch download-thread crash from insufficient stack size.

---
_Generated by [Claude Code](https://claude.ai/code)_