### PR TITLE
Reset settings detail scroll to top on section switch

### DIFF
--- a/src/view/settings_tab.cpp
+++ b/src/view/settings_tab.cpp
@@ -314,6 +314,11 @@ void SettingsTab::showSection(int sectionId) {
         m_detailContent->setLastFocusedView(target);
         m_detailScroll->setLastFocusedView(m_detailContent);
         m_detailContainer->setLastFocusedView(m_detailScroll);
+
+        // Reset the shared detail scroll to the top; otherwise a new (often
+        // shorter) section inherits the previous section's scroll offset and
+        // renders clipped past its top until the user scrolls back up.
+        m_detailScroll->setContentOffsetY(0.0f, false);
     }
 
     if (sectionId < static_cast<int>(m_sectionNames.size()))


### PR DESCRIPTION
Reset settings detail scroll to top on section switch

All settings sections share one detail ScrollingFrame. After scrolling down
inside a tall section (Library, Sync), switching to another section kept the
stale scroll offset, so the new (often shorter) section rendered clipped past
its top — only its bottom row visible until the user scrolled back up. Reset
the detail scroll offset to 0 whenever the active section changes.

---
_Generated by [Claude Code](https://claude.ai/code)_