### PR TITLE
CI: resolve console toolchain packages from the release API instead of pinning versions

### DIFF
--- a/.github/workflows/build-multi-platform.yml
+++ b/.github/workflows/build-multi-platform.yml
@@ -366,33 +366,39 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache Vita portlibs
-        id: cache-vita-portlibs
-        uses: actions/cache@v4
-        with:
-          path: portlib-cache
-          # The key IS the pin list, so bumping a version misses and refetches.
-          key: vita-portlibs-mbedtls-3.6.7-1_curl-8.16.0-3_ffmpeg-n6.0-3_mpv-0.36.0-3
-
       - name: Install Vita dependencies
         env:
-          BASE_URL: https://github.com/dragonflylee/switchfin/releases/download/vita-packages
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
-          # vita-packages is ROLLING — version bumps REPLACE assets, so stale pins
-          # 404. Use *-vita.pkg.tar.xz (real pacman packages), NOT the legacy
-          # *-arm.tar.xz bare sysroots (no .PKGINFO → "invalid or corrupted package").
-          fetch() {
-            if command -v curl >/dev/null 2>&1; then
-              curl -fL --retry 4 --retry-all-errors --speed-limit 102400 --speed-time 30 -o "$2" "$1"
-            else
-              wget --tries=4 --read-timeout=30 -O "$2" "$1"
-            fi
-          }
+          # vita-packages is ROLLING: a version bump REPLACES the asset, so any
+          # pinned URL 404s eventually. Resolve what is published right now from
+          # the release API and match by package name, not by version. Use the
+          # *-vita.pkg.tar.xz files (real pacman packages) — the legacy
+          # *-arm.tar.xz are bare sysroots with no .PKGINFO ("invalid or
+          # corrupted package").
+          API="https://api.github.com/repos/dragonflylee/switchfin/releases/tags/vita-packages"
+          curl -fsSL --retry 4 --retry-all-errors \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer $GH_TOKEN" "$API" -o /tmp/vitapkgs.json
+          urls=$(grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' /tmp/vitapkgs.json \
+                 | sed -E 's/.*"(https[^"]+)"$/\1/')
+          [ -n "$urls" ] || { echo "::error::could not read the vita-packages asset list"; exit 1; }
+
+          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
+                     '$NF ~ re && $NF ~ /-vita\.pkg\.tar\.xz$/ {print; exit}'; }
+
           mkdir -p portlib-cache
