### PR TITLE
Library & storage: add Select action, fix cache size, tidy storage columns

### DIFF
--- a/src/utils/library_cache.cpp
+++ b/src/utils/library_cache.cpp
@@ -453,6 +453,16 @@ void LibraryCache::clearAllCache() {
     clearLibraryCache();
     clearCoverCache();
     clearPageCache();
+
+    // Also clear the manga-details cache and the categories index so the whole
+    // cache is emptied (matches the size reported by getCacheSize()).
+    std::lock_guard<std::mutex> lock(m_mutex);
+    std::string detailsDir = getMangaDetailsCacheDir();
+    for (const auto& name : platform::listDir(detailsDir)) {
+        if (name.empty() || name[0] == '.') continue;
+        platform::deleteFile(detailsDir + "/" + name);
+    }
+    platform::deleteFile(getCategoriesFilePath());
 }
 
 void LibraryCache::clearLibraryCache() {
@@ -481,16 +491,22 @@ void LibraryCache::clearCoverCache() {
     brls::Logger::info("LibraryCache: Cover cache cleared");
 }
 
-size_t LibraryCache::getCacheSize() {
+static size_t sumDirRecursive(const std::string& dir) {
     size_t total = 0;
-    std::string coverDir = getCoverCacheDir();
-
-    for (const auto& name : platform::listDir(coverDir)) {
-        int64_t sz = platform::fileSize(coverDir + "/" + name);
-        if (sz > 0) total += static_cast<size_t>(sz);
+    for (const auto& name : platform::listDir(dir)) {
+        if (name.empty() || name[0] == '.') continue;
+        std::string p = dir + "/" + name;
+        int64_t sz = platform::fileSize(p);
+        if (sz > 0) total += static_cast<size_t>(sz);   // regular file
+        else        total += sumDirRecursive(p);         // directory -> recurse
     }
-
     return total;
+}
+
+size_t LibraryCache::getCacheSize() {
+    // Whole cache footprint: covers/, pages/, manga_details/ and the *.txt index
+    // files (previously only covers/ was counted, undercounting the real size).
+    return sumDirRecursive(getCacheDir());
 }
 
 // Helper to escape special characters for serialization

--- a/src/view/library_section_tab.cpp
+++ b/src/view/library_section_tab.cpp
@@ -2416,6 +2416,12 @@ void LibrarySectionTab::showMangaContextMenu(const Manga& manga, int index) {
             [this, captured]() { onMangaSelected(captured); }});
     }
 
+    // Enter multi-select mode with this book (only when not already selecting).
+    if (!m_selectionMode) {
+        rows.push_back({ "checkbox.png", "Select", "", false, false,
+            [this, index]() { enterSelectionMode(index); }});
+    }
+
     // Reopening the main Options popover is the "back" target for the sub-menus.
     Manga backManga = manga;
     auto reopenMain = [this, backManga, index]() { showMangaContextMenu(backManga, index); };

--- a/src/view/storage_view.cpp
+++ b/src/view/storage_view.cpp
@@ -124,10 +124,7 @@ void StorageView::loadStorageInfo() {
             // server-side downloads (no local files) are excluded below.
             item.sizeBytes = 0;
             std::string mangaPath = dm.getDownloadsPath() + "/manga_" + std::to_string(download.mangaId);
-            auto entries = platform::listDir(mangaPath);
-            brls::Logger::info("StorageView: scan '{}' ({} entries) for manga {} '{}'",
-                               mangaPath, entries.size(), download.mangaId, download.title);
-            for (const auto& name : entries) {
+            for (const auto& name : platform::listDir(mangaPath)) {
                 if (name.empty() || name[0] == '.') continue;
                 std::string entryPath = mangaPath + "/" + name;
                 int64_t sz = platform::fileSize(entryPath);
@@ -135,18 +132,13 @@ void StorageView::loadStorageInfo() {
                     item.sizeBytes += sz;   // a regular file (e.g. cover.jpg)
                 } else {
                     // Directory (chapter_<i>) -> sum its page files.
-                    int64_t chSize = 0;
                     for (const auto& fname : platform::listDir(entryPath)) {
                         if (fname.empty() || fname[0] == '.') continue;
                         int64_t fsz = platform::fileSize(entryPath + "/" + fname);
-                        if (fsz > 0) chSize += fsz;
+                        if (fsz > 0) item.sizeBytes += fsz;
                     }
-                    item.sizeBytes += chSize;
-                    brls::Logger::info("StorageView:   dir '{}' -> {} bytes", name, chSize);
                 }
             }
-            brls::Logger::info("StorageView: manga {} local total = {} bytes",
-                               download.mangaId, item.sizeBytes);
             if (item.sizeBytes <= 0) continue;   // nothing stored locally -> skip
 
             // Count only the chapters that are present on the device.
@@ -252,28 +244,24 @@ void StorageView::loadStorageInfo() {
                 mid->addView(barTrack);
                 rowBox->addView(mid);
 
-                // Chapters — fixed width so the growing title/bar can't squeeze
-                // or overlap it (which made the text marquee/clip).
+                // Chapters + size: size to their content and don't shrink, so
+                // they pack tightly against the right edge while the bar fills
+                // the rest (no wide blank gap, no marquee/overlap).
                 auto* chaps = new brls::Label();
                 chaps->setText(std::to_string(item.chapterCount) + " ch");
                 chaps->setFontSize(13);
                 chaps->setTextColor(svcol::muted());
                 chaps->setSingleLine(true);
                 chaps->setShrink(0.0f);
-                chaps->setWidth(72);
-                chaps->setMarginRight(14);
-                chaps->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
+                chaps->setMarginRight(16);
                 rowBox->addView(chaps);
 
-                // Size — fixed width, right-aligned.
                 auto* size = new brls::Label();
                 size->setText(formatSize(item.sizeBytes));
                 size->setFontSize(14);
                 size->setTextColor(svcol::accent());
                 size->setSingleLine(true);
                 size->setShrink(0.0f);
-                size->setWidth(96);
-                size->setHorizontalAlign(brls::HorizontalAlign::RIGHT);
                 rowBox->addView(size);
 
                 int index = static_cast<int>(i);


### PR DESCRIPTION
Adds a Select action to the library book context menu, fixes cache-size reporting to count the whole cache directory instead of just covers, and tidies the storage list's chapter/size columns.

---
_Generated by [Claude Code](https://claude.ai/code)_