### PR TITLE
Add centered Options popover for the library context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ set(APP_SOURCES
     src/activity/login_activity.cpp
     src/activity/reader_activity.cpp
     src/view/library_section_tab.cpp
+    src/view/options_popover.cpp
     src/view/history_tab.cpp
     src/view/search_tab.cpp
     src/view/settings_tab.cpp

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -8,6 +8,7 @@
 
 #include <borealis.hpp>
 #include <memory>
+#include <functional>
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "view/recycling_grid.hpp"
@@ -76,8 +77,8 @@ private:
     void showChangeCategoryDialog(const std::vector<Manga>& mangaList, int focusedIndex = -1);
     // New-design sub-popovers opened from the Options popover (replace the old
     // inline panels that showDownloadSubmenu / showChangeCategoryDialog raise).
-    void showDownloadPopover(const std::vector<Manga>& mangaList);
-    void showCategoriesPopover(const std::vector<Manga>& mangaList);
+    void showDownloadPopover(const std::vector<Manga>& mangaList, std::function<void()> onBack = nullptr);
+    void showCategoriesPopover(const std::vector<Manga>& mangaList, std::function<void()> onBack = nullptr);
     void hideCategoryPanel();
     bool isFocusInCategoryPanel(brls::View* view) const;
     void showMigrateSourceMenu(const Manga& manga);

--- a/include/view/library_section_tab.hpp
+++ b/include/view/library_section_tab.hpp
@@ -74,6 +74,10 @@ private:
     void showMangaContextMenu(const Manga& manga, int index);
     void showDownloadSubmenu(const std::vector<Manga>& mangaList);
     void showChangeCategoryDialog(const std::vector<Manga>& mangaList, int focusedIndex = -1);
+    // New-design sub-popovers opened from the Options popover (replace the old
+    // inline panels that showDownloadSubmenu / showChangeCategoryDialog raise).
+    void showDownloadPopover(const std::vector<Manga>& mangaList);
+    void showCategoriesPopover(const std::vector<Manga>& mangaList);
     void hideCategoryPanel();
     bool isFocusInCategoryPanel(brls::View* view) const;
     void showMigrateSourceMenu(const Manga& manga);

--- a/include/view/options_popover.hpp
+++ b/include/view/options_popover.hpp
@@ -44,10 +44,13 @@ public:
     //   onBack      — if set, the B button dismisses this popover and then runs
     //                 onBack (e.g. reopen the parent menu); otherwise B just
     //                 closes the popover.
+    //   maxVisibleRows — if > 0, cap the visible height to this many rows and
+    //                 scroll the rest (e.g. 5). 0 = fit to screen (default).
     static void show(const std::string& contextLine,
                      const std::string& title,
                      std::vector<OptionRow> rows,
-                     std::function<void()> onBack = nullptr);
+                     std::function<void()> onBack = nullptr,
+                     int maxVisibleRows = 0);
 };
 
 } // namespace vitasuwayomi

--- a/include/view/options_popover.hpp
+++ b/include/view/options_popover.hpp
@@ -25,7 +25,13 @@ struct OptionRow {
     std::string sub;              // optional trailing mono sub-value
     bool primary = false;         // receives default focus
     bool danger  = false;         // muted label color (destructive/cancel)
-    std::function<void()> action; // run after the popover fades out
+    std::function<void()> action; // run when activated
+
+    // Checkable rows toggle in place: activating them flips the leading
+    // checkbox and runs `action` WITHOUT dismissing the popover (used for
+    // multi-select lists such as categories). `checked` is the initial state.
+    bool checkable = false;
+    bool checked   = false;
 };
 
 class OptionsPopover {
@@ -35,9 +41,13 @@ public:
     //                 (·) makes it gold, otherwise it renders dim.
     //   title       — bold title line.
     //   rows        — the selectable rows, top to bottom.
+    //   onBack      — if set, the B button dismisses this popover and then runs
+    //                 onBack (e.g. reopen the parent menu); otherwise B just
+    //                 closes the popover.
     static void show(const std::string& contextLine,
                      const std::string& title,
-                     std::vector<OptionRow> rows);
+                     std::vector<OptionRow> rows,
+                     std::function<void()> onBack = nullptr);
 };
 
 } // namespace vitasuwayomi

--- a/include/view/options_popover.hpp
+++ b/include/view/options_popover.hpp
@@ -1,0 +1,43 @@
+/**
+ * VitaSuwayomi - Options Popover
+ *
+ * A compact, centered options panel over a dimmed scrim — a 1:1 port of the
+ * "Options" context-menu design from VitaPlex (artboard "D4a"). Presentation
+ * only: callers translate their actions into OptionRow entries and hand the
+ * vector to OptionsPopover::show().
+ */
+
+#pragma once
+
+#include <borealis.hpp>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace vitasuwayomi {
+
+// One selectable row in the popover.
+struct OptionRow {
+    // Leading icon. "download.png" / "refresh.png" / "cross.png" are drawn as
+    // crisp MDI vector glyphs; any other non-empty value loads "icons/<icon>".
+    std::string icon;
+    std::string label;
+    std::string sub;              // optional trailing mono sub-value
+    bool primary = false;         // receives default focus
+    bool danger  = false;         // muted label color (destructive/cancel)
+    std::function<void()> action; // run after the popover fades out
+};
+
+class OptionsPopover {
+public:
+    // Show a centered options popover.
+    //   contextLine — small line above the title (e.g. "MANGA", ""); a middot
+    //                 (·) makes it gold, otherwise it renders dim.
+    //   title       — bold title line.
+    //   rows        — the selectable rows, top to bottom.
+    static void show(const std::string& contextLine,
+                     const std::string& title,
+                     std::vector<OptionRow> rows);
+};
+
+} // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2495,11 +2495,15 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
             [this, captured]() { onMangaSelected(captured); }});
     }
 
+    // Reopening the main Options popover is the "back" target for the sub-menus.
+    Manga backManga = manga;
+    auto reopenMain = [this, backManga, index]() { showMangaContextMenu(backManga, index); };
+
     rows.push_back({ "download.png", "Download", "", false, false,
-        [this, mangaList]() { showDownloadPopover(mangaList); }});
+        [this, mangaList, reopenMain]() { showDownloadPopover(mangaList, reopenMain); }});
 
     rows.push_back({ "tag.png", "Edit Categories", "", false, false,
-        [this, mangaList]() { showCategoriesPopover(mangaList); }});
+        [this, mangaList, reopenMain]() { showCategoriesPopover(mangaList, reopenMain); }});
 
     rows.push_back({ "checkbox_checked.png", "Mark as Read", "", false, false,
         [this, mangaList]() { markMangaRead(mangaList); }});