-          for pkg in mbedtls-3.6.7-1 curl-8.16.0-3 ffmpeg-n6.0-3 mpv-0.36.0-3; do
-            f="portlib-cache/${pkg}-vita.pkg.tar.xz"
-            [ -s "$f" ] || fetch "$BASE_URL/${pkg}-vita.pkg.tar.xz" "$f"
+          for re in '^mbedtls-' '^curl-' '^ffmpeg-' '^mpv-'; do
+            u=$(pick "$re")
+            if [ -z "$u" ]; then
+              echo "::warning::no published vita package matches ${re} - leaving it to vdpm"
+              continue
+            fi
+            f="portlib-cache/$(basename "$u")"
+            echo "resolved ${re} -> $(basename "$u")"
+            curl -fL --retry 4 --retry-all-errors \
+                 --speed-limit 102400 --speed-time 30 -o "$f" "$u"
           done
           cp portlib-cache/*-vita.pkg.tar.xz .
 
@@ -686,59 +692,64 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { driver: opengl, mpv_pkg: switch-libmpv-0.36.0-5-any.pkg.tar.zst, cmake_extra: "" }
-        - { driver: deko3d, mpv_pkg: switch-libmpv-deko3d-0.36.0-5-any.pkg.tar.zst, cmake_extra: "-DUSE_DEKO3D=ON" }
+        # mpv_re selects the leg's package from the release by name, not by a
+        # pinned version. "[0-9]" is what keeps the opengl pattern from also
+        # matching switch-libmpv-deko3d-*.
+        - { driver: opengl, mpv_re: "^switch-libmpv-[0-9]",     cmake_extra: "" }
+        - { driver: deko3d, mpv_re: "^switch-libmpv-deko3d-",   cmake_extra: "-DUSE_DEKO3D=ON" }
     container:
       image: devkitpro/devkita64:20260219
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Cache Switch portlibs
-        uses: actions/cache@v4
-        with:
-          path: portlib-cache
-          key: switch-portlibs-v4-hacBrewPack-3.05-1_libuam-master-1_dav1d-1.5.4-1_mbedtls-3.6.7-1_libssh2-1.11.1-1_ffmpeg-7.1.5-5_${{ matrix.mpv_pkg }}
       - name: Install switchfin portlibs
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          BASE_URL="https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs"
-          set -eu
-          fetch() {
-            curl -fL --retry 4 --retry-all-errors \
-                 --speed-limit 102400 --speed-time 30 -o "$2" "$1"
-          }
+          set -euo pipefail
+          # switchfin's portlibs are a ROLLING release: every bump REPLACES the
+          # asset, so any pinned URL 404s eventually (it has broken this build
+          # three times — dav1d 1.5.3->1.5.4, and switch-uchardet was withdrawn
+          # outright). Resolve whatever is published RIGHT NOW from the release
+          # API and match packages by name instead of by version.
+          API="https://api.github.com/repos/dragonflylee/switchfin/releases/tags/switch-portlibs"
+          curl -fsSL --retry 4 --retry-all-errors \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer $GH_TOKEN" "$API" -o /tmp/portlibs.json
+          urls=$(grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' /tmp/portlibs.json \
+                 | sed -E 's/.*"(https[^"]+)"$/\1/')
+          [ -n "$urls" ] || { echo "::error::could not read the switchfin portlibs asset list"; exit 1; }
+          echo "$urls" | wc -l | xargs echo "assets published:"
+
+          # First asset whose FILE NAME matches the regex and is a pacman package.
+          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
+                     '$NF ~ re && $NF ~ /\.pkg\.tar\.zst$/ {print; exit}'; }
+
           mkdir -p portlib-cache
-          # The switchfin mpv -> ffmpeg -> tls stack must be installed together so
-          # it stays ABI-consistent (mpv is built against switchfin's ffmpeg,
-          # which is built against its mbedtls/libssh2).
-          #
-          # These assets are ROLLING: switchfin replaces them on every bump, so a
-          # pinned URL 404s without warning (dav1d 1.5.3-1 -> 1.5.4-1, and
-          # switch-uchardet was withdrawn entirely). A missing package is
-          # therefore a warning, not a hard failure: `dkp-pacman -Sy` below
-          # refreshes the databases, so anything we couldn't fetch can still be
-          # resolved from the devkitPro repo. If it genuinely can't be, the
-          # `pacman -U` step reports the unmet dependency, which is the error we
-          # actually want to see.
-          missing=0
-          for pkg in hacBrewPack-3.05-1-x86_64.pkg.tar.zst \
-                     libuam-master-1-any.pkg.tar.zst \
-                     switch-dav1d-1.5.4-1-any.pkg.tar.zst \
-                     switch-mbedtls-3.6.7-1-any.pkg.tar.zst \
-                     switch-libssh2-1.11.1-1-any.pkg.tar.zst \
-                     switch-ffmpeg-7.1.5-5-any.pkg.tar.zst \
-                     ${{ matrix.mpv_pkg }}; do
-            f="portlib-cache/$pkg"
-            if [ ! -f "$f" ] || [ "$(stat -c%s "$f" 2>/dev/null || echo 0)" -lt 4096 ]; then
-              if ! fetch "$BASE_URL/$pkg" "$f"; then
-                rm -f "$f"
-                echo "::warning::portlib $pkg is no longer published (rolling release);"\
-                     " continuing and letting pacman resolve it from the repo."
-                missing=$((missing + 1))
-              fi
+          # The mpv -> ffmpeg -> tls stack must come from switchfin as a set so it
+          # stays ABI-consistent (its mpv is built against its ffmpeg, which is
+          # built against its mbedtls/libssh2). Anything absent is a warning: the
+          # `dkp-pacman -Sy` below lets pacman resolve it from the devkitPro repo
+          # instead, and a genuinely unmet dependency still surfaces in the
+          # `pacman -U` error we capture.
+          for re in '^hacBrewPack-.*x86_64' \
+                    '^libuam-' \
+                    '^switch-dav1d-' \
+                    '^switch-mbedtls-' \
+                    '^switch-libssh2-' \
+                    '^switch-ffmpeg-' \
+                    '${{ matrix.mpv_re }}'; do
+            u=$(pick "$re")
+            if [ -z "$u" ]; then
+              echo "::warning::no published portlib matches ${re} - leaving it to pacman"
+              continue
             fi
+            f="portlib-cache/$(basename "$u")"
+            echo "resolved ${re} -> $(basename "$u")"
+            curl -fL --retry 4 --retry-all-errors \
+                 --speed-limit 102400 --speed-time 30 -o "$f" "$u"
           done
-          [ "$missing" -eq 0 ] || echo "$missing pinned portlib(s) unavailable; see warnings above."
           dkp-pacman --noconfirm -Rdd switch-libmpv || true
           dkp-pacman --noconfirm -Rdd switch-libmpv-deko3d || true
           # Refresh the package databases so pacman -U can pull any remaining
@@ -796,11 +807,41 @@ jobs:
           submodules: recursive
       - name: Install PS4 portlibs
         env:
-          BASE_URL: https://github.com/dragonflylee/switchfin/releases/download/pacbrew
+          GH_TOKEN: ${{ github.token }}
         run: |
-          for pkg in musl-1.5-3 mbedtls-2.28.10-2 sdl2-2.0.18-19 libcurl-7.80.0-5; do
-            pacman --noconfirm -U "$BASE_URL/ps4-openorbis-${pkg}-any.pkg.tar.gz"
+          set -eu
+          # pacbrew is ROLLING too: resolve the current assets rather than pinning
+          # versions that 404 on the next bump. Note these are .tar.gz (gzip), and
+          # the ps4-openorbis- prefix matters. The old, deliberate pins live here:
+          # PS4's stack is mbedtls 2.28.x and sdl2 2.0.18 because that is what the
+          # toolchain provides — matching by name keeps that property.
+          API="https://api.github.com/repos/dragonflylee/switchfin/releases/tags/pacbrew"
+          curl -fsSL --retry 4 --retry-all-errors \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer $GH_TOKEN" "$API" -o /tmp/pacbrew.json
+          urls=$(grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' /tmp/pacbrew.json \
+                 | sed -E 's/.*"(https[^"]+)"$/\1/')
+          [ -n "$urls" ] || { echo "::error::could not read the pacbrew asset list"; exit 1; }
+
+          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
+                     '$NF ~ re && $NF ~ /\.pkg\.tar\.gz$/ {print; exit}'; }
+
+          mkdir -p portlib-cache
+          for re in '^ps4-openorbis-musl-' \
+                    '^ps4-openorbis-mbedtls-' \
+                    '^ps4-openorbis-sdl2-' \
+                    '^ps4-openorbis-libcurl-'; do
+            u=$(pick "$re")
+            if [ -z "$u" ]; then
+              echo "::error::no published pacbrew package matches ${re}"
+              exit 1
+            fi
+            f="portlib-cache/$(basename "$u")"
+            echo "resolved ${re} -> $(basename "$u")"
+            curl -fL --retry 4 --retry-all-errors \
+                 --speed-limit 102400 --speed-time 30 -o "$f" "$u"
           done
+          pacman --noconfirm -U portlib-cache/*.pkg.tar.gz
       - name: Build
         env:
           OPENORBIS: /opt/pacbrew/ps4/openorbis

--- a/.github/workflows/build-multi-platform.yml
+++ b/.github/workflows/build-multi-platform.yml
@@ -234,7 +234,10 @@ jobs:
           done
 
           # Flatpak bundle (single-file .flatpak)
-          for fp in $(find . -name "*.flatpak"); do
+          # -type f matters: download-artifact creates a DIRECTORY named after
+          # the artifact (VitaSuwayomi-x86_64.flatpak), and cp without -r fails
+          # on it. The real bundle is the regular file inside.
+          for fp in $(find . -type f -name "*.flatpak"); do
             cp "$fp" "release/VitaSuwayomi.${FVER}.flatpak"
           done
 
@@ -385,11 +388,20 @@ jobs:
                  | sed -E 's/.*"(https[^"]+)"$/\1/')
           [ -n "$urls" ] || { echo "::error::could not read the vita-packages asset list"; exit 1; }
 
-          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
-                     '$NF ~ re && $NF ~ /-vita\.pkg\.tar\.xz$/ {print; exit}'; }
+          pick() {
+            printf '%s\n' "$urls" | {
+              while IFS= read -r u; do
+                n=${u##*/}
+                case "$n" in
+                  $1) case "$n" in *-vita.pkg.tar.xz) printf '%s\n' "$u"; return 0;; esac;;
+                esac
+              done
+              return 0
+            }
+          }
 
           mkdir -p portlib-cache
