### PR TITLE
Use the Options popover for the detail view Filter and Options menus

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -673,8 +673,9 @@ query GetManga($mangaId: Int!) {
 # )
 
 # Refresh Manga (Fetch latest from source)
+# Note: fetchManga is deprecated; use fetchMangaAndChapters with fetchChapters:false.
 mutation RefreshManga($mangaId: Int!) {
-    fetchManga(input: { id: $mangaId }) {
+    fetchMangaAndChapters(input: { id: $mangaId, fetchManga: true, fetchChapters: false }) {
         manga {
             id
             title
@@ -799,8 +800,9 @@ query GetChapters($mangaId: Int!) {
 # )
 
 # Fetch Chapters from Source (refresh chapter list)
+# Note: fetchChapters is deprecated; use fetchMangaAndChapters with fetchManga:false.
 mutation FetchChapters($mangaId: Int!) {
-    fetchChapters(input: { mangaId: $mangaId }) {
+    fetchMangaAndChapters(input: { id: $mangaId, fetchManga: false, fetchChapters: true }) {
         chapters {
             id
             name
@@ -2212,3 +2214,40 @@ subscription WebUIUpdateStatusChange {
 # Connect to: ws://{serverUrl}/api/graphql
 # Protocol: graphql-transport-ws
 # Send connection_init, then subscribe messages
+
+# ============================================================================
+# API AUDIT NOTES (client vs current Suwayomi-Server)
+# ============================================================================
+# GraphQL is the PRIMARY API; the /api/v1 REST calls are only a fallback.
+# The GraphQL operations above were audited against the current server schema
+# and are correct. Fixes applied to the client this pass:
+#
+# GraphQL (primary):
+#  - Source filters: removed nonexistent SelectFilter.displayValues (server
+#    SelectFilter only has name/values/default; display strings are in values).
+#  - Library list / chapters list: migrated deprecated `orderBy`/`orderByType`
+#    to `order: [{ by, byType }]`.
+#  - Refresh manga / fetch chapters: migrated deprecated `fetchManga` /
+#    `fetchChapters` to `fetchMangaAndChapters(input:{id,fetchManga,fetchChapters})`.
+#
+# REST fallback (high-impact fixes applied):
+#  - POST /update/fetch: send form param `categoryId=<id>` (not JSON) — JSON was
+#    ignored, so the server updated ALL categories instead of the target one.
+#  - GET  /update/summary: response is { categoryStatusMap, mangaStatusMap,
+#    running }; read `running` and count mangaStatusMap.PENDING / .RUNNING for
+#    progress (old pendingJobs/runningJobs/isRunning fields do not exist).
+#  - POST /manga/{id}/chapter/batch: change field is `isRead` (not `read`).
+#  - GET  /category/{id}: returns the category's manga (no `/manga` suffix).
+#
+# REST fallback (KNOWN-STILL-BROKEN — not yet fixed; GraphQL primary covers these):
+#  - Server reads FORM params, not JSON, for: PATCH /manga/{id}/meta (key,value),
+#    PATCH /manga/{id}/chapter/{index} (read,bookmarked,lastPageRead),
+#    POST /category (name), PATCH /category/{id} (name,default,...),
+#    PATCH /category/reorder (from,to — single move, not an id array).
+#  - No REST route for: GET/DELETE /manga/{id}/meta (GraphQL only),
+#    PATCH /chapter/{id} progress, GET /chapter/{id} pages.
+#  - Path drift: chapter page image is
+#    /manga/{mangaId}/chapter/{chapterIndex}/page/{index} (not /chapter/{id}/...);
+#    source popular/latest take pageNum in the PATH: /source/{id}/popular/{page}.
+#  - DELETE /download/batch expects body { "chapterIds": [<int>...] } (flat ints)
+#    and the body must actually be sent on the DELETE.

--- a/api.txt
+++ b/api.txt
@@ -2230,7 +2230,7 @@ subscription WebUIUpdateStatusChange {
 #  - Refresh manga / fetch chapters: migrated deprecated `fetchManga` /
 #    `fetchChapters` to `fetchMangaAndChapters(input:{id,fetchManga,fetchChapters})`.
 #
-# REST fallback (high-impact fixes applied):
+# REST fallback (fixes applied):
 #  - POST /update/fetch: send form param `categoryId=<id>` (not JSON) — JSON was
 #    ignored, so the server updated ALL categories instead of the target one.
 #  - GET  /update/summary: response is { categoryStatusMap, mangaStatusMap,
@@ -2238,16 +2238,19 @@ subscription WebUIUpdateStatusChange {
 #    progress (old pendingJobs/runningJobs/isRunning fields do not exist).
 #  - POST /manga/{id}/chapter/batch: change field is `isRead` (not `read`).
 #  - GET  /category/{id}: returns the category's manga (no `/manga` suffix).
+#  - Form params (not JSON) now sent for: PATCH /manga/{id}/meta (key,value),
+#    PATCH /manga/{id}/chapter/{index} (read,bookmarked),
+#    POST /category (name), PATCH /category/{id} (name,default).
+#  - PATCH /category/reorder can't take an id array; whole-array reorder now goes
+#    through the GraphQL updateCategoryOrder (position per category) instead.
+#  - Source popular/latest take the page in the PATH: /source/{id}/popular/{page},
+#    /source/{id}/latest/{page} (was ?pageNum=).
+#  - DELETE /download/batch: sends a flat { "chapterIds": [<int>...] } body via a
+#    real DELETE-with-body request.
 #
-# REST fallback (KNOWN-STILL-BROKEN — not yet fixed; GraphQL primary covers these):
-#  - Server reads FORM params, not JSON, for: PATCH /manga/{id}/meta (key,value),
-#    PATCH /manga/{id}/chapter/{index} (read,bookmarked,lastPageRead),
-#    POST /category (name), PATCH /category/{id} (name,default,...),
-#    PATCH /category/reorder (from,to — single move, not an id array).
-#  - No REST route for: GET/DELETE /manga/{id}/meta (GraphQL only),
-#    PATCH /chapter/{id} progress, GET /chapter/{id} pages.
-#  - Path drift: chapter page image is
-#    /manga/{mangaId}/chapter/{chapterIndex}/page/{index} (not /chapter/{id}/...);
-#    source popular/latest take pageNum in the PATH: /source/{id}/popular/{page}.
-#  - DELETE /download/batch expects body { "chapterIds": [<int>...] } (flat ints)
-#    and the body must actually be sent on the DELETE.
+# GraphQL-only (no usable REST fallback; a failed GraphQL call is terminal):
+#  - Manga meta: no GET/DELETE meta REST route exists; fetch/delete meta are
+#    GraphQL only (PATCH set-meta over REST is form-encoded as above).
+#  - Chapter progress + chapter page listing: the REST routes are keyed by
+#    /manga/{mangaId}/chapter/{chapterIndex}, but only the global chapterId is
+#    available at those call sites, so these are GraphQL only.

--- a/include/view/extensions_tab.hpp
+++ b/include/view/extensions_tab.hpp
@@ -172,6 +172,8 @@ private:
     void uninstallExtension(const Extension& ext);
     void showSourceSettings(const Extension& ext);
     void showSourcePreferencesDialog(const Source& source);
+    void showSourcePreferencesMenu(const Source& source,
+                                   std::shared_ptr<std::vector<SourcePreference>> prefs);
 
     // Helpers
     void showError(const std::string& message);

--- a/include/view/media_detail_view.hpp
+++ b/include/view/media_detail_view.hpp
@@ -111,6 +111,7 @@ private:
     void hideCategoryPanel();
     bool isFocusInCategoryPanel(brls::View* view) const;
     void showMangaMenu();
+    void showChapterFilterMenu();
 
     // Chapter actions
     void markAllRead();

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -967,7 +967,7 @@ bool SuwayomiClient::fetchLibraryMangaGraphQL(std::vector<Manga>& manga) {
             mangas(
                 condition: { inLibrary: true }
                 first: 500
-                orderBy: TITLE
+                order: [{ by: TITLE }]
             ) {
                 nodes {
                     id
@@ -1066,8 +1066,7 @@ bool SuwayomiClient::fetchChaptersGraphQL(int mangaId, std::vector<Chapter>& cha
             chapters(
                 condition: { mangaId: $mangaId }
                 first: 1000
-                orderBy: SOURCE_ORDER
-                orderByType: DESC
+                order: [{ by: SOURCE_ORDER, byType: DESC }]
             ) {
                 nodes {
                     id
@@ -1152,7 +1151,7 @@ bool SuwayomiClient::fetchMangaGraphQL(int mangaId, Manga& manga) {
 bool SuwayomiClient::refreshMangaGraphQL(int mangaId) {
     const char* query = R"(
         mutation RefreshManga($id: Int!) {
-            fetchManga(input: { id: $id }) {
+            fetchMangaAndChapters(input: { id: $id, fetchManga: true, fetchChapters: false }) {
                 manga {
                     id
                     initialized
@@ -1170,7 +1169,7 @@ bool SuwayomiClient::refreshMangaGraphQL(int mangaId) {
 bool SuwayomiClient::refreshChaptersGraphQL(int mangaId) {
     const char* query = R"(
         mutation FetchChapters($mangaId: Int!) {
-            fetchChapters(input: { mangaId: $mangaId }) {
+            fetchMangaAndChapters(input: { id: $mangaId, fetchManga: false, fetchChapters: true }) {
                 chapters {
                     id
                 }
@@ -1186,7 +1185,7 @@ bool SuwayomiClient::refreshChaptersGraphQL(int mangaId) {
         return false;
     }
     // Check for successful response
-    bool success = response.find("\"fetchChapters\"") != std::string::npos;
+    bool success = response.find("\"fetchMangaAndChapters\"") != std::string::npos;
     brls::Logger::info("GraphQL: fetchChapters mutation for manga {} {}", mangaId, success ? "succeeded" : "failed");
     return success;
 }
@@ -1985,8 +1984,7 @@ bool SuwayomiClient::fetchMangaWithChaptersGraphQL(int mangaId, Manga& manga, st
             chapters(
                 condition: { mangaId: $mangaId }
                 first: 1000
-                orderBy: SOURCE_ORDER
-                orderByType: DESC
+                order: [{ by: SOURCE_ORDER, byType: DESC }]
             ) {
                 nodes {
                     id
@@ -4093,7 +4091,7 @@ bool SuwayomiClient::markChaptersRead(int mangaId, const std::vector<int>& chapt
         indexList += std::to_string(chapterIndexes[i]);
     }
 
-    std::string body = "{\"chapterIndexes\":[" + indexList + "],\"change\":{\"read\":true}}";
+    std::string body = "{\"chapterIndexes\":[" + indexList + "],\"change\":{\"isRead\":true}}";
 
     vitasuwayomi::HttpResponse response = http.post(url, body);
     return response.success && response.statusCode == 200;
@@ -4111,7 +4109,7 @@ bool SuwayomiClient::markChaptersUnread(int mangaId, const std::vector<int>& cha
         indexList += std::to_string(chapterIndexes[i]);
     }
 
-    std::string body = "{\"chapterIndexes\":[" + indexList + "],\"change\":{\"read\":false}}";
+    std::string body = "{\"chapterIndexes\":[" + indexList + "],\"change\":{\"isRead\":false}}";
 
     vitasuwayomi::HttpResponse response = http.post(url, body);
     return response.success && response.statusCode == 200;
@@ -4462,7 +4460,8 @@ bool SuwayomiClient::fetchCategoryManga(int categoryId, std::vector<Manga>& mang
     brls::Logger::info("GraphQL failed for category manga, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
 
-    std::string url = buildApiUrl("/category/" + std::to_string(categoryId) + "/manga");
+    // Server returns the category's manga at /category/{id} (no /manga suffix).
+    std::string url = buildApiUrl("/category/" + std::to_string(categoryId));
     brls::Logger::debug("Fetching category manga from: {}", url);
     vitasuwayomi::HttpResponse response = http.get(url);
 
@@ -4527,10 +4526,12 @@ bool SuwayomiClient::triggerLibraryUpdate(int categoryId) {
     // REST fallback
     brls::Logger::info("GraphQL failed for triggerCategoryUpdate, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
+    // Server reads categoryId as a form param, not JSON — JSON would be ignored
+    // and the server would update ALL categories instead of the target one.
+    http.setDefaultHeader("Content-Type", "application/x-www-form-urlencoded");
 
     std::string url = buildApiUrl("/update/fetch");
-    std::string body = "{\"categoryId\":" + std::to_string(categoryId) + "}";
+    std::string body = "categoryId=" + std::to_string(categoryId);
 
     vitasuwayomi::HttpResponse response = http.post(url, body);
     return response.success && response.statusCode == 200;
@@ -4576,11 +4577,12 @@ bool SuwayomiClient::triggerLibraryUpdate(const std::vector<int>& categoryIds) {
     brls::Logger::info("GraphQL failed for multi-category update, falling back to REST...");
     bool anySuccess = false;
     vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
+    // categoryId is a form param on the server, not JSON.
+    http.setDefaultHeader("Content-Type", "application/x-www-form-urlencoded");
     std::string url = buildApiUrl("/update/fetch");
 
     for (int catId : categoryIds) {
-        std::string body = "{\"categoryId\":" + std::to_string(catId) + "}";
+        std::string body = "categoryId=" + std::to_string(catId);
         vitasuwayomi::HttpResponse resp = http.post(url, body);
         if (resp.success && resp.statusCode == 200) {
             anySuccess = true;
@@ -5742,9 +5744,21 @@ bool SuwayomiClient::fetchUpdateSummary(int& pendingUpdates, int& runningJobs, b
         return false;
     }
 
-    pendingUpdates = extractJsonInt(response.body, "pendingJobs");
-    runningJobs = extractJsonInt(response.body, "runningJobs");
-    isUpdating = extractJsonBool(response.body, "isRunning");
+    // Server returns UpdateStatus as { categoryStatusMap, mangaStatusMap, running }.
+    // The old pendingJobs/runningJobs/isRunning fields no longer exist; derive the
+    // active-job counts from mangaStatusMap (keyed by JobStatus: PENDING/RUNNING/
+    // COMPLETE/FAILED) and read the boolean "running" flag.
+    isUpdating = extractJsonBool(response.body, "running");
+
+    pendingUpdates = 0;
+    runningJobs = 0;
+    std::string mangaStatusMap = extractJsonObject(response.body, "mangaStatusMap");
+    if (!mangaStatusMap.empty()) {
+        std::string pendingArr = extractJsonArray(mangaStatusMap, "PENDING");
+        std::string runningArr = extractJsonArray(mangaStatusMap, "RUNNING");
+        if (!pendingArr.empty()) pendingUpdates = static_cast<int>(splitJsonArray(pendingArr).size());
+        if (!runningArr.empty()) runningJobs = static_cast<int>(splitJsonArray(runningArr).size());
+    }
 
     return true;
 }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -3410,7 +3410,7 @@ bool SuwayomiClient::fetchSourceFiltersGraphQL(int64_t sourceId, std::vector<Sou
                     ... on TextFilter { __typename name default }
                     ... on CheckBoxFilter { __typename name default }
                     ... on TriStateFilter { __typename name default }
-                    ... on SelectFilter { __typename name default values displayValues }
+                    ... on SelectFilter { __typename name default values }
                     ... on SortFilter { __typename name default { index ascending } values }
                     ... on GroupFilter {
                         __typename name
@@ -3420,7 +3420,7 @@ bool SuwayomiClient::fetchSourceFiltersGraphQL(int64_t sourceId, std::vector<Sou
                             ... on TextFilter { __typename name default }
                             ... on CheckBoxFilter { __typename name default }
                             ... on TriStateFilter { __typename name default }
-                            ... on SelectFilter { __typename name default values displayValues }
+                            ... on SelectFilter { __typename name default values }
                             ... on SortFilter { __typename name default { index ascending } values }
                         }
                     }

--- a/src/app/suwayomi_client.cpp
+++ b/src/app/suwayomi_client.cpp
@@ -1625,38 +1625,10 @@ bool SuwayomiClient::fetchMangaMeta(int mangaId, std::map<std::string, std::stri
         return true;
     }
 
-    // REST fallback: GET /api/v1/manga/{id}/meta
-    brls::Logger::info("GraphQL failed for fetchMangaMeta, falling back to REST...");
-    HttpClient client = createHttpClient();
-    HttpResponse httpResp = client.get(buildApiUrl("manga/" + std::to_string(mangaId) + "/meta"));
-
-    if (!httpResp.success || httpResp.body.empty()) {
-        brls::Logger::warning("REST fallback also failed for manga meta");
-        return false;
-    }
-
-    // Parse REST response (array of {key, value} objects)
-    std::string response = httpResp.body;
-    meta.clear();
-    size_t pos = 0;
-    while ((pos = response.find("\"key\"", pos)) != std::string::npos) {
-        size_t keyStart = response.find("\"", pos + 5) + 1;
-        size_t keyEnd = response.find("\"", keyStart);
-        std::string key = response.substr(keyStart, keyEnd - keyStart);
-
-        size_t valueStart = response.find("\"value\"", keyEnd);
-        if (valueStart != std::string::npos) {
-            valueStart = response.find("\"", valueStart + 7) + 1;
-            size_t valueEnd = response.find("\"", valueStart);
-            std::string value = response.substr(valueStart, valueEnd - valueStart);
-            meta[key] = value;
-            pos = valueEnd + 1;
-        } else {
-            break;
-        }
-    }
-
-    return true;
+    // No REST fallback: the server exposes manga meta only over GraphQL (there
+    // is no GET /manga/{id}/meta route), so a failed GraphQL fetch is terminal.
+    brls::Logger::warning("fetchMangaMeta: GraphQL failed and no REST meta endpoint exists");
+    return false;
 }
 
 bool SuwayomiClient::setMangaMeta(int mangaId, const std::string& key, const std::string& value) {
@@ -1665,19 +1637,19 @@ bool SuwayomiClient::setMangaMeta(int mangaId, const std::string& key, const std
         return true;
     }
 
-    // REST fallback: PATCH /api/v1/manga/{id}/meta
+    // REST fallback: PATCH /api/v1/manga/{id}/meta — the server reads `key` and
+    // `value` as form params (not JSON).
     brls::Logger::info("GraphQL failed for setMangaMeta, falling back to REST...");
     HttpClient client = createHttpClient();
-    client.setDefaultHeader("Content-Type", "application/json");
 
-    std::string body = "{\"key\":\"" + key + "\",\"value\":\"" + value + "\"}";
+    std::string body = "key=" + vitasuwayomi::HttpClient::urlEncode(key) +
+                       "&value=" + vitasuwayomi::HttpClient::urlEncode(value);
 
-    // Use request() with PATCH method since HttpClient doesn't have patch()
     HttpRequest req;
-    req.url = buildApiUrl("manga/" + std::to_string(mangaId) + "/meta");
+    req.url = buildApiUrl("/manga/" + std::to_string(mangaId) + "/meta");
     req.method = "PATCH";
     req.body = body;
-    req.headers["Content-Type"] = "application/json";
+    req.headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     HttpResponse httpResp = client.request(req);
     return httpResp.success;
@@ -1689,12 +1661,10 @@ bool SuwayomiClient::deleteMangaMeta(int mangaId, const std::string& key) {
         return true;
     }
 
-    // REST fallback: DELETE /api/v1/manga/{id}/meta/{key}
-    brls::Logger::info("GraphQL failed for deleteMangaMeta, falling back to REST...");
-    HttpClient client = createHttpClient();
-    HttpResponse httpResp = client.del(buildApiUrl("manga/" + std::to_string(mangaId) + "/meta/" + key));
-
-    return httpResp.success;
+    // No REST fallback: there is no DELETE meta route; meta deletion is GraphQL
+    // only, so a failed GraphQL call is terminal.
+    brls::Logger::warning("deleteMangaMeta: GraphQL failed and no REST meta endpoint exists");
+    return false;
 }
 
 bool SuwayomiClient::fetchCategoryMangaGraphQL(int categoryId, std::vector<Manga>& manga) {
@@ -3760,8 +3730,8 @@ bool SuwayomiClient::fetchPopularManga(int64_t sourceId, int page,
     brls::Logger::info("GraphQL failed for popular manga, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
 
-    // Use query parameter format like Kodi addon: /source/{id}/popular?pageNum={page}
-    std::string url = buildApiUrl("/source/" + std::to_string(sourceId) + "/popular?pageNum=" + std::to_string(page));
+    // Server takes the page number as a path segment: /source/{id}/popular/{page}
+    std::string url = buildApiUrl("/source/" + std::to_string(sourceId) + "/popular/" + std::to_string(page));
     brls::Logger::debug("Fetching popular manga from: {}", url);
     vitasuwayomi::HttpResponse response = http.get(url);
 
@@ -3799,8 +3769,8 @@ bool SuwayomiClient::fetchLatestManga(int64_t sourceId, int page,
     brls::Logger::info("GraphQL failed for latest manga, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
 
-    // Use query parameter format like Kodi addon: /source/{id}/latest?pageNum={page}
-    std::string url = buildApiUrl("/source/" + std::to_string(sourceId) + "/latest?pageNum=" + std::to_string(page));
+    // Server takes the page number as a path segment: /source/{id}/latest/{page}
+    std::string url = buildApiUrl("/source/" + std::to_string(sourceId) + "/latest/" + std::to_string(page));
     brls::Logger::debug("Fetching latest manga from: {}", url);
     vitasuwayomi::HttpResponse response = http.get(url);
 
@@ -4037,19 +4007,19 @@ bool SuwayomiClient::fetchChapter(int mangaId, int chapterIndex, Chapter& chapte
 
 bool SuwayomiClient::updateChapter(int mangaId, int chapterIndex, bool read, bool bookmarked) {
     vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
 
     std::string url = buildApiUrl("/manga/" + std::to_string(mangaId) +
                                    "/chapter/" + std::to_string(chapterIndex));
 
-    std::string body = "{\"read\":" + std::string(read ? "true" : "false") +
-                       ",\"bookmarked\":" + std::string(bookmarked ? "true" : "false") + "}";
+    // Server reads read/bookmarked as form params (not JSON).
+    std::string body = std::string("read=") + (read ? "true" : "false") +
+                       "&bookmarked=" + (bookmarked ? "true" : "false");
 
     vitasuwayomi::HttpRequest req;
     req.url = url;
     req.method = "PATCH";
     req.body = body;
-    req.headers["Content-Type"] = "application/json";
+    req.headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     vitasuwayomi::HttpResponse response = http.request(req);
     return response.success && response.statusCode == 200;
@@ -4194,24 +4164,11 @@ bool SuwayomiClient::updateChapterProgress(int mangaId, int chapterId, int lastP
         return true;
     }
 
-    // REST fallback - uses /chapter/{id} endpoint with chapter ID
-    brls::Logger::info("GraphQL failed for chapter progress, trying REST...");
-    vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
-
-    // Use the chapter ID endpoint directly
-    std::string url = buildApiUrl("/chapter/" + std::to_string(chapterId));
-
-    std::string body = "{\"lastPageRead\":" + std::to_string(lastPageRead) + "}";
-
-    vitasuwayomi::HttpRequest req;
-    req.url = url;
-    req.method = "PATCH";
-    req.body = body;
-    req.headers["Content-Type"] = "application/json";
-
-    vitasuwayomi::HttpResponse response = http.request(req);
-    return response.success && response.statusCode == 200;
+    // No usable REST fallback: the server's progress route is keyed by
+    // /manga/{mangaId}/chapter/{chapterIndex}, but only the global chapterId is
+    // available here, so chapter progress is GraphQL-only.
+    brls::Logger::warning("updateChapterProgress: GraphQL failed; no REST route keyed by chapterId");
+    return false;
 }
 
 // ============================================================================
@@ -4230,30 +4187,11 @@ bool SuwayomiClient::fetchChapterPages(int mangaId, int chapterId, std::vector<P
         return true;
     }
 
-    // REST fallback - use chapter ID in URL
-    brls::Logger::info("GraphQL failed for chapter pages, trying REST...");
-    vitasuwayomi::HttpClient http = createHttpClient();
-
-    std::string url = buildApiUrl("/chapter/" + std::to_string(chapterId));
-    vitasuwayomi::HttpResponse response = http.get(url);
-
-    if (!response.success || response.statusCode != 200) {
-        brls::Logger::error("Failed to fetch chapter pages: {}", response.error);
-        return false;
-    }
-
-    pages.clear();
-    int pageCount = extractJsonInt(response.body, "pageCount");
-
-    for (int i = 0; i < pageCount; i++) {
-        Page page;
-        page.index = i;
-        page.imageUrl = getPageImageUrl(chapterId, i);
-        pages.push_back(page);
-    }
-
-    brls::Logger::debug("Chapter {} has {} pages", chapterId, pageCount);
-    return true;
+    // No usable REST fallback: the server's chapter/page routes are keyed by
+    // /manga/{mangaId}/chapter/{chapterIndex}, but only the global chapterId is
+    // available here, so page listing is GraphQL-only.
+    brls::Logger::warning("fetchChapterPages: GraphQL failed; no REST route keyed by chapterId");
+    return false;
 }
 
 std::string SuwayomiClient::getPageImageUrl(int chapterId, int pageIndex) {
@@ -4299,13 +4237,13 @@ bool SuwayomiClient::createCategory(const std::string& name) {
         return true;
     }
 
-    // REST fallback
+    // REST fallback — server reads `name` as a form param (not JSON).
     brls::Logger::info("GraphQL failed for createCategory, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
+    http.setDefaultHeader("Content-Type", "application/x-www-form-urlencoded");
 
     std::string url = buildApiUrl("/category");
-    std::string body = "{\"name\":\"" + name + "\"}";
+    std::string body = "name=" + vitasuwayomi::HttpClient::urlEncode(name);
 
     vitasuwayomi::HttpResponse response = http.post(url, body);
     return response.success && response.statusCode == 200;
@@ -4333,47 +4271,35 @@ bool SuwayomiClient::updateCategory(int categoryId, const std::string& name, boo
         return true;
     }
 
-    // REST fallback
+    // REST fallback — server reads name/default as form params (not JSON).
     brls::Logger::info("GraphQL failed for updateCategory, falling back to REST...");
     vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
 
     std::string url = buildApiUrl("/category/" + std::to_string(categoryId));
-    std::string body = "{\"name\":\"" + name + "\",\"default\":" +
-                       std::string(isDefault ? "true" : "false") + "}";
+    std::string body = "name=" + vitasuwayomi::HttpClient::urlEncode(name) +
+                       "&default=" + std::string(isDefault ? "true" : "false");
 
     vitasuwayomi::HttpRequest req;
     req.url = url;
     req.method = "PATCH";
     req.body = body;
-    req.headers["Content-Type"] = "application/json";
+    req.headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     vitasuwayomi::HttpResponse response = http.request(req);
     return response.success && response.statusCode == 200;
 }
 
 bool SuwayomiClient::reorderCategories(const std::vector<int>& categoryIds) {
-    vitasuwayomi::HttpClient http = createHttpClient();
-    http.setDefaultHeader("Content-Type", "application/json");
-
-    std::string url = buildApiUrl("/category/reorder");
-
-    std::string idList;
+    // GraphQL primary: set each category's position to its index in the desired
+    // order. The REST /category/reorder route only accepts a single {from,to}
+    // move (form params), so a whole-array reorder can't be sent in one call.
+    bool allOk = true;
     for (size_t i = 0; i < categoryIds.size(); i++) {
-        if (i > 0) idList += ",";
-        idList += std::to_string(categoryIds[i]);
+        if (!updateCategoryOrderGraphQL(categoryIds[i], static_cast<int>(i))) {
+            allOk = false;
+        }
     }
-
-    std::string body = "{\"categoryIds\":[" + idList + "]}";
-
-    vitasuwayomi::HttpRequest req;
-    req.url = url;
-    req.method = "PATCH";
-    req.body = body;
-    req.headers["Content-Type"] = "application/json";
-
-    vitasuwayomi::HttpResponse response = http.request(req);
-    return response.success && response.statusCode == 200;
+    return allOk;
 }
 
 bool SuwayomiClient::moveCategoryOrder(int categoryId, int newPosition) {
@@ -4804,23 +4730,28 @@ bool SuwayomiClient::deleteChapterDownloads(const std::vector<int>& chapterIds, 
     // REST fallback
     brls::Logger::info("SuwayomiClient: GraphQL batch dequeue failed, falling back to REST...");
 
-    // If we have mangaId and chapterIndexes for REST fallback
-    if (mangaId > 0 && !chapterIndexes.empty()) {
+    // REST fallback: DELETE /download/batch. The server decodes a flat
+    // { "chapterIds": [<int>, ...] } body (global chapter IDs), and the body
+    // must actually be sent on the DELETE.
+    (void)mangaId;
+    (void)chapterIndexes;
+    if (!chapterIds.empty()) {
         vitasuwayomi::HttpClient http = createHttpClient();
-        http.setDefaultHeader("Content-Type", "application/json");
 
-        std::string url = buildApiUrl("/download/batch");
-
-        std::string chapterList;
-        for (size_t i = 0; i < chapterIndexes.size(); i++) {
-            if (i > 0) chapterList += ",";
-            chapterList += "{\"mangaId\":" + std::to_string(mangaId) +
-                           ",\"chapterIndex\":" + std::to_string(chapterIndexes[i]) + "}";
+        std::string idList;
+        for (size_t i = 0; i < chapterIds.size(); i++) {
+            if (i > 0) idList += ",";
+            idList += std::to_string(chapterIds[i]);
         }
+        std::string body = "{\"chapterIds\":[" + idList + "]}";
 
-        std::string body = "{\"chapterIds\":[" + chapterList + "]}";
-        vitasuwayomi::HttpResponse response = http.del(url);
+        vitasuwayomi::HttpRequest req;
+        req.url = buildApiUrl("/download/batch");
+        req.method = "DELETE";
+        req.body = body;
+        req.headers["Content-Type"] = "application/json";
 
+        vitasuwayomi::HttpResponse response = http.request(req);
         return response.success && response.statusCode == 200;
     }
 

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "view/extensions_tab.hpp"
+#include "view/options_popover.hpp"
 #include "app/suwayomi_client.hpp"
 #include "app/application.hpp"
 #include "utils/image_loader.hpp"
@@ -1422,178 +1423,129 @@ void ExtensionsTab::showSourcePreferencesDialog(const Source& source) {
             return;
         }
 
-        brls::sync([this, source, prefs, aliveWeak]() {
+        auto prefsPtr = std::make_shared<std::vector<SourcePreference>>(prefs);
+        brls::sync([this, source, prefsPtr, aliveWeak]() {
             auto alive = aliveWeak.lock();
             if (!alive || !*alive) return;
-            auto* dialog = new brls::Dialog(source.name + " Settings");
-            dialog->setCancelable(false);  // Prevent exit dialog from appearing
-
-            auto* scrollFrame = new brls::ScrollingFrame();
-            scrollFrame->setHeight(400);
-
-            auto* list = new brls::Box();
-            list->setAxis(brls::Axis::COLUMN);
-            list->setPadding(10, 15, 10, 15);
-
-            for (int prefIdx = 0; prefIdx < static_cast<int>(prefs.size()); prefIdx++) {
-                const auto& pref = prefs[prefIdx];
-                if (!pref.visible) continue;
-
-                auto* prefBox = new brls::Box();
-                prefBox->setAxis(brls::Axis::COLUMN);
-                prefBox->setMarginBottom(15);
-
-                auto* titleLabel = new brls::Label();
-                titleLabel->setText(pref.title.empty() ? pref.key : pref.title);
-                titleLabel->setFontSize(14);
-                prefBox->addView(titleLabel);
-
-                if (!pref.summary.empty()) {
-                    auto* summaryLabel = new brls::Label();
-                    summaryLabel->setText(pref.summary);
-                    summaryLabel->setFontSize(11);
-                    summaryLabel->setTextColor(Application::getInstance().getSubtitleColor());
-                    prefBox->addView(summaryLabel);
-                }
-
-                // Value display (interactive)
-                auto* valueBox = new brls::Box();
-                valueBox->setAxis(brls::Axis::ROW);
-                valueBox->setFocusable(true);
-                valueBox->setPadding(8, 10, 8, 10);
-                valueBox->setMarginTop(5);
-                valueBox->setCornerRadius(4);
-                valueBox->setBackgroundColor(Application::getInstance().getCardBackground());
-
-                auto* valueLabel = new brls::Label();
-                valueLabel->setFontSize(13);
-
-                if (pref.type == SourcePreferenceType::CHECKBOX || pref.type == SourcePreferenceType::SWITCH_TOGGLE) {
-                    valueLabel->setText(pref.currentValue ? "Enabled" : "Disabled");
-
-                    // Toggle on click
-                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
-                        bool newValue = !pref.currentValue;
-                        SourcePreferenceChange change;
-                        change.position = prefIdx;
-                        if (pref.type == SourcePreferenceType::SWITCH_TOGGLE) {
-                            change.switchState = newValue;
-                        } else {
-                            change.checkBoxState = newValue;
-                        }
-
-                        brls::async([this, source, change, newValue, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
-                            SuwayomiClient& client = SuwayomiClient::getInstance();
-                            bool success = client.updateSourcePreference(source.id, change);
-                            brls::sync([success, newValue, valueLabel, aliveWeak]() {
-                                auto alive = aliveWeak.lock();
-                                if (!alive || !*alive) return;
-                                if (success) {
-                                    valueLabel->setText(newValue ? "Enabled" : "Disabled");
-                                } else {
-                                    brls::Application::notify("Failed to update setting");
-                                }
-                            });
-                        });
-                        return true;
-                    });
-                } else if (pref.type == SourcePreferenceType::LIST) {
-                    // Show selected entry display name if available
-                    std::string displayValue = pref.selectedValue;
-                    for (size_t i = 0; i < pref.entryValues.size(); i++) {
-                        if (pref.entryValues[i] == pref.selectedValue && i < pref.entries.size()) {
-                            displayValue = pref.entries[i];
-                            break;
-                        }
-                    }
-                    valueLabel->setText(displayValue);
-
-                    // Show dropdown on click
-                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
-                        if (pref.entries.empty()) return true;
-
-                        // Find current selection index
-                        int currentIdx = 0;
-                        for (size_t i = 0; i < pref.entryValues.size(); i++) {
-                            if (pref.entryValues[i] == pref.selectedValue) {
-                                currentIdx = static_cast<int>(i);
-                                break;
-                            }
-                        }
-
-                        brls::Dropdown* dropdown = new brls::Dropdown(
-                            pref.title.empty() ? pref.key : pref.title, pref.entries,
-                            [this, source, prefIdx, pref, valueLabel](int selected) {
-                                if (selected < 0 || selected >= static_cast<int>(pref.entryValues.size())) return;
-
-                                std::string selectedVal = pref.entryValues[selected];
-                                std::string displayName = pref.entries[selected];
-
-                                SourcePreferenceChange change;
-                                change.position = prefIdx;
-                                change.listState = selectedVal;
-
-                                brls::async([this, source, change, displayName, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
-                                    SuwayomiClient& client = SuwayomiClient::getInstance();
-                                    bool success = client.updateSourcePreference(source.id, change);
-                                    brls::sync([success, displayName, valueLabel, aliveWeak]() {
-                                        auto alive = aliveWeak.lock();
-                                        if (!alive || !*alive) return;
-                                        if (success) {
-                                            valueLabel->setText(displayName);
-                                        } else {
-                                            brls::Application::notify("Failed to update setting");
-                                        }
-                                    });
-                                });
-                            }, currentIdx);
-                        brls::Application::pushActivity(new brls::Activity(dropdown));
-                        return true;
-                    });
-                } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {
-                    valueLabel->setText(pref.currentText.empty() ? "(empty)" : pref.currentText);
-
-                    // Open IME on click
-                    valueBox->registerClickAction([this, source, prefIdx, pref, valueLabel](brls::View*) {
-                        brls::Application::getImeManager()->openForText([this, source, prefIdx, pref, valueLabel](std::string text) {
-                            SourcePreferenceChange change;
-                            change.position = prefIdx;
-                            change.editTextState = text;
-
-                            brls::async([this, source, change, text, valueLabel, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
-                                SuwayomiClient& client = SuwayomiClient::getInstance();
-                                bool success = client.updateSourcePreference(source.id, change);
-                                brls::sync([success, text, valueLabel, aliveWeak]() {
-                                    auto alive = aliveWeak.lock();
-                                    if (!alive || !*alive) return;
-                                    if (success) {
-                                        valueLabel->setText(text.empty() ? "(empty)" : text);
-                                    } else {
-                                        brls::Application::notify("Failed to update setting");
-                                    }
-                                });
-                            });
-                        }, pref.dialogTitle.empty() ? pref.title : pref.dialogTitle,
-                           pref.dialogMessage, 256, pref.currentText);
-                        return true;
-                    });
-                } else {
-                    valueLabel->setText(pref.key);
-                }
-
-                valueBox->addView(valueLabel);
-                valueBox->addGestureRecognizer(new brls::TapGestureRecognizer(valueBox));
-
-                prefBox->addView(valueBox);
-                list->addView(prefBox);
-            }
-
-            scrollFrame->setContentView(list);
-            dialog->addView(scrollFrame);
-            dialog->addButton("Close", []() {});
-            dialog->open();
+            showSourcePreferencesMenu(source, prefsPtr);
         });
     });
+}
+
+void ExtensionsTab::showSourcePreferencesMenu(const Source& source,
+                                              std::shared_ptr<std::vector<SourcePreference>> prefs) {
+    std::weak_ptr<bool> aliveWeak = m_alive;
+    Source src = source;
+    // Reopening the menu is both the "back" target for sub-menus and the way
+    // list/edit changes refresh the displayed value.
+    auto reopen = [this, src, prefs]() { showSourcePreferencesMenu(src, prefs); };
+
+    auto applyChange = [this, src, aliveWeak](SourcePreferenceChange change) {
+        brls::async([this, src, change, aliveWeak]() {
+            SuwayomiClient& client = SuwayomiClient::getInstance();
+            bool ok = client.updateSourcePreference(src.id, change);
+            if (!ok) {
+                brls::sync([aliveWeak]() {
+                    auto a = aliveWeak.lock();
+                    if (!a || !*a) return;
+                    brls::Application::notify("Failed to update setting");
+                });
+            }
+        });
+    };
+
+    std::vector<OptionRow> rows;
+    for (int prefIdx = 0; prefIdx < static_cast<int>(prefs->size()); prefIdx++) {
+        const SourcePreference& pref = (*prefs)[prefIdx];
+        if (!pref.visible) continue;
+        const std::string label = pref.title.empty() ? pref.key : pref.title;
+
+        if (pref.type == SourcePreferenceType::SWITCH_TOGGLE ||
+            pref.type == SourcePreferenceType::CHECKBOX) {
+            const bool isSwitch = pref.type == SourcePreferenceType::SWITCH_TOGGLE;
+            auto cur = std::make_shared<bool>(pref.currentValue);
+            OptionRow row;
+            row.label     = label;
+            row.checkable = true;
+            row.checked   = pref.currentValue;
+            row.action    = [applyChange, prefs, prefIdx, isSwitch, cur]() {
+                *cur = !*cur;
+                (*prefs)[prefIdx].currentValue = *cur;   // keep local state in sync
+                SourcePreferenceChange change;
+                change.position = prefIdx;
+                if (isSwitch) { change.switchState = *cur;   change.hasSwitchState = true; }
+                else          { change.checkBoxState = *cur; change.hasCheckBoxState = true; }
+                applyChange(change);
+            };
+            rows.push_back(std::move(row));
+
+        } else if (pref.type == SourcePreferenceType::LIST) {
+            std::string disp = pref.selectedValue;
+            for (size_t i = 0; i < pref.entryValues.size(); i++) {
+                if (pref.entryValues[i] == pref.selectedValue && i < pref.entries.size()) {
+                    disp = pref.entries[i];
+                    break;
+                }
+            }
+            OptionRow row;
+            row.label = label;
+            row.sub   = disp;
+            SourcePreference p = pref;
+            row.action = [applyChange, reopen, prefs, prefIdx, p]() {
+                std::vector<OptionRow> sub;
+                for (size_t i = 0; i < p.entries.size(); i++) {
+                    const bool cur = (i < p.entryValues.size() && p.entryValues[i] == p.selectedValue);
+                    std::string val = (i < p.entryValues.size()) ? p.entryValues[i] : std::string();
+                    sub.push_back({ cur ? "radio_checked.png" : "radio.png", p.entries[i], "", cur, false,
+                        [applyChange, reopen, prefs, prefIdx, val]() {
+                            (*prefs)[prefIdx].selectedValue = val;
+                            SourcePreferenceChange change;
+                            change.position = prefIdx;
+                            change.listState = val;
+                            change.hasListState = true;
+                            applyChange(change);
+                            reopen();
+                        }});
+                }
+                sub.push_back({ "back.png", "Cancel", "", false, true, [reopen]() { reopen(); }});
+                OptionsPopover::show("SETTING", p.title.empty() ? p.key : p.title,
+                                     std::move(sub), reopen, 6);
+            };
+            rows.push_back(std::move(row));
+
+        } else if (pref.type == SourcePreferenceType::EDIT_TEXT) {
+            OptionRow row;
+            row.label = label;
+            row.sub   = pref.currentText.empty() ? "(empty)" : pref.currentText;
+            SourcePreference p = pref;
+            row.action = [applyChange, reopen, prefs, prefIdx, p]() {
+                brls::Application::getImeManager()->openForText(
+                    [applyChange, reopen, prefs, prefIdx](std::string text) {
+                        (*prefs)[prefIdx].currentText = text;
+                        SourcePreferenceChange change;
+                        change.position = prefIdx;
+                        change.editTextState = text;
+                        change.hasEditTextState = true;
+                        applyChange(change);
+                        reopen();
+                    },
+                    p.dialogTitle.empty() ? p.title : p.dialogTitle,
+                    p.dialogMessage, 256, p.currentText);
+            };
+            rows.push_back(std::move(row));
+
+        } else {
+            // MULTI_SELECT_LIST / unknown: show value read-only for now.
+            OptionRow row;
+            row.label  = label;
+            row.action = []() {};
+            rows.push_back(std::move(row));
+        }
+    }
+
+    rows.push_back({ "back.png", "Close", "", false, true, []() {}});
+
+    OptionsPopover::show("SOURCE", source.name, std::move(rows), nullptr, 6);
 }
 
 // ============================================================================

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1354,43 +1354,15 @@ void ExtensionsTab::showSourceSettings(const Extension& ext) {
             if (sources.size() == 1) {
                 showSourcePreferencesDialog(sources[0]);
             } else {
-                // Show source selection dialog
-                auto* dialog = new brls::Dialog("Select Source");
-                dialog->setCancelable(false);  // Prevent exit dialog from appearing
-
-                auto* list = new brls::Box();
-                list->setAxis(brls::Axis::COLUMN);
-                list->setPadding(10, 15, 10, 15);
-
+                // Source picker as the new popover; picking one opens its settings.
+                std::vector<OptionRow> rows;
                 for (const auto& source : sources) {
-                    auto* item = new brls::Box();
-                    item->setAxis(brls::Axis::ROW);
-                    item->setFocusable(true);
-                    item->setPadding(10, 10, 10, 10);
-                    item->setMarginBottom(5);
-                    item->setCornerRadius(4);
-                    item->setBackgroundColor(Application::getInstance().getCardBackground());
-
-                    auto* label = new brls::Label();
-                    label->setText(source.name);
-                    label->setFontSize(14);
-                    item->addView(label);
-
-                    item->registerClickAction([this, dialog, source](brls::View*) {
-                        dialog->dismiss();
-                        brls::sync([this, source]() {
-                            showSourcePreferencesDialog(source);
-                        });
-                        return true;
-                    });
-                    item->addGestureRecognizer(new brls::TapGestureRecognizer(item));
-
-                    list->addView(item);
+                    Source src = source;
+                    rows.push_back({ "web.png", source.name, "", false, false,
+                        [this, src]() { showSourcePreferencesDialog(src); }});
                 }
-
-                dialog->addView(list);
-                dialog->addButton("Cancel", []() {});
-                dialog->open();
+                rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
+                OptionsPopover::show("EXTENSION", ext.name, std::move(rows), nullptr, 6);
             }
         });
     });

--- a/src/view/extensions_tab.cpp
+++ b/src/view/extensions_tab.cpp
@@ -1362,7 +1362,7 @@ void ExtensionsTab::showSourceSettings(const Extension& ext) {
                         [this, src]() { showSourcePreferencesDialog(src); }});
                 }
                 rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
-                OptionsPopover::show("EXTENSION", ext.name, std::move(rows), nullptr, 6);
+                OptionsPopover::show("EXTENSION", ext.name, std::move(rows), nullptr, 5);
             }
         });
     });

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -5,6 +5,7 @@
 
 #include "view/media_detail_view.hpp"
 #include "view/tracking_search_view.hpp"
+#include "view/options_popover.hpp"
 #include "app/suwayomi_client.hpp"
 #include "app/application.hpp"
 #include "app/downloads_manager.hpp"
@@ -626,36 +627,44 @@ MangaDetailView::MangaDetailView(const Manga& manga)
 
     // Register Y button for chapter filter
     this->registerAction("Filter", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
-        // Show filter options dialog
-        std::vector<std::string> options = {"Toggle Downloaded", "Toggle Unread", "Toggle Bookmarked", "Clear Filters"};
-        brls::Dropdown* dropdown = new brls::Dropdown(
-            "Chapter Filters", options,
-            [this](int selected) {
-                if (selected < 0) return;
-                switch (selected) {
-                    case 0:
-                        m_filterDownloaded = !m_filterDownloaded;
-                        brls::Application::notify(m_filterDownloaded ? "Filtering: Downloaded" : "Filter removed");
-                        break;
-                    case 1:
-                        m_filterUnread = !m_filterUnread;
-                        brls::Application::notify(m_filterUnread ? "Filtering: Unread" : "Filter removed");
-                        break;
-                    case 2:
-                        m_filterBookmarked = !m_filterBookmarked;
-                        brls::Application::notify(m_filterBookmarked ? "Filtering: Bookmarked" : "Filter removed");
-                        break;
-                    case 3:
-                        m_filterDownloaded = false;
-                        m_filterUnread = false;
-                        m_filterBookmarked = false;
-                        m_filterScanlator.clear();
-                        brls::Application::notify("Filters cleared");
-                        break;
-                }
+        // Chapter filters as checkable rows that toggle in place and refresh the
+        // list live, plus Clear Filters and Cancel.
+        std::vector<OptionRow> rows;
+
+        OptionRow rDown;
+        rDown.label     = "Downloaded";
+        rDown.checkable = true;
+        rDown.checked   = m_filterDownloaded;
+        rDown.action    = [this]() { m_filterDownloaded = !m_filterDownloaded; populateChaptersList(); };
+        rows.push_back(std::move(rDown));
+
+        OptionRow rUnread;
+        rUnread.label     = "Unread";
+        rUnread.checkable = true;
+        rUnread.checked   = m_filterUnread;
+        rUnread.action    = [this]() { m_filterUnread = !m_filterUnread; populateChaptersList(); };
+        rows.push_back(std::move(rUnread));
+
+        OptionRow rBook;
+        rBook.label     = "Bookmarked";
+        rBook.checkable = true;
+        rBook.checked   = m_filterBookmarked;
+        rBook.action    = [this]() { m_filterBookmarked = !m_filterBookmarked; populateChaptersList(); };
+        rows.push_back(std::move(rBook));
+
+        rows.push_back({ "cross.png", "Clear Filters", "", false, true,
+            [this]() {
+                m_filterDownloaded = false;
+                m_filterUnread = false;
+                m_filterBookmarked = false;
+                m_filterScanlator.clear();
+                brls::Application::notify("Filters cleared");
                 populateChaptersList();
-            }, 0);
-        brls::Application::pushActivity(new brls::Activity(dropdown));
+            }});
+
+        rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
+
+        OptionsPopover::show("CHAPTERS", "Filter", std::move(rows));
         return true;
     });
 
@@ -1908,7 +1917,6 @@ void MangaDetailView::showMangaMenu() {
     // Build options list with action IDs so hidden items don't shift indices
     struct MenuAction { std::string label; int actionId; };
     std::vector<MenuAction> actions;
-    std::vector<std::string> options;
 
     // Hide download options if all chapters are downloaded or all unread are downloading
     if (online && !allDownloaded && !allUnreadDownloading) {
@@ -1923,14 +1931,8 @@ void MangaDetailView::showMangaMenu() {
         actions.push_back({"Reset cover", 4});
     }
 
-    for (const auto& a : actions) options.push_back(a.label);
-
-    brls::Dropdown* dropdown = new brls::Dropdown(
-        "Options", options,
-        [this, mangaId, chapters, actions](int selected) {
-            if (selected < 0 || selected >= static_cast<int>(actions.size())) return;
-            int actionId = actions[selected].actionId;
-
+    // Dispatch for a chosen action id; each popover row runs it.
+    auto runAction = [this, mangaId, chapters](int actionId) {
             switch (actionId) {
                 case 0:  // Download all
                     brls::sync([this, aliveWeak = std::weak_ptr<bool>(m_alive)]() {
@@ -2048,8 +2050,20 @@ void MangaDetailView::showMangaMenu() {
                     });
                     break;
             }
-        }, 0);
-    brls::Application::pushActivity(new brls::Activity(dropdown));
+    };
+
+    std::vector<OptionRow> rows;
+    for (const auto& a : actions) {
+        int actionId = a.actionId;
+        std::string icon = (actionId == 0 || actionId == 1) ? "download.png"
+                         : (actionId == 2)                  ? "cross.png"
+                         : (actionId == 4)                  ? "refresh.png" : "";
+        rows.push_back({ icon, a.label, "", false, false,
+            [runAction, actionId]() { runAction(actionId); }});
+    }
+    rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
+
+    OptionsPopover::show("MANGA", mangaTitle, std::move(rows));
 }
 
 void MangaDetailView::onChapterSelected(const Chapter& chapter) {

--- a/src/view/media_detail_view.cpp
+++ b/src/view/media_detail_view.cpp
@@ -627,44 +627,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
 
     // Register Y button for chapter filter
     this->registerAction("Filter", brls::ControllerButton::BUTTON_Y, [this](brls::View* view) {
-        // Chapter filters as checkable rows that toggle in place and refresh the
-        // list live, plus Clear Filters and Cancel.
-        std::vector<OptionRow> rows;
-
-        OptionRow rDown;
-        rDown.label     = "Downloaded";
-        rDown.checkable = true;
-        rDown.checked   = m_filterDownloaded;
-        rDown.action    = [this]() { m_filterDownloaded = !m_filterDownloaded; populateChaptersList(); };
-        rows.push_back(std::move(rDown));
-
-        OptionRow rUnread;
-        rUnread.label     = "Unread";
-        rUnread.checkable = true;
-        rUnread.checked   = m_filterUnread;
-        rUnread.action    = [this]() { m_filterUnread = !m_filterUnread; populateChaptersList(); };
-        rows.push_back(std::move(rUnread));
-
-        OptionRow rBook;
-        rBook.label     = "Bookmarked";
-        rBook.checkable = true;
-        rBook.checked   = m_filterBookmarked;
-        rBook.action    = [this]() { m_filterBookmarked = !m_filterBookmarked; populateChaptersList(); };
-        rows.push_back(std::move(rBook));
-
-        rows.push_back({ "cross.png", "Clear Filters", "", false, true,
-            [this]() {
-                m_filterDownloaded = false;
-                m_filterUnread = false;
-                m_filterBookmarked = false;
-                m_filterScanlator.clear();
-                brls::Application::notify("Filters cleared");
-                populateChaptersList();
-            }});
-
-        rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
-
-        OptionsPopover::show("CHAPTERS", "Filter", std::move(rows));
+        showChapterFilterMenu();
         return true;
     });
 
@@ -964,36 +927,7 @@ MangaDetailView::MangaDetailView(const Manga& manga)
     m_filterBtn->addView(filterIcon);
 
     m_filterBtn->registerClickAction([this](brls::View* view) {
-        // Show filter options dialog
-        std::vector<std::string> options = {"Toggle Downloaded", "Toggle Unread", "Toggle Bookmarked", "Clear Filters"};
-        brls::Dropdown* dropdown = new brls::Dropdown(
-            "Chapter Filters", options,
-            [this](int selected) {
-                if (selected < 0) return;
-                switch (selected) {
-                    case 0:
-                        m_filterDownloaded = !m_filterDownloaded;
-                        brls::Application::notify(m_filterDownloaded ? "Filtering: Downloaded" : "Filter removed");
-                        break;
-                    case 1:
-                        m_filterUnread = !m_filterUnread;
-                        brls::Application::notify(m_filterUnread ? "Filtering: Unread" : "Filter removed");
-                        break;
-                    case 2:
-                        m_filterBookmarked = !m_filterBookmarked;
-                        brls::Application::notify(m_filterBookmarked ? "Filtering: Bookmarked" : "Filter removed");
-                        break;
-                    case 3:
-                        m_filterDownloaded = false;
-                        m_filterUnread = false;
-                        m_filterBookmarked = false;
-                        m_filterScanlator.clear();
-                        brls::Application::notify("Filters cleared");
-                        break;
-                }
-                populateChaptersList();
-            }, 0);
-        brls::Application::pushActivity(new brls::Activity(dropdown));
+        showChapterFilterMenu();
         return true;
     });
     m_filterBtn->addGestureRecognizer(new brls::TapGestureRecognizer(m_filterBtn));
@@ -1869,6 +1803,48 @@ void MangaDetailView::setupChapterNavigation() {
     if (m_filterBtn) m_filterBtn->getFocusEvent()->subscribe(hideChapterIcon);
     if (m_menuBtn) m_menuBtn->getFocusEvent()->subscribe(hideChapterIcon);
     if (m_selectBtn) m_selectBtn->getFocusEvent()->subscribe(hideChapterIcon);
+}
+
+void MangaDetailView::showChapterFilterMenu() {
+    // Chapter filters as checkable rows that toggle in place and refresh the
+    // list live, plus Clear Filters and Cancel. Shared by the Y button and the
+    // on-screen filter button.
+    std::vector<OptionRow> rows;
+
+    OptionRow rDown;
+    rDown.label     = "Downloaded";
+    rDown.checkable = true;
+    rDown.checked   = m_filterDownloaded;
+    rDown.action    = [this]() { m_filterDownloaded = !m_filterDownloaded; populateChaptersList(); };
+    rows.push_back(std::move(rDown));
+
+    OptionRow rUnread;
+    rUnread.label     = "Unread";
+    rUnread.checkable = true;
+    rUnread.checked   = m_filterUnread;
+    rUnread.action    = [this]() { m_filterUnread = !m_filterUnread; populateChaptersList(); };
+    rows.push_back(std::move(rUnread));
+
+    OptionRow rBook;
+    rBook.label     = "Bookmarked";
+    rBook.checkable = true;
+    rBook.checked   = m_filterBookmarked;
+    rBook.action    = [this]() { m_filterBookmarked = !m_filterBookmarked; populateChaptersList(); };
+    rows.push_back(std::move(rBook));
+
+    rows.push_back({ "cross.png", "Clear Filters", "", false, true,
+        [this]() {
+            m_filterDownloaded = false;
+            m_filterUnread = false;
+            m_filterBookmarked = false;
+            m_filterScanlator.clear();
+            brls::Application::notify("Filters cleared");
+            populateChaptersList();
+        }});
+
+    rows.push_back({ "back.png", "Cancel", "", false, true, []() {}});
+
+    OptionsPopover::show("CHAPTERS", "Filter", std::move(rows));
 }
 
 void MangaDetailView::showMangaMenu() {


### PR DESCRIPTION
Uses the Options popover for the detail-view Filter and Options menus and the extension Select Source picker (capped to 5 rows), and does a GraphQL/REST API audit — dropping the nonexistent `SelectFilter.displayValues`, migrating deprecated operations, and fixing REST fallback endpoints against the current server.

---
_Generated by [Claude Code](https://claude.ai/code)_