@@ -2523,7 +2527,8 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
     OptionsPopover::show(contextLine, title, std::move(rows));
 }
 
-void LibrarySectionTab::showDownloadPopover(const std::vector<Manga>& mangaList) {
+void LibrarySectionTab::showDownloadPopover(const std::vector<Manga>& mangaList,
+                                            std::function<void()> onBack) {
     if (mangaList.empty()) return;
 
     const bool single = mangaList.size() == 1;
@@ -2544,12 +2549,15 @@ void LibrarySectionTab::showDownloadPopover(const std::vector<Manga>& mangaList)
             [this, mangaList, mode]() { downloadChapters(mangaList, mode); }});
         first = false;
     }
-    rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
+    // Cancel returns to the parent Options menu when there is one.
+    rows.push_back({ "back.png", "Cancel", "", false, true,
+        [onBack]() { if (onBack) onBack(); }});
 
-    OptionsPopover::show("DOWNLOAD", title, std::move(rows));
+    OptionsPopover::show("DOWNLOAD", title, std::move(rows), onBack);
 }
 
-void LibrarySectionTab::showCategoriesPopover(const std::vector<Manga>& mangaList) {
+void LibrarySectionTab::showCategoriesPopover(const std::vector<Manga>& mangaList,
+                                              std::function<void()> onBack) {
     if (mangaList.empty()) return;
     if (m_categories.empty()) {
         brls::Application::notify("No categories available");
@@ -2577,58 +2585,54 @@ void LibrarySectionTab::showCategoriesPopover(const std::vector<Manga>& mangaLis
     const std::string title = mangaList.size() == 1 ? mangaList[0].title
                                     : std::to_string(mangaList.size()) + " manga";
 
-    // Self-referential builder so toggling a category re-opens the popover with
-    // refreshed check marks. *rebuild holds only a weak ref (no permanent
-    // cycle); the currently-shown rows hold a strong ref, keeping it alive while
-    // the menu is open.
-    auto rebuild = std::make_shared<std::function<void()>>();
-    std::weak_ptr<std::function<void()>> rebuildWeak = rebuild;
-    *rebuild = [this, visible, selected, capturedList, title, rebuildWeak]() {
-        auto rb = rebuildWeak.lock();
-        std::vector<OptionRow> rows;
+    std::vector<OptionRow> rows;
 
-        for (const auto& cat : *visible) {
-            int id = cat.id;
-            bool on = selected->count(id) > 0;
-            rows.push_back({ on ? "checkbox_checked.png" : "checkbox.png", cat.name, "", false, false,
-                [this, id, selected, rb]() {
-                    if (selected->count(id)) selected->erase(id);
-                    else                     selected->insert(id);
-                    if (rb) (*rb)();
-                }});
-        }
+    // Category rows toggle in place — the checkbox flips and `selected` updates
+    // without dismissing the popover (checkable = true).
+    for (const auto& cat : *visible) {
+        int id = cat.id;
+        OptionRow row;
+        row.label     = cat.name;
+        row.checkable = true;
+        row.checked   = selected->count(id) > 0;
+        row.action    = [selected, id]() {
+            if (selected->count(id)) selected->erase(id);
+            else                     selected->insert(id);
+        };
+        rows.push_back(std::move(row));
+    }
 
-        rows.push_back({ "checkbox_checked.png", "Apply", "", true, false,
-            [this, capturedList, selected]() {
-                std::vector<int> newCatIds(selected->begin(), selected->end());
-                if (newCatIds.empty()) {
-                    brls::Application::notify("Select at least one category");
-                    return;
+    rows.push_back({ "checkbox_checked.png", "Apply", "", true, false,
+        [this, capturedList, selected]() {
+            std::vector<int> newCatIds(selected->begin(), selected->end());
+            if (newCatIds.empty()) {
+                brls::Application::notify("Select at least one category");
+                return;
+            }
+            std::weak_ptr<bool> aliveWeak = m_alive;
+            std::vector<Manga> asyncList = capturedList;
+            brls::Application::notify("Updating categories...");
+            asyncRun([this, asyncList, newCatIds, aliveWeak]() {
+                SuwayomiClient& client = SuwayomiClient::getInstance();
+                int successCount = 0;
+                for (const auto& manga : asyncList) {
+                    if (client.setMangaCategories(manga.id, newCatIds)) successCount++;
                 }
-                std::weak_ptr<bool> aliveWeak = m_alive;
-                std::vector<Manga> asyncList = capturedList;
-                brls::Application::notify("Updating categories...");
-                asyncRun([this, asyncList, newCatIds, aliveWeak]() {
-                    SuwayomiClient& client = SuwayomiClient::getInstance();
-                    int successCount = 0;
-                    for (const auto& manga : asyncList) {
-                        if (client.setMangaCategories(manga.id, newCatIds)) successCount++;
-                    }
-                    brls::sync([this, successCount, aliveWeak]() {
-                        auto alive = aliveWeak.lock();
-                        if (!alive || !*alive) return;
-                        brls::Application::notify("Updated " + std::to_string(successCount) + " manga");
-                        if (m_selectionMode) exitSelectionMode();
-                        refresh();
-                    });
+                brls::sync([this, successCount, aliveWeak]() {
+                    auto alive = aliveWeak.lock();
+                    if (!alive || !*alive) return;
+                    brls::Application::notify("Updated " + std::to_string(successCount) + " manga");
+                    if (m_selectionMode) exitSelectionMode();
+                    refresh();
                 });
-            }});
+            });
+        }});
 
-        rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
+    // Cancel returns to the parent Options menu when there is one.
+    rows.push_back({ "back.png", "Cancel", "", false, true,
+        [onBack]() { if (onBack) onBack(); }});
 
-        OptionsPopover::show("CATEGORIES", title, std::move(rows));
-    };
-    (*rebuild)();
+    OptionsPopover::show("CATEGORIES", title, std::move(rows), onBack);
 }
 
 void LibrarySectionTab::showDownloadSubmenu(const std::vector<Manga>& mangaList) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -8,6 +8,7 @@
 #include "view/manga_item_cell.hpp"
 #include "view/manga_detail_view.hpp"
 #include "view/tracking_search_view.hpp"
+#include "view/options_popover.hpp"
 #include "app/application.hpp"
 #include "app/suwayomi_client.hpp"
 #include "app/downloads_manager.hpp"
@@ -2479,8 +2480,47 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
         mangaList.push_back(manga);
     }
 
-    // Delegate to the unified panel which has Select at top + Categories + Downloads + actions
-    showChangeCategoryDialog(mangaList, index);
+    const bool single = mangaList.size() == 1;
+    const std::string contextLine = single ? "MANGA"
+                                           : std::to_string(mangaList.size()) + " SELECTED";
+    const std::string title = single ? manga.title
+                                     : std::to_string(mangaList.size()) + " manga";
+
+    std::vector<OptionRow> rows;
+
+    // Open detail — only for a single manga.
+    if (single) {
+        Manga captured = manga;
+        rows.push_back({ "book-open-page-variant.png", "Open", "", true, false,
+            [this, captured]() { onMangaSelected(captured); }});
+    }
+
+    rows.push_back({ "download.png", "Download", "", false, false,
+        [this, mangaList]() { showDownloadSubmenu(mangaList); }});
+
+    rows.push_back({ "tag.png", "Edit Categories", "", false, false,
+        [this, mangaList, index]() { showChangeCategoryDialog(mangaList, index); }});
+
+    rows.push_back({ "checkbox_checked.png", "Mark as Read", "", false, false,
+        [this, mangaList]() { markMangaRead(mangaList); }});
+
+    rows.push_back({ "checkbox.png", "Mark as Unread", "", false, false,
+        [this, mangaList]() { markMangaUnread(mangaList); }});
+
+    if (single) {
+        Manga captured = manga;
+        rows.push_back({ "web.png", "Tracking", "", false, false,
+            [this, captured]() { openTracking(captured); }});
+        rows.push_back({ "import.png", "Migrate", "", false, false,
+            [this, captured]() { showMigrateSourceMenu(captured); }});
+    }
+
+    rows.push_back({ "hide.png", "Remove from Library", "", false, true,
+        [this, mangaList]() { removeFromLibrary(mangaList); }});
+
+    rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
+
+    OptionsPopover::show(contextLine, title, std::move(rows));
 }
 
 void LibrarySectionTab::showDownloadSubmenu(const std::vector<Manga>& mangaList) {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2177,130 +2177,50 @@ void LibrarySectionTab::cycleSortMode() {
 }
 
 void LibrarySectionTab::showSortMenu() {
-    std::vector<std::string> options = {
-        "Default (Settings)",
-        "A-Z",
-        "Z-A",
-        "Most Unread",
-        "Least Unread",
-        "Recently Added (Newest)",
-        "Recently Added (Oldest)",
-        "Last Read",
-        "Date Updated (Newest)",
-        "Date Updated (Oldest)",
-        "Total Chapters",
+    static const char* labels[] = {
+        "Default (Settings)", "A-Z", "Z-A", "Most Unread", "Least Unread",
+        "Recently Added (Newest)", "Recently Added (Oldest)", "Last Read",
+        "Date Updated (Newest)", "Date Updated (Oldest)", "Total Chapters",
         "Local Downloads Only"
     };
-
-    // Find current selection index for highlighting
-    int currentIndex = 0;
-    switch (m_sortMode) {
-        case LibrarySortMode::DEFAULT:
-            currentIndex = 0;
-            break;
-        case LibrarySortMode::TITLE_ASC:
-            currentIndex = 1;
-            break;
-        case LibrarySortMode::TITLE_DESC:
-            currentIndex = 2;
-            break;
-        case LibrarySortMode::UNREAD_DESC:
-            currentIndex = 3;
-            break;
-        case LibrarySortMode::UNREAD_ASC:
-            currentIndex = 4;
-            break;
-        case LibrarySortMode::RECENTLY_ADDED_DESC:
-            currentIndex = 5;
-            break;
-        case LibrarySortMode::RECENTLY_ADDED_ASC:
-            currentIndex = 6;
-            break;
-        case LibrarySortMode::LAST_READ:
-            currentIndex = 7;
-            break;
-        case LibrarySortMode::DATE_UPDATED_DESC:
-            currentIndex = 8;
-            break;
-        case LibrarySortMode::DATE_UPDATED_ASC:
-            currentIndex = 9;
-            break;
-        case LibrarySortMode::TOTAL_CHAPTERS:
-            currentIndex = 10;
-            break;
-        case LibrarySortMode::DOWNLOADED_ONLY:
-            currentIndex = 11;
-            break;
-    }
+    static const LibrarySortMode modes[] = {
+        LibrarySortMode::DEFAULT, LibrarySortMode::TITLE_ASC, LibrarySortMode::TITLE_DESC,
+        LibrarySortMode::UNREAD_DESC, LibrarySortMode::UNREAD_ASC,
+        LibrarySortMode::RECENTLY_ADDED_DESC, LibrarySortMode::RECENTLY_ADDED_ASC,
+        LibrarySortMode::LAST_READ, LibrarySortMode::DATE_UPDATED_DESC,
+        LibrarySortMode::DATE_UPDATED_ASC, LibrarySortMode::TOTAL_CHAPTERS,
+        LibrarySortMode::DOWNLOADED_ONLY
+    };
+    const int count = static_cast<int>(sizeof(modes) / sizeof(modes[0]));
 
     int categoryId = m_currentCategoryId;
 
-    auto* dropdown = new brls::Dropdown(
-        "Sort By",
-        options,
-        [this, categoryId](int selected) {
-            if (selected < 0) return; // Cancelled
+    std::vector<OptionRow> rows;
+    for (int i = 0; i < count; i++) {
+        const bool current = (m_sortMode == modes[i]);
+        LibrarySortMode mode = modes[i];
+        rows.push_back({ current ? "radio_checked.png" : "radio.png", labels[i], "", current, false,
+            [this, mode, categoryId]() {
+                // Defer so the popover fully closes first (avoids focus churn).
+                brls::sync([this, mode, categoryId]() {
+                    m_sortMode = mode;
+                    updateSortButtonText();
+                    sortMangaList();
 
-            // Defer action to next frame so dropdown fully closes first
-            // This fixes hover/focus transfer issues
-            brls::sync([this, selected, categoryId]() {
-                switch (selected) {
-                    case 0:
-                        m_sortMode = LibrarySortMode::DEFAULT;
-                        break;
-                    case 1:
-                        m_sortMode = LibrarySortMode::TITLE_ASC;
-                        break;
-                    case 2:
-                        m_sortMode = LibrarySortMode::TITLE_DESC;
-                        break;
-                    case 3:
-                        m_sortMode = LibrarySortMode::UNREAD_DESC;
-                        break;
-                    case 4:
-                        m_sortMode = LibrarySortMode::UNREAD_ASC;
-                        break;
-                    case 5:
-                        m_sortMode = LibrarySortMode::RECENTLY_ADDED_DESC;
-                        break;
-                    case 6:
-                        m_sortMode = LibrarySortMode::RECENTLY_ADDED_ASC;
-                        break;
-                    case 7:
-                        m_sortMode = LibrarySortMode::LAST_READ;
-                        break;
-                    case 8:
-                        m_sortMode = LibrarySortMode::DATE_UPDATED_DESC;
-                        break;
-                    case 9:
-                        m_sortMode = LibrarySortMode::DATE_UPDATED_ASC;
-                        break;
-                    case 10:
-                        m_sortMode = LibrarySortMode::TOTAL_CHAPTERS;
-                        break;
-                    case 11:
-                        m_sortMode = LibrarySortMode::DOWNLOADED_ONLY;
-                        break;
-                }
+                    // Persist per-category sort mode
+                    auto& app = Application::getInstance();
+                    if (m_sortMode == LibrarySortMode::DEFAULT) {
+                        app.getSettings().categorySortModes.erase(categoryId);
+                    } else {
+                        app.getSettings().categorySortModes[categoryId] = static_cast<int>(m_sortMode);
+                    }
+                    app.saveSettings();
+                });
+            }});
+    }
+    rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
 
-                updateSortButtonText();
-                sortMangaList();
-
-                // Persist per-category sort mode
-                auto& app = Application::getInstance();
-                if (m_sortMode == LibrarySortMode::DEFAULT) {
-                    // Remove per-category setting to use default
-                    app.getSettings().categorySortModes.erase(categoryId);
-                } else {
-                    // Save per-category sort mode
-                    app.getSettings().categorySortModes[categoryId] = static_cast<int>(m_sortMode);
-                }
-                app.saveSettings();
-            });
-        },
-        currentIndex
-    );
-    brls::Application::pushActivity(new brls::Activity(dropdown));
+    OptionsPopover::show("LIBRARY", "Sort By", std::move(rows));
 }
 
 void LibrarySectionTab::updateSortButtonText() {
@@ -4617,29 +4537,27 @@ void LibrarySectionTab::selectSource(const std::string& sourceName) {
 }
 
 void LibrarySectionTab::showGroupModeMenu() {
-    std::vector<std::string> options = {
-        "By Category",
-        "By Source",
-        "No Grouping (All)"
-    };
+    static const char* labels[] = { "By Category", "By Source", "No Grouping (All)" };
+    const int count = static_cast<int>(sizeof(labels) / sizeof(labels[0]));
 
-    int currentMode = static_cast<int>(m_groupMode);
+    const int currentMode = static_cast<int>(m_groupMode);
 
-    brls::Dropdown* dropdown = new brls::Dropdown(
-        "Library Grouping",
-        options,
-        [this](int selected) {
-            if (selected < 0 || selected > 2) return;
-            // Defer to next frame so dropdown fully closes first
-            // This fixes crash from UI updates while dropdown is dismissing
-            brls::sync([this, selected]() {
-                setGroupMode(static_cast<LibraryGroupMode>(selected));
-            });
-        },
-        currentMode
-    );
+    std::vector<OptionRow> rows;
+    for (int i = 0; i < count; i++) {
+        const bool current = (currentMode == i);
+        int idx = i;
+        rows.push_back({ current ? "radio_checked.png" : "radio.png", labels[i], "", current, false,
+            [this, idx]() {
+                // Defer so the popover fully closes first (avoids UI churn while
+                // the activity is dismissing).
+                brls::sync([this, idx]() {
+                    setGroupMode(static_cast<LibraryGroupMode>(idx));
+                });
+            }});
+    }
+    rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
 
-    brls::Application::pushActivity(new brls::Activity(dropdown));
+    OptionsPopover::show("LIBRARY", "Library Grouping", std::move(rows));
 }
 
 } // namespace vitasuwayomi

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2220,7 +2220,8 @@ void LibrarySectionTab::showSortMenu() {
     }
     rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
 
-    OptionsPopover::show("LIBRARY", "Sort By", std::move(rows));
+    // Show 5 rows, then scroll the rest.
+    OptionsPopover::show("LIBRARY", "Sort By", std::move(rows), nullptr, 5);
 }
 
 void LibrarySectionTab::updateSortButtonText() {

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2496,10 +2496,10 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
     }
 
     rows.push_back({ "download.png", "Download", "", false, false,
-        [this, mangaList]() { showDownloadSubmenu(mangaList); }});
+        [this, mangaList]() { showDownloadPopover(mangaList); }});
 
     rows.push_back({ "tag.png", "Edit Categories", "", false, false,
-        [this, mangaList, index]() { showChangeCategoryDialog(mangaList, index); }});
+        [this, mangaList]() { showCategoriesPopover(mangaList); }});
 
     rows.push_back({ "checkbox_checked.png", "Mark as Read", "", false, false,
         [this, mangaList]() { markMangaRead(mangaList); }});
@@ -2521,6 +2521,114 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
     rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
 
     OptionsPopover::show(contextLine, title, std::move(rows));
+}
+
+void LibrarySectionTab::showDownloadPopover(const std::vector<Manga>& mangaList) {
+    if (mangaList.empty()) return;
+
+    const bool single = mangaList.size() == 1;
+    const std::string title = single ? mangaList[0].title
+                                     : std::to_string(mangaList.size()) + " manga";
+
+    struct Opt { const char* label; const char* mode; };
+    static const Opt opts[] = {
+        {"All Chapters", "all"}, {"Unread Chapters", "unread"}, {"Next Chapter", "next1"},
+        {"Next 5 Chapters", "next5"}, {"Next 10 Chapters", "next10"}, {"Next 25 Chapters", "next25"}
+    };
+
+    std::vector<OptionRow> rows;
+    bool first = true;
+    for (const auto& o : opts) {
+        std::string mode = o.mode;
+        rows.push_back({ "download.png", o.label, "", first, false,
+            [this, mangaList, mode]() { downloadChapters(mangaList, mode); }});
+        first = false;
+    }
+    rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
+
+    OptionsPopover::show("DOWNLOAD", title, std::move(rows));
+}
+
+void LibrarySectionTab::showCategoriesPopover(const std::vector<Manga>& mangaList) {
+    if (mangaList.empty()) return;
+    if (m_categories.empty()) {
+        brls::Application::notify("No categories available");
+        return;
+    }
+
+    // Filter out hidden categories, matching the old dialog.
+    const auto& hiddenIds = Application::getInstance().getSettings().hiddenCategoryIds;
+    auto visible = std::make_shared<std::vector<Category>>();
+    for (const auto& cat : m_categories) {
+        if (hiddenIds.find(cat.id) == hiddenIds.end()) visible->push_back(cat);
+    }
+    if (visible->empty()) {
+        brls::Application::notify("No visible categories available");
+        return;
+    }
+
+    // Seed the checked set from the union of the manga's current categories.
+    auto selected = std::make_shared<std::set<int>>();
+    for (const auto& m : mangaList) {
+        for (int id : m.categoryIds) selected->insert(id);
+    }
+
+    std::vector<Manga> capturedList = mangaList;
+    const std::string title = mangaList.size() == 1 ? mangaList[0].title
+                                    : std::to_string(mangaList.size()) + " manga";
+
+    // Self-referential builder so toggling a category re-opens the popover with
+    // refreshed check marks. *rebuild holds only a weak ref (no permanent
+    // cycle); the currently-shown rows hold a strong ref, keeping it alive while
+    // the menu is open.
+    auto rebuild = std::make_shared<std::function<void()>>();
+    std::weak_ptr<std::function<void()>> rebuildWeak = rebuild;
+    *rebuild = [this, visible, selected, capturedList, title, rebuildWeak]() {
+        auto rb = rebuildWeak.lock();
+        std::vector<OptionRow> rows;
+
+        for (const auto& cat : *visible) {
+            int id = cat.id;
+            bool on = selected->count(id) > 0;
+            rows.push_back({ on ? "checkbox_checked.png" : "checkbox.png", cat.name, "", false, false,
+                [this, id, selected, rb]() {
+                    if (selected->count(id)) selected->erase(id);
+                    else                     selected->insert(id);
+                    if (rb) (*rb)();
+                }});
+        }
+
+        rows.push_back({ "checkbox_checked.png", "Apply", "", true, false,
+            [this, capturedList, selected]() {
+                std::vector<int> newCatIds(selected->begin(), selected->end());
+                if (newCatIds.empty()) {
+                    brls::Application::notify("Select at least one category");
+                    return;
+                }
+                std::weak_ptr<bool> aliveWeak = m_alive;
+                std::vector<Manga> asyncList = capturedList;
+                brls::Application::notify("Updating categories...");
+                asyncRun([this, asyncList, newCatIds, aliveWeak]() {
+                    SuwayomiClient& client = SuwayomiClient::getInstance();
+                    int successCount = 0;
+                    for (const auto& manga : asyncList) {
+                        if (client.setMangaCategories(manga.id, newCatIds)) successCount++;
+                    }
+                    brls::sync([this, successCount, aliveWeak]() {
+                        auto alive = aliveWeak.lock();
+                        if (!alive || !*alive) return;
+                        brls::Application::notify("Updated " + std::to_string(successCount) + " manga");
+                        if (m_selectionMode) exitSelectionMode();
+                        refresh();
+                    });
+                });
+            }});
+
+        rows.push_back({ "cross.png", "Cancel", "", false, true, []() {}});
+
+        OptionsPopover::show("CATEGORIES", title, std::move(rows));
+    };
+    (*rebuild)();
 }
 
 void LibrarySectionTab::showDownloadSubmenu(const std::vector<Manga>& mangaList) {

--- a/src/view/options_popover.cpp
+++ b/src/view/options_popover.cpp
@@ -1,0 +1,278 @@
+/**
+ * VitaSuwayomi - Options Popover
+ *
+ * 1:1 port of VitaPlex's "Options" context-menu design (artboard "D4a"):
+ * a compact centered panel over a dimmed scrim, with a context line + title,
+ * a hairline divider, and icon rows. The download / restart / close glyphs are
+ * drawn as exact MDI vector paths so they stay crisp and tintable at any size.
+ */
+
+#include "view/options_popover.hpp"
+
+namespace vitasuwayomi {
+
+namespace {
+
+// Palette literals scoped to this component (matches artboard "D4a"): a neutral
+// sheet surface that reads as the same material as the shell, not a tint.
+namespace popcol {
+    inline NVGcolor panel() { return nvgRGB(50, 50, 50); }
+    inline NVGcolor line()  { return nvgRGB(67, 67, 74); }
+    inline NVGcolor text()  { return nvgRGB(255, 255, 255); }
+    inline NVGcolor muted() { return nvgRGB(0xA8, 0xA6, 0xB4); }
+    inline NVGcolor dim()   { return nvgRGB(0x80, 0x7E, 0x8C); }
+    inline NVGcolor gold()  { return nvgRGB(0xE5, 0xA0, 0x0D); }
+    inline NVGcolor scrim() { return nvgRGBA(10, 9, 14, 128); }
+}
+
+// Translucent host so the underlying screen shows through the scrim.
+class PopoverActivity : public brls::Activity {
+public:
+    explicit PopoverActivity(brls::Box* content) : brls::Activity(content) {}
+    bool isTranslucent() override { return true; }
+};
+
+// download / restart / close drawn as exact MDI vector paths (24x24 viewBox)
+// rather than relying on a PNG — crisp at any size and tintable. nanovg fills
+// with nonzero winding, so download's separate bar + arrow sub-paths render
+// correctly.
+enum class MdiGlyph { Download, Restart, Close };
+
+class MdiGlyphIcon : public brls::Box {
+public:
+    MdiGlyphIcon(MdiGlyph g, NVGcolor color) : m_glyph(g), m_color(color) {}
+    void draw(NVGcontext* vg, float x, float y, float w, float h,
+              brls::Style style, brls::FrameContext* ctx) override {
+        brls::Box::draw(vg, x, y, w, h, style, ctx);
+        const float side = (w < h) ? w : h;
+        const float gx = x + (w - side) * 0.5f;
+        const float gy = y + (h - side) * 0.5f;
+        const float s  = side / 24.0f;
+        auto X = [=](float v) { return gx + v * s; };
+        auto Y = [=](float v) { return gy + v * s; };
+        nvgBeginPath(vg);
+        switch (m_glyph) {
+            case MdiGlyph::Close:
+                nvgMoveTo(vg, X(19), Y(6.41f));   nvgLineTo(vg, X(17.59f), Y(5));
+                nvgLineTo(vg, X(12), Y(10.59f));  nvgLineTo(vg, X(6.41f), Y(5));
+                nvgLineTo(vg, X(5), Y(6.41f));    nvgLineTo(vg, X(10.59f), Y(12));
+                nvgLineTo(vg, X(5), Y(17.59f));   nvgLineTo(vg, X(6.41f), Y(19));
+                nvgLineTo(vg, X(12), Y(13.41f));  nvgLineTo(vg, X(17.59f), Y(19));
+                nvgLineTo(vg, X(19), Y(17.59f));  nvgLineTo(vg, X(13.41f), Y(12));
+                nvgClosePath(vg);
+                break;
+            case MdiGlyph::Download:
+                nvgMoveTo(vg, X(5), Y(20));  nvgLineTo(vg, X(19), Y(20));
+                nvgLineTo(vg, X(19), Y(18)); nvgLineTo(vg, X(5), Y(18));
+                nvgClosePath(vg);
+                nvgMoveTo(vg, X(19), Y(9));  nvgLineTo(vg, X(15), Y(9));
+                nvgLineTo(vg, X(15), Y(3));  nvgLineTo(vg, X(9), Y(3));
+                nvgLineTo(vg, X(9), Y(9));   nvgLineTo(vg, X(5), Y(9));
+                nvgLineTo(vg, X(12), Y(16)); nvgLineTo(vg, X(19), Y(9));
+                nvgClosePath(vg);
+                break;
+            case MdiGlyph::Restart:
+                nvgMoveTo(vg, X(12), Y(4));
+                nvgBezierTo(vg, X(14.1f), Y(4),     X(16.1f), Y(4.8f),  X(17.6f), Y(6.3f));
+                nvgBezierTo(vg, X(20.7f), Y(9.4f),  X(20.7f), Y(14.5f), X(17.6f), Y(17.6f));
+                nvgBezierTo(vg, X(15.8f), Y(19.5f), X(13.3f), Y(20.2f), X(10.9f), Y(19.9f));
+                nvgLineTo(vg, X(11.4f), Y(17.9f));
+                nvgBezierTo(vg, X(13.1f), Y(18.1f), X(14.9f), Y(17.5f), X(16.2f), Y(16.2f));
+                nvgBezierTo(vg, X(18.5f), Y(13.9f), X(18.5f), Y(10.1f), X(16.2f), Y(7.7f));
+                nvgBezierTo(vg, X(15.1f), Y(6.6f),  X(13.5f), Y(6),     X(12),    Y(6));
+                nvgLineTo(vg, X(12), Y(10.6f));
+                nvgLineTo(vg, X(7),  Y(5.6f));
+                nvgLineTo(vg, X(12), Y(0.6f));
+                nvgClosePath(vg);
+                nvgMoveTo(vg, X(6.3f), Y(17.6f));
+                nvgBezierTo(vg, X(3.7f), Y(15),    X(3.3f), Y(11),    X(5.1f), Y(7.9f));
+                nvgLineTo(vg, X(6.6f), Y(9.4f));
+                nvgBezierTo(vg, X(5.5f), Y(11.6f), X(5.9f), Y(14.4f), X(7.8f), Y(16.2f));
+                nvgBezierTo(vg, X(8.3f), Y(16.7f), X(8.9f), Y(17.1f), X(9.6f), Y(17.4f));
+                nvgLineTo(vg, X(9), Y(19.4f));
+                nvgBezierTo(vg, X(8), Y(19),       X(7.1f), Y(18.4f), X(6.3f), Y(17.6f));
+                nvgClosePath(vg);
+                break;
+        }
+        nvgFillColor(vg, m_color);
+        nvgFill(vg);
+    }
+private:
+    MdiGlyph m_glyph;
+    NVGcolor m_color;
+};
+
+}  // namespace
+
+void OptionsPopover::show(const std::string& contextLine,
+                          const std::string& title,
+                          std::vector<OptionRow> rows) {
+    namespace pc = popcol;
+
+    // A middot (·) in the context line marks a "gold" case (e.g. "Ch. 12 · …");
+    // every other line ("MANGA", …) renders dim.
+    const bool episodic = contextLine.find("\xC2\xB7") != std::string::npos;
+
+    // ── Geometry ────────────────────────────────────────────────────────
+    const float screenW = brls::Application::contentWidth;
+    const float screenH = brls::Application::contentHeight;
+    const float kPopoverW = 320.0f;
+    const float kMargin   = 40.0f;
+
+    // ── Scrim (full-screen, centers the panel) ──────────────────────────
+    auto* scrim = new brls::Box();
+    scrim->setAxis(brls::Axis::COLUMN);
+    scrim->setWidthPercentage(100.0f);
+    scrim->setHeightPercentage(100.0f);
+    scrim->setJustifyContent(brls::JustifyContent::CENTER);
+    scrim->setAlignItems(brls::AlignItems::CENTER);
+    scrim->setBackgroundColor(pc::scrim());
+    scrim->addGestureRecognizer(new brls::TapGestureRecognizer(scrim,
+        []() { brls::Application::popActivity(); }));
+
+    // ── Popover panel ───────────────────────────────────────────────────
+    auto* panel = new brls::Box();
+    panel->setAxis(brls::Axis::COLUMN);
+    panel->setBackgroundColor(pc::panel());
+    panel->setBorderColor(pc::line());
+    panel->setBorderThickness(1.0f);
+    panel->setShadowType(brls::ShadowType::GENERIC);
+    panel->setPadding(8.0f, 8.0f, 8.0f, 8.0f);
+    panel->setCornerRadius(14.0f);
+    // Fixed 320px, clamped on screens too narrow to hold it with margins.
+    float panelW = kPopoverW;
+    if (panelW + 2.0f * kMargin > screenW) panelW = screenW - 2.0f * kMargin;
+    panel->setWidth(panelW);
+
+    // ── Header (context line + title) ───────────────────────────────────
+    auto* header = new brls::Box();
+    header->setAxis(brls::Axis::COLUMN);
+    header->setPadding(8.0f, 10.0f, 11.0f, 10.0f);
+
+    if (!contextLine.empty()) {
+        auto* ctx = new brls::Label();
+        ctx->setText(contextLine);
+        ctx->setFontSize(11.0f);
+        ctx->setTextColor(episodic ? pc::gold() : pc::dim());
+        ctx->setSingleLine(true);
+        ctx->setMarginBottom(2.0f);
+        header->addView(ctx);
+    }
+    auto* titleLabel = new brls::Label();
+    titleLabel->setText(title);
+    titleLabel->setFontSize(16.0f);
+    titleLabel->setTextColor(pc::text());
+    titleLabel->setSingleLine(true);
+    header->addView(titleLabel);
+    panel->addView(header);
+
+    // borealis only supports a uniform border, so the rule under the header is
+    // a separate 1px divider box rather than a per-side border.
+    auto* divider = new brls::Box();
+    divider->setHeight(1.0f);
+    divider->setAlignSelf(brls::AlignSelf::STRETCH);
+    divider->setBackgroundColor(pc::line());
+    divider->setMarginBottom(6.0f);
+    panel->addView(divider);
+
+    // Only a genuinely long menu scrolls; short menus add rows straight to the
+    // panel and render centered.
+    brls::Box* rowsParent = panel;
+    {
+        const float availForRows = screenH - 2.0f * kMargin - 90.0f;
+        const float wantRows = static_cast<float>(rows.size()) * 44.0f;
+        if (wantRows > availForRows && availForRows > 132.0f) {
+            auto* rowsBox = new brls::Box();
+            rowsBox->setAxis(brls::Axis::COLUMN);
+            auto* scrollFrame = new brls::ScrollingFrame();
+            scrollFrame->setContentView(rowsBox);
+            scrollFrame->setHeight(availForRows);
+            panel->addView(scrollFrame);
+            rowsParent = rowsBox;
+        }
+    }
+
+    // ── Rows ────────────────────────────────────────────────────────────
+    brls::View* defaultFocus = nullptr;
+    brls::View* firstRow      = nullptr;
+    for (auto& r : rows) {
+        OptionRow row = r;  // copy into the row closure
+
+        auto* rowBox = new brls::Box();
+        rowBox->setAxis(brls::Axis::ROW);
+        rowBox->setAlignItems(brls::AlignItems::CENTER);
+        rowBox->setHeight(44.0f);
+        rowBox->setPadding(0.0f, 12.0f, 0.0f, 12.0f);
+        rowBox->setCornerRadius(9.0f);
+        rowBox->setFocusable(true);
+        rowBox->setHighlightCornerRadius(9.0f);
+
+        // Leading icon. download/restart/close are drawn as exact MDI vectors
+        // (tinted to match the row); everything else uses its PNG.
+        brls::View* iconView;
+        NVGcolor iconColor = pc::text();
+        if (row.icon == "download.png") {
+            iconView = new MdiGlyphIcon(MdiGlyph::Download, iconColor);
+        } else if (row.icon == "refresh.png") {
+            iconView = new MdiGlyphIcon(MdiGlyph::Restart, iconColor);
+        } else if (row.icon == "cross.png") {
+            iconView = new MdiGlyphIcon(MdiGlyph::Close, iconColor);
+        } else {
+            auto* img = new brls::Image();
+            if (!row.icon.empty()) img->setImageFromRes("icons/" + row.icon);
+            img->setScalingType(brls::ImageScalingType::FIT);
+            iconView = img;
+        }
+        iconView->setWidth(20.0f);
+        iconView->setHeight(20.0f);
+        iconView->setMarginRight(11.0f);
+        rowBox->addView(iconView);
+
+        // Label.
+        auto* lbl = new brls::Label();
+        lbl->setText(row.label);
+        lbl->setFontSize(15.0f);
+        lbl->setSingleLine(true);
+        lbl->setGrow(1.0f);
+        if (row.danger) lbl->setTextColor(pc::muted());
+        else            lbl->setTextColor(pc::text());
+        rowBox->addView(lbl);
+
+        // Trailing mono sub-value.
+        if (!row.sub.empty()) {
+            auto* sub = new brls::Label();
+            sub->setText(row.sub);
+            sub->setFontSize(12.0f);
+            sub->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
+            sub->setSingleLine(true);
+            sub->setMarginLeft(8.0f);
+            sub->setTextColor(pc::dim());
+            rowBox->addView(sub);
+        }
+
+        // Activate: fade the popover out first, then run the action.
+        auto act = row.action;
+        auto onActivate = [act](brls::View*) -> bool {
+            brls::Application::popActivity(brls::TransitionAnimation::FADE,
+                [act]() { if (act) act(); });
+            return true;
+        };
+        rowBox->registerClickAction(onActivate);
+        rowBox->addGestureRecognizer(new brls::TapGestureRecognizer(rowBox));
+
+        rowsParent->addView(rowBox);
+        if (!firstRow) firstRow = rowBox;
+        if (row.primary && !defaultFocus) defaultFocus = rowBox;
+    }
+    if (!defaultFocus) defaultFocus = firstRow;
+
+    scrim->addView(panel);
+
+    scrim->registerAction("Back", brls::ControllerButton::BUTTON_B,
+        [](brls::View*) { brls::Application::popActivity(); return true; });
+
+    brls::Application::pushActivity(new PopoverActivity(scrim));
+    if (defaultFocus) brls::Application::giveFocus(defaultFocus);
+}
+
+} // namespace vitasuwayomi

--- a/src/view/options_popover.cpp
+++ b/src/view/options_popover.cpp
@@ -106,7 +106,8 @@ private:
 
 void OptionsPopover::show(const std::string& contextLine,
                           const std::string& title,
-                          std::vector<OptionRow> rows) {
+                          std::vector<OptionRow> rows,
+                          std::function<void()> onBack) {
     namespace pc = popcol;
 
     // A middot (·) in the context line marks a "gold" case (e.g. "Ch. 12 · …");
@@ -207,11 +208,20 @@ void OptionsPopover::show(const std::string& contextLine,
         rowBox->setFocusable(true);
         rowBox->setHighlightCornerRadius(9.0f);
 
-        // Leading icon. download/restart/close are drawn as exact MDI vectors
-        // (tinted to match the row); everything else uses its PNG.
+        // Leading icon. Checkable rows show a checkbox that flips in place;
+        // download/restart/close are drawn as exact MDI vectors (tinted to
+        // match the row); everything else uses its PNG.
         brls::View* iconView;
+        brls::Image* checkImg = nullptr;   // set for checkable rows so we can swap in place
         NVGcolor iconColor = pc::text();
-        if (row.icon == "download.png") {
+        if (row.checkable) {
+            auto* img = new brls::Image();
+            img->setImageFromRes(std::string("icons/") +
+                                 (row.checked ? "checkbox_checked.png" : "checkbox.png"));
+            img->setScalingType(brls::ImageScalingType::FIT);
+            iconView = img;
+            checkImg = img;
+        } else if (row.icon == "download.png") {
             iconView = new MdiGlyphIcon(MdiGlyph::Download, iconColor);
         } else if (row.icon == "refresh.png") {
             iconView = new MdiGlyphIcon(MdiGlyph::Restart, iconColor);
@@ -250,14 +260,29 @@ void OptionsPopover::show(const std::string& contextLine,
             rowBox->addView(sub);
         }
 
-        // Activate: fade the popover out first, then run the action.
+        // Activate. Checkable rows flip their checkbox and run the action in
+        // place (no dismiss). Other rows fade the popover out, then run.
         auto act = row.action;
-        auto onActivate = [act](brls::View*) -> bool {
-            brls::Application::popActivity(brls::TransitionAnimation::FADE,
-                [act]() { if (act) act(); });
-            return true;
-        };
-        rowBox->registerClickAction(onActivate);
+        if (row.checkable) {
+            auto checkedState = std::make_shared<bool>(row.checked);
+            auto onToggle = [act, checkImg, checkedState](brls::View*) -> bool {
+                *checkedState = !*checkedState;
+                if (checkImg) {
+                    checkImg->setImageFromRes(std::string("icons/") +
+                        (*checkedState ? "checkbox_checked.png" : "checkbox.png"));
+                }
+                if (act) act();
+                return true;
+            };
+            rowBox->registerClickAction(onToggle);
+        } else {
+            auto onActivate = [act](brls::View*) -> bool {
+                brls::Application::popActivity(brls::TransitionAnimation::FADE,
+                    [act]() { if (act) act(); });
+                return true;
+            };
+            rowBox->registerClickAction(onActivate);
+        }
         rowBox->addGestureRecognizer(new brls::TapGestureRecognizer(rowBox));
 
         rowsParent->addView(rowBox);
@@ -268,8 +293,17 @@ void OptionsPopover::show(const std::string& contextLine,
 
     scrim->addView(panel);
 
+    // B dismisses; if a back handler was given, run it after the pop so B
+    // returns to the parent menu instead of closing outright.
     scrim->registerAction("Back", brls::ControllerButton::BUTTON_B,
-        [](brls::View*) { brls::Application::popActivity(); return true; });
+        [onBack](brls::View*) {
+            if (onBack) {
+                brls::Application::popActivity(brls::TransitionAnimation::FADE, onBack);
+            } else {
+                brls::Application::popActivity();
+            }
+            return true;
+        });
 
     brls::Application::pushActivity(new PopoverActivity(scrim));
     if (defaultFocus) brls::Application::giveFocus(defaultFocus);

--- a/src/view/options_popover.cpp
+++ b/src/view/options_popover.cpp
@@ -107,7 +107,8 @@ private:
 void OptionsPopover::show(const std::string& contextLine,
                           const std::string& title,
                           std::vector<OptionRow> rows,
-                          std::function<void()> onBack) {
+                          std::function<void()> onBack,
+                          int maxVisibleRows) {
     namespace pc = popcol;
 
     // A middot (·) in the context line marks a "gold" case (e.g. "Ch. 12 · …");
@@ -176,18 +177,25 @@ void OptionsPopover::show(const std::string& contextLine,
     divider->setMarginBottom(6.0f);
     panel->addView(divider);
 
-    // Only a genuinely long menu scrolls; short menus add rows straight to the
-    // panel and render centered.
+    // Rows scroll when they don't fit: either past the screen-derived space, or
+    // past an explicit maxVisibleRows cap (e.g. the Sort menu shows 5, scrolls
+    // the rest). Short menus add rows straight to the panel and render centered.
     brls::Box* rowsParent = panel;
     {
+        const float rowH = 44.0f;
         const float availForRows = screenH - 2.0f * kMargin - 90.0f;
-        const float wantRows = static_cast<float>(rows.size()) * 44.0f;
-        if (wantRows > availForRows && availForRows > 132.0f) {
+        float capHeight = availForRows;
+        if (maxVisibleRows > 0) {
+            const float capped = static_cast<float>(maxVisibleRows) * rowH;
+            if (capped < capHeight) capHeight = capped;
+        }
+        const float wantRows = static_cast<float>(rows.size()) * rowH;
+        if (wantRows > capHeight && capHeight > 132.0f) {
             auto* rowsBox = new brls::Box();
             rowsBox->setAxis(brls::Axis::COLUMN);
             auto* scrollFrame = new brls::ScrollingFrame();
             scrollFrame->setContentView(rowsBox);
-            scrollFrame->setHeight(availForRows);
+            scrollFrame->setHeight(capHeight);
             panel->addView(scrollFrame);
             rowsParent = rowsBox;
         }


### PR DESCRIPTION
Adds the centered Options popover for the library context menu and routes Download, Categories, Sort By and Library Grouping through it, with in-place category toggles, sub-menu Cancel returning to the popover, and the Sort By list capped to 5 visible rows.

---
_Generated by [Claude Code](https://claude.ai/code)_