-          for re in '^mbedtls-' '^curl-' '^ffmpeg-' '^mpv-'; do
+          for re in 'mbedtls-*' 'curl-*' 'ffmpeg-*' 'mpv-*'; do
             u=$(pick "$re")
             if [ -z "$u" ]; then
               echo "::warning::no published vita package matches ${re} - leaving it to vdpm"
@@ -692,11 +704,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # mpv_re selects the leg's package from the release by name, not by a
-        # pinned version. "[0-9]" is what keeps the opengl pattern from also
-        # matching switch-libmpv-deko3d-*.
-        - { driver: opengl, mpv_re: "^switch-libmpv-[0-9]",     cmake_extra: "" }
-        - { driver: deko3d, mpv_re: "^switch-libmpv-deko3d-",   cmake_extra: "-DUSE_DEKO3D=ON" }
+        # mpv_re is a filename GLOB selecting the leg's package from the release
+        # by name, not by a pinned version. "[0-9]" is what keeps the opengl
+        # pattern from also matching switch-libmpv-deko3d-*.
+        - { driver: opengl, mpv_re: "switch-libmpv-[0-9]*",     cmake_extra: "" }
+        - { driver: deko3d, mpv_re: "switch-libmpv-deko3d-*",   cmake_extra: "-DUSE_DEKO3D=ON" }
     container:
       image: devkitpro/devkita64:20260219
     steps:
