### PR TITLE
Fix "update available" on the current release, and the Android hand-off

### DIFF
--- a/.github/workflows/build-multi-platform.yml
+++ b/.github/workflows/build-multi-platform.yml
@@ -74,13 +74,24 @@ jobs:
             V="${BASE}.${{ github.run_number }}"
           fi
           V="${V#v}"
-          # Extract numeric version for CMake / Vita / PS4 / deb (no labels)
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          # Numeric version for CMake / Vita / PS4 / deb (no labels).
+          #
+          # Derive it from the version we actually resolved above, NOT from the
+          # VERSION file. A release cut by workflow_dispatch carries its new
+          # version in inputs.version and only writes it back to VERSION in the
+          # parallel save-version job, so reading the checked-out file here
+          # produced the PREVIOUS version: Beta-2.2.3 shipped binaries stamped
+          # 2.2.2.<run>, which then saw their own release as an update forever.
+          V_NUM=$(echo "$V" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+          if [[ -z "$V_NUM" ]]; then
+            V_NUM="${BASE_NUM}"
+          fi
+          if [[ -n "${{ inputs.version }}" || "$GITHUB_REF" == refs/tags/* ]]; then
             # Release: X.Y.Z only
-            NUM="${BASE_NUM}"
+            NUM="${V_NUM}"
           else
             # Non-release: X.Y.Z.build
-            NUM="${BASE_NUM}.${{ github.run_number }}"
+            NUM="${V_NUM}.${{ github.run_number }}"
           fi
           # Filename/tag-safe version (spaces → hyphens)
           TAG="${V// /-}"

--- a/src/utils/app_update.cpp
+++ b/src/utils/app_update.cpp
@@ -302,7 +302,10 @@ void forEachObject(const std::string& arr, Fn fn) {
 
 // Parse the first three numeric runs of a version-ish string, ignoring any
 // leading non-digits ("Beta-1.2.6", "v1.2.6", "1.2.6.1448" → {1,2,6}).
-void parseVersion(const std::string& v, int out[3]) {
+// Returns false when the string held no number at all. That matters: a version
+// we cannot read must never compare as "older than everything", or a build with
+// a broken version stamp offers an update on every check, forever.
+bool parseVersion(const std::string& v, int out[3]) {
     out[0] = out[1] = out[2] = 0;
     int idx = 0;
     size_t i = 0;
@@ -315,12 +318,12 @@ void parseVersion(const std::string& v, int out[3]) {
             ++i;
         }
     }
+    return idx > 0;
 }
 
 bool isNewer(const std::string& tag, const std::string& current) {
     int a[3], b[3];
-    parseVersion(tag, a);
-    parseVersion(current, b);
+    if (!parseVersion(tag, a) || !parseVersion(current, b)) return false;
     for (int i = 0; i < 3; ++i) {
         if (a[i] != b[i]) return a[i] > b[i];
     }
@@ -970,38 +973,48 @@ bool installDownloaded(const ReleaseInfo& rel, const std::string& path,
     // routes them to the "install unknown apps" screen, because without that
     // per-app grant newer Android (Android TV especially) never prompts and the
     // install silently aborts after "Staging app…".
-    setProgress(ui, "Opening installer…");
-    JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
-    bool called = false, launched = false;
-    if (env) {
-        jclass u = env->FindClass("org/libsdl/app/PlatformUtils");
-        if (u) {
-            jmethodID m = env->GetStaticMethodID(u, "installApk", "(Ljava/lang/String;)Z");
-            if (m) {
-                jstring js = env->NewStringUTF(path.c_str());
-                launched = env->CallStaticBooleanMethod(u, m, js) == JNI_TRUE;
-                env->DeleteLocalRef(js);
-                called = true;
+    setProgress(ui, "Handing to system installer…");
+    // The JNI hand-off MUST run on the main thread, which is why it lives in
+    // the finish callback rather than here: everything above runs on a worker,
+    // and FindClass on a thread the VM merely attached resolves against the
+    // *system* class loader, which cannot see org/libsdl/app/* at all. From the
+    // worker it therefore returned null every time, and we fell through to the
+    // browser fallback — the app appeared to just close into a web page and the
+    // install-permission prompt was never reached.
+    finishProgress(ui, [rel, path]() {
+        JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
+        bool called = false, launched = false;
+        if (env) {
+            jclass u = env->FindClass("org/libsdl/app/PlatformUtils");
+            if (u) {
+                jmethodID m = env->GetStaticMethodID(u, "installApk", "(Ljava/lang/String;)Z");
+                if (m) {
+                    jstring js = env->NewStringUTF(path.c_str());
+                    launched = env->CallStaticBooleanMethod(u, m, js) == JNI_TRUE;
+                    env->DeleteLocalRef(js);
+                    called = true;
+                }
+                env->DeleteLocalRef(u);
             }
-            env->DeleteLocalRef(u);
+            if (env->ExceptionCheck()) { env->ExceptionClear(); called = false; launched = false; }
         }
-        if (env->ExceptionCheck()) { env->ExceptionClear(); called = false; launched = false; }
-    }
-    if (launched) {
-        // The system installer takes over; do NOT quit — it streams the APK from
-        // our in-process provider while staging, and Android force-stops this
-        // package itself once the update commits.
-        finishProgress(ui, []() {});
-    } else if (called) {
-        // We were sent to the permission screen (or the hand-off failed).
-        finishProgress(ui, []() {
+        if (launched) {
+            // The system installer took over; do NOT quit — it streams the APK
+            // from our in-process provider while staging, and Android
+            // force-stops this package itself once the update commits.
+            return;
+        }
+        if (called) {
+            // installApk sent us to the "install unknown apps" screen. Without
+            // that per-app grant newer Android (Android TV especially) never
+            // prompts and the install silently aborts after "Staging app…".
             showMessage("Allow VitaSuwayomi to install apps, then choose Update again.\n\n"
                         "Android needs a one-time \"install unknown apps\" permission "
                         "before it can install the update.");
-        });
-    } else {
-        finishProgress(ui, [rel]() { openUrl(rel.pageUrl); });
-    }
+            return;
+        }
+        openUrl(rel.pageUrl);
+    });
     return false;
 
 #elif defined(_WIN32)


### PR DESCRIPTION
Two more device-reported failures.

Windows (and every other platform) offered an update while already on the newest release. A release cut by workflow_dispatch carries its new version in inputs.version, but resolve-version computed the *numeric* version from the checked-out VERSION file — which the parallel save-version job has not written yet. So Beta-2.2.3 shipped binaries stamped 2.2.2.<run>, and every one of them sees its own release as an update, forever. Derive the numeric version from the version actually resolved, and don't append a build number to a release.

isNewer() now also fails closed when either side has no number in it, as the reference does: a build with a broken version stamp used to compare as older than everything and prompt on every check.

Android showed no installer and appeared to just close into a web page. The JNI hand-off ran on the download worker thread, where FindClass("org/libsdl/app/PlatformUtils") resolves against the system class loader and cannot see app classes — it returned null every time, so we fell through to the browser fallback and never reached the install-permission prompt. Moved into the finish callback, which runs on the main thread, matching the reference.

Note: an already-installed Beta-2.2.3 build still reports 2.2.2 and will keep offering the update until a build with this fix is installed.