### PR TITLE
Fix use-after-free and null pointer crashes in UI callbacks

### DIFF
--- a/src/view/downloads_tab.cpp
+++ b/src/view/downloads_tab.cpp
@@ -1120,7 +1120,9 @@ brls::Box* DownloadsTab::createLocalRow(int mangaId, int chapterIndex, const std
                 m_currentFocusedIcon = nullptr;
             }
         }
-        xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
+        if (xButtonIcon) {
+            xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
+        }
         m_currentFocusedIcon = xButtonIcon;
     });
 
@@ -1527,7 +1529,9 @@ brls::Box* DownloadsTab::createServerRow(int chapterId, int mangaId, const std::
                 m_currentFocusedIcon = nullptr;
             }
         }
-        xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
+        if (xButtonIcon) {
+            xButtonIcon->setVisibility(brls::Visibility::VISIBLE);
+        }
         m_currentFocusedIcon = xButtonIcon;
     });
 

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -239,7 +239,9 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
             if (prev && prev != xIcon) {
                 prev->setVisibility(brls::Visibility::INVISIBLE);
             }
-            xIcon->setVisibility(brls::Visibility::VISIBLE);
+            if (xIcon) {
+                xIcon->setVisibility(brls::Visibility::VISIBLE);
+            }
             v->setCurrentFocusedIcon(xIcon);
         });
     }
@@ -315,7 +317,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
         std::string mangaTitle = m_view->m_manga.title;
 
         cell->addGestureRecognizer(new brls::PanGestureRecognizer(
-            [view, cell, mangaId, mangaTitle](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
+            [view, cell, mangaId, mangaTitle, aliveWeakForBtn](brls::PanGestureStatus status, brls::Sound* soundToPlay) {
                 static brls::Point touchStart;
                 static bool isValidSwipe = false;
                 const NVGcolor originalBgColor = Application::getInstance().getRowBackground();
@@ -380,10 +382,12 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                             DownloadMode downloadMode = Application::getInstance().getSettings().downloadMode;
 
                             if (isLiveQueued || isLiveDownloading) {
-                                asyncRun([view, mangaId, curChapterIndex]() {
+                                asyncRun([view, mangaId, curChapterIndex, aliveWeakForBtn]() {
                                     DownloadsManager& dm = DownloadsManager::getInstance();
                                     if (dm.cancelChapterDownload(mangaId, curChapterIndex)) {
-                                        brls::sync([view]() {
+                                        brls::sync([view, aliveWeakForBtn]() {
+                                            auto alive = aliveWeakForBtn.lock();
+                                            if (!alive || !*alive) return;
                                             brls::Application::notify("Removed from queue");
                                             view->refreshVisibleDownloadIcons();
                                         });
@@ -391,7 +395,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                 });
                             } else if (isLiveDownloaded || curServerDownloaded) {
                                 asyncRun([view, mangaId, curChapterId, curChapterIndex, downloadMode,
-                                          curServerDownloaded, isLiveDownloaded]() {
+                                          curServerDownloaded, isLiveDownloaded, aliveWeakForBtn]() {
                                     int serverDeleted = 0;
                                     int localDeleted = 0;
                                     if (curServerDownloaded &&
@@ -410,7 +414,9 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                             localDeleted = 1;
                                         }
                                     }
-                                    brls::sync([view, serverDeleted, localDeleted]() {
+                                    brls::sync([view, serverDeleted, localDeleted, aliveWeakForBtn]() {
+                                        auto alive = aliveWeakForBtn.lock();
+                                        if (!alive || !*alive) return;
                                         if (serverDeleted > 0 || localDeleted > 0) {
                                             brls::Application::notify("Download deleted");
                                         }
@@ -419,7 +425,7 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                 });
                             } else {
                                 asyncRun([view, mangaId, curChapterId, curChapterIndex, curChapterNum, mangaTitle,
-                                          curChapterName, downloadMode]() {
+                                          curChapterName, downloadMode, aliveWeakForBtn]() {
                                     SuwayomiClient& client = SuwayomiClient::getInstance();
                                     DownloadsManager& dm = DownloadsManager::getInstance();
                                     bool serverQueued = false;
@@ -434,7 +440,9 @@ void ChaptersDataSource::bindCell(ChapterCell* cell, int row) {
                                                                               mangaTitle, curChapterName, curChapterNum);
                                         if (localQueued) { dm.startDownloads(); }
                                     }
-                                    brls::sync([view, serverQueued, localQueued]() {
+                                    brls::sync([view, serverQueued, localQueued, aliveWeakForBtn]() {
+                                        auto alive = aliveWeakForBtn.lock();
+                                        if (!alive || !*alive) return;
                                         if (serverQueued || localQueued) {
                                             brls::Application::notify("Download queued");
                                         } else {

--- a/src/view/recycling_grid.cpp
+++ b/src/view/recycling_grid.cpp
@@ -263,6 +263,7 @@ void RecyclingGrid::appendItems(const std::vector<Manga>& newItems) {
                                static_cast<int>((savedScrollY + viewH) / rowH) + 2);
 
         for (int i = oldRowCount; i < static_cast<int>(m_rows.size()); i++) {
+            if (!m_rows[i]) continue;
             brls::Visibility vis = (i >= firstVis && i < lastVis)
                 ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
             m_rows[i]->setVisibility(vis);
@@ -730,6 +731,7 @@ void RecyclingGrid::draw(NVGcontext* vg, float x, float y, float width, float he
             } else {
                 // First call: set all visibility in one pass
                 for (int i = 0; i < static_cast<int>(m_rows.size()); i++) {
+                    if (!m_rows[i]) continue;
                     brls::Visibility desired = (i >= firstVisible && i < lastVisible)
                         ? brls::Visibility::VISIBLE : brls::Visibility::INVISIBLE;
                     m_rows[i]->setVisibility(desired);


### PR DESCRIPTION
Fix use-after-free and null pointer crashes in UI callbacks

Three categories of null/dangling pointer bugs:

1. brls::sync callbacks in the swipe gesture handler captured a raw
   MangaDetailView* without alive checks. If the user navigates away
   while a download operation is pending, the deferred callback
   dereferences freed memory on the UI thread, crashing during frame
   processing. Fixed by passing aliveWeakForBtn and checking it.

2. xButtonIcon used without null check in focus event handlers across
   media_detail_view.cpp and downloads_tab.cpp. Added null guards.

3. RecyclingGrid row visibility updates missing null checks in two
   code paths (appendItems first-call and draw first-call), while
   other paths properly check. Added consistency.

---
_Generated by [Claude Code](https://claude.ai/code)_