@@ -707,7 +719,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -eu
           # switchfin's portlibs are a ROLLING release: every bump REPLACES the
           # asset, so any pinned URL 404s eventually (it has broken this build
           # three times — dav1d 1.5.3->1.5.4, and switch-uchardet was withdrawn
@@ -723,8 +735,18 @@ jobs:
           echo "$urls" | wc -l | xargs echo "assets published:"
 
           # First asset whose FILE NAME matches the regex and is a pacman package.
-          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
-                     '$NF ~ re && $NF ~ /\.pkg\.tar\.zst$/ {print; exit}'; }
+          # POSIX glob match on the file name; no awk (the container runs dash).
+          pick() {
+            printf '%s\n' "$urls" | {
+              while IFS= read -r u; do
+                n=${u##*/}
+                case "$n" in
+                  $1) case "$n" in *.pkg.tar.zst) printf '%s\n' "$u"; return 0;; esac;;
+                esac
+              done
+              return 0
+            }
+          }
 
           mkdir -p portlib-cache
           # The mpv -> ffmpeg -> tls stack must come from switchfin as a set so it
@@ -733,12 +755,12 @@ jobs:
           # `dkp-pacman -Sy` below lets pacman resolve it from the devkitPro repo
           # instead, and a genuinely unmet dependency still surfaces in the
           # `pacman -U` error we capture.
-          for re in '^hacBrewPack-.*x86_64' \
-                    '^libuam-' \
-                    '^switch-dav1d-' \
-                    '^switch-mbedtls-' \
-                    '^switch-libssh2-' \
-                    '^switch-ffmpeg-' \
+          for re in 'hacBrewPack-*x86_64*' \
+                    'libuam-*' \
+                    'switch-dav1d-*' \
+                    'switch-mbedtls-*' \
+                    'switch-libssh2-*' \
+                    'switch-ffmpeg-*' \
                     '${{ matrix.mpv_re }}'; do
             u=$(pick "$re")
             if [ -z "$u" ]; then
@@ -823,14 +845,23 @@ jobs:
                  | sed -E 's/.*"(https[^"]+)"$/\1/')
           [ -n "$urls" ] || { echo "::error::could not read the pacbrew asset list"; exit 1; }
 
-          pick() { printf '%s\n' "$urls" | awk -v re="$1" -F/ \
-                     '$NF ~ re && $NF ~ /\.pkg\.tar\.gz$/ {print; exit}'; }
+          pick() {
+            printf '%s\n' "$urls" | {
+              while IFS= read -r u; do
+                n=${u##*/}
+                case "$n" in
+                  $1) case "$n" in *.pkg.tar.gz) printf '%s\n' "$u"; return 0;; esac;;
+                esac
+              done
+              return 0
+            }
+          }
 
           mkdir -p portlib-cache
-          for re in '^ps4-openorbis-musl-' \
-                    '^ps4-openorbis-mbedtls-' \
-                    '^ps4-openorbis-sdl2-' \
-                    '^ps4-openorbis-libcurl-'; do
+          for re in 'ps4-openorbis-musl-*' \
+                    'ps4-openorbis-mbedtls-*' \
+                    'ps4-openorbis-sdl2-[0-9]*' \
+                    'ps4-openorbis-libcurl-*'; do
             u=$(pick "$re")
             if [ -z "$u" ]; then
               echo "::error::no published pacbrew package matches ${re}"


### PR DESCRIPTION
The Switch, Vita and PS4 jobs each downloaded their toolchain packages from a pinned URL like `switch-dav1d-1.5.3-1-any.pkg.tar.zst`. Those upstream releases are **rolling**: a version bump *replaces* the asset, so the pinned URL starts returning 404 and the build breaks with no change on our side. On Switch alone that happened three times — `dav1d` 1.5.3 → 1.5.4, and `switch-uchardet` was withdrawn from the release entirely.

This resolves the packages that are published **right now** from the release API and matches each one by name, so an upstream version bump is a no-op for us.

## What changed

- Switch (`switch-portlibs`), Vita (`vita-packages`) and PS4 (`pacbrew`) all query `/releases/tags/<tag>` and pick their assets from the live list, using `${{ github.token }}` for the API rate limit.
- Packages are selected by an anchored filename **glob**, which preserves the exclusions the exact pins used to give for free:
  - `switch-libmpv-[0-9]*` must not match `switch-libmpv-deko3d-*` (the two matrix legs)
  - `mpv-*` must not match `libmpv-*` on Vita
  - `ps4-openorbis-sdl2-[0-9]*` must not match `sdl2_mixer-*`
  - Vita takes only `-vita.pkg.tar.xz`, never the legacy `-arm.tar.xz` sysroots (no `.PKGINFO` → "invalid or corrupted package")
- A package that is no longer published is a **warning** on Switch and Vita, not a hard failure: `dkp-pacman -Sy` / `vdpm` can resolve it from the toolchain repo instead — which is exactly how the withdrawn `uchardet` now resolves. PS4 still fails loudly, since `pacman -U` there has no repo fallback.
- Dropped the Switch/Vita portlib caches. Their keys *were* the pin lists, which no longer exist, and a stale cache had previously poisoned the build with a truncated package. The downloads are only a few MB.

## Fixes found while getting this green

- **`set: Illegal option -o pipefail` (exit 2) on Switch.** These console jobs run inside containers whose `/bin/sh` is dash, not bash. The steps now use POSIX `set -eu`; the two release-signing steps keep `pipefail` since they run on `ubuntu-latest` under bash.
- **Dropped the `awk` dependency.** A fatal `awk` exits 2 and `u=$(pick …)` propagates that under `set -e`, and `awk` isn't guaranteed in these images — the picker is now plain `case` globbing.
- **`cp: -r not specified; omitting directory './VitaSuwayomi-x86_64.flatpak'`** in the pre-release job. `download-artifact` creates a *directory* named after the artifact, which here ends in `.flatpak`, so `find -name "*.flatpak"` matched the directory rather than the bundle. Restricted to `-type f`.

## Testing

Each picker was checked against realistic asset lists including the near-miss cases listed above. Vita passed with the dynamic resolution before the dash fix landed; Switch and PS4 were verified after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDeQM4PYiy3ifqJzGzs4s


---
_Generated by [Claude Code](https://claude.ai/